### PR TITLE
A proposal to add 'flattening' support to the standard library for Set and List

### DIFF
--- a/src/org/rascalmpl/library/List.rsc
+++ b/src/org/rascalmpl/library/List.rsc
@@ -210,6 +210,22 @@ test: getOneFrom(<L>)
 public java &T getOneFrom(list[&T] lst);
 
 @doc{
+Synopsis: Flatten a list of lists to a single list
+
+Description:
+Given a list of lists, flatten it so that it becomes a single list of those elements.
+
+Examples:
+<screen>
+import List;
+flatten([[1, 2], [3, 4], [5, 6]]);
+flatten([[1, 2], ["a", "b"]]);
+</screen>
+}
+public list[&T] flatten(list[list[&T]] lst) =
+	[ r | e <- lst, r <- e];
+
+@doc{
 Synopsis: Get the first element(s) from a list.
 
 Description:

--- a/src/org/rascalmpl/library/Set.rsc
+++ b/src/org/rascalmpl/library/Set.rsc
@@ -49,6 +49,22 @@ test: classify({"apple", "berry", "cucumber", "banana"}, getColor) == <?>
 public map[&K,set[&V]] classify(set[&V] input, &K (&V) getClass) = toMap({<getClass(e),e> | e <- input});
 
 @doc{
+Synopsis: Flatten a set of sets to a single set
+
+Description:
+Given a set of sets, flatten it so that it becomes a single set of those elements.
+
+Examples:
+<screen>
+import Set;
+flatten([[1, 2], [3, 4], [5, 6]]);
+flatten([[1, 2], ["a", "b"]]);
+</screen>
+}
+public set[&T] flatten(set[set[&T]] lst) =
+  { r | e <- lst, r <- e};
+
+@doc{
 Synopsis: Pick a random element from a set.
 
 Description: Also see [$Set/takeOneFrom].

--- a/test/org/rascalmpl/test/library/ListTests.java
+++ b/test/org/rascalmpl/test/library/ListTests.java
@@ -43,6 +43,16 @@ public class ListTests extends TestFramework {
 	}
 
 	@Test
+	public void flatten() {
+
+		prepare("import List;");
+
+		assertTrue(runTestInSameEvaluator("{flatten([[1, 2], [3]]) == [1, 2, 3];}"));
+		assertTrue(runTestInSameEvaluator("{flatten([[]]) == [];}"));
+		assertTrue(runTestInSameEvaluator("{flatten([[], [1]]) == [1];}"));
+	}
+
+	@Test
 	public void getOneFrom() {
 
 		prepare("import List;");

--- a/test/org/rascalmpl/test/library/SetTests.java
+++ b/test/org/rascalmpl/test/library/SetTests.java
@@ -24,6 +24,16 @@ import org.rascalmpl.test.infrastructure.TestFramework;
 public class SetTests extends TestFramework {
 
 	@Test
+	public void flatten() {
+
+		prepare("import Set;");
+
+		assertTrue(runTestInSameEvaluator("{flatten({{1, 2}, {3}}) == {1, 2, 3};}"));
+		assertTrue(runTestInSameEvaluator("{flatten({{}}) == {};}"));
+		assertTrue(runTestInSameEvaluator("{flatten({{}, {1}}) == {1};}"));
+	}
+
+	@Test
 	public void getOneFrom() {
 
 		prepare("import Set;");


### PR DESCRIPTION
e.g. `flatten([1, 2], [3, 4]) == [1, 2, 3, 4]`

@ioanarucareanu and I both came across the fact that there is no library function to flatten a list of lists or a set of sets.
While trivial to implement, incorporating this in stdlib seems useful.
