### PR TITLE
fixed buggy createM3FromDirectory

### DIFF
--- a/src/org/rascalmpl/library/lang/java/m3/Core.rsc
+++ b/src/org/rascalmpl/library/lang/java/m3/Core.rsc
@@ -80,10 +80,7 @@ public M3 createM3FromDirectory(loc project, str javaVersion = "1.7") {
     sourcePaths = getPaths(project, "java");
     //setEnvironmentOptions(project);
     setEnvironmentOptions(classPaths, sourcePaths);
-    m3s = {};
-    for (sp <- sourcePaths) {
-      m3s += { createM3FromFile(f, javaVersion = javaVersion) | loc f <- find(sp, "java") };
-    }
+    m3s = { *createM3FromFile(f, javaVersion = javaVersion) | sp <- sourcePaths, loc f <- find(sp, "java") };
     M3 result = composeJavaM3(project, m3s);
     registerProject(project, result);
     return result;


### PR DESCRIPTION
createM3FromDirectory was not working properly.

This code ...

result = composeJavaM3(project, { createM3FromFile(f, javaVersion = javaVersion) | loc f <- find(sp, "java") });

used to be in the for-sourcePaths loop reassigning the result variable each time. Instead of creating a union of all the M3's it would just end up returning the last M3 created using createM3FromFile.

This fix simply collects all M3's discovered on all sourcePaths into a set. With this set (m3s) a JavaM3 is composed.
