### PR TITLE
A `Lval` should not be assigned to the environment

### DIFF
--- a/src/org/rascalmpl/library/demo/lang/Lisra/Eval.rsc
+++ b/src/org/rascalmpl/library/demo/lang/Lisra/Eval.rsc
@@ -37,7 +37,7 @@ public Result eval(List([Atom("begin"), *Lval exps]) , Env e) {
 }
                                                              /*7*/
 public Result eval(List([Atom("define"), var, exp]), Env e){
-   e = e[0][var] = eval(exp, e).val;
+   e[0][var] = eval(exp, e).val;
    return <FALSE, e>;
 }
                                                              /*8*/


### PR DESCRIPTION
This breaks the REPL.  It is surprising that Rescal does not catch the type error in this assignment!
