### PR TITLE
Fix for project:// locations not working on createM3From.. methods

### DIFF
--- a/src/org/rascalmpl/library/lang/java/m3/Core.rsc
+++ b/src/org/rascalmpl/library/lang/java/m3/Core.rsc
@@ -60,7 +60,7 @@ public M3 link(M3 projectModel, set[M3] libraryModels) {
 
 @javaClass{org.rascalmpl.library.lang.java.m3.internal.EclipseJavaCompiler}
 @reflect
-public java M3 createM3FromFile(loc file, str javaVersion = "1.7");
+public java M3 createM3FromFile(loc file, str javaVersion = "1.7", bool resetEnvironment = true);
 
 @javaClass{org.rascalmpl.library.lang.java.m3.internal.EclipseJavaCompiler}
 @reflect
@@ -83,7 +83,7 @@ public M3 createM3FromDirectory(loc project, map[str, str] dependencyUpdateSites
     classPaths = find(project, "jar");
     sourcePaths = getPaths(project, "java");
     setEnvironmentOptions(classPaths, findRoots(sourcePaths));
-    m3s = { *createM3FromFile(f, javaVersion = javaVersion) | sp <- sourcePaths, loc f <- find(sp, "java") };
+    m3s = { *createM3FromFile(f, javaVersion = javaVersion, resetEnvironment = false) | sp <- sourcePaths, loc f <- find(sp, "java") };
     M3 result = composeJavaM3(project, m3s);
     registerProject(project, result);
     return result;

--- a/src/org/rascalmpl/test/infrastructure/ConcurrentTestFramework.java
+++ b/src/org/rascalmpl/test/infrastructure/ConcurrentTestFramework.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
@@ -123,6 +124,16 @@ public class ConcurrentTestFramework {
 		@Override
 		public Charset getCharset(ISourceLocation uri) throws IOException {
 			return null;
+		}
+
+		@Override
+		public boolean supportsToFileURI() {
+			return false;
+		}
+
+		@Override
+		public URI toFileURI(ISourceLocation uri) {
+			throw new UnsupportedOperationException("Cannot convert TestModule to File URI");
 		}
 	}
 

--- a/src/org/rascalmpl/test/infrastructure/TestFramework.java
+++ b/src/org/rascalmpl/test/infrastructure/TestFramework.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
@@ -123,6 +124,16 @@ public class TestFramework {
 		@Override
 		public Charset getCharset(ISourceLocation uri) throws IOException {
 			return null;
+		}
+
+		@Override
+		public boolean supportsToFileURI() {
+			return false;
+		}
+
+		@Override
+		public URI toFileURI(ISourceLocation uri) {
+			throw new UnsupportedOperationException("Cannot convert TestModule to File URI");
 		}
 	}
 	

--- a/src/org/rascalmpl/uri/ClassResourceInput.java
+++ b/src/org/rascalmpl/uri/ClassResourceInput.java
@@ -21,7 +21,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
 import org.rascalmpl.values.ValueFactoryFactory;
 

--- a/src/org/rascalmpl/uri/ClassResourceInput.java
+++ b/src/org/rascalmpl/uri/ClassResourceInput.java
@@ -16,10 +16,12 @@ package org.rascalmpl.uri;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
 import org.rascalmpl.values.ValueFactoryFactory;
 
@@ -129,5 +131,15 @@ public class ClassResourceInput implements ISourceLocationInput {
 	@Override
 	public Charset getCharset(ISourceLocation uri) throws IOException {
 		return registry.getCharset(resolve(uri));
+	}
+
+	@Override
+	public boolean supportsToFileURI() {
+		return false;
+	}
+
+	@Override
+	public URI toFileURI(ISourceLocation uri) {
+		throw new UnsupportedOperationException("Cannot convert resources to File URI");
 	}
 }

--- a/src/org/rascalmpl/uri/CompressedStreamResolver.java
+++ b/src/org/rascalmpl/uri/CompressedStreamResolver.java
@@ -5,6 +5,7 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.regex.Matcher;
@@ -12,6 +13,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
 
 public class CompressedStreamResolver implements ISourceLocationInputOutput {
@@ -157,5 +159,15 @@ public class CompressedStreamResolver implements ISourceLocationInputOutput {
 	@Override
 	public boolean supportsHost() {
 		return true;
+	}
+
+	@Override
+	public boolean supportsToFileURI() {
+		return false;
+	}
+
+	@Override
+	public URI toFileURI(ISourceLocation uri) {
+		throw new UnsupportedOperationException("Cannot convert Compressed streams to File URI");
 	}
 }

--- a/src/org/rascalmpl/uri/FileURIResolver.java
+++ b/src/org/rascalmpl/uri/FileURIResolver.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
 
 public class FileURIResolver implements ISourceLocationInputOutput {

--- a/src/org/rascalmpl/uri/FileURIResolver.java
+++ b/src/org/rascalmpl/uri/FileURIResolver.java
@@ -21,9 +21,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
 
 public class FileURIResolver implements ISourceLocationInputOutput {
@@ -109,5 +111,15 @@ public class FileURIResolver implements ISourceLocationInputOutput {
 	@Override
 	public Charset getCharset(ISourceLocation uri) throws IOException {
 		return null;
+	}
+
+	@Override
+	public boolean supportsToFileURI() {
+		return true;
+	}
+
+	@Override
+	public URI toFileURI(ISourceLocation uri) {
+		return uri.getURI();
 	}
 }

--- a/src/org/rascalmpl/uri/HttpURIResolver.java
+++ b/src/org/rascalmpl/uri/HttpURIResolver.java
@@ -18,7 +18,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
 
 public class HttpURIResolver implements ISourceLocationInput {

--- a/src/org/rascalmpl/uri/HttpURIResolver.java
+++ b/src/org/rascalmpl/uri/HttpURIResolver.java
@@ -15,8 +15,10 @@ package org.rascalmpl.uri;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.Charset;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
 
 public class HttpURIResolver implements ISourceLocationInput {
@@ -84,5 +86,15 @@ public class HttpURIResolver implements ISourceLocationInput {
 		catch (IOException e) {
 			return null;
 		}
+	}
+
+	@Override
+	public boolean supportsToFileURI() {
+		return false;
+	}
+
+	@Override
+	public URI toFileURI(ISourceLocation uri) {
+		throw new UnsupportedOperationException("Cannot convert HTTP to File URI");
 	}
 }

--- a/src/org/rascalmpl/uri/ISourceLocationInput.java
+++ b/src/org/rascalmpl/uri/ISourceLocationInput.java
@@ -14,6 +14,7 @@ package org.rascalmpl.uri;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.Charset;
 
 import org.eclipse.imp.pdb.facts.ISourceLocation;
@@ -28,4 +29,6 @@ public interface ISourceLocationInput {
 	String[] list(ISourceLocation uri)  throws IOException;
 	String scheme();
 	boolean supportsHost();
+	boolean supportsToFileURI();
+	URI toFileURI(ISourceLocation uri);
 }

--- a/src/org/rascalmpl/uri/ISourceLocationOutput.java
+++ b/src/org/rascalmpl/uri/ISourceLocationOutput.java
@@ -15,6 +15,7 @@ package org.rascalmpl.uri;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 import java.nio.charset.Charset;
 
 import org.apache.commons.compress.utils.Charsets;
@@ -29,4 +30,7 @@ public interface ISourceLocationOutput {
 	default Charset getCharset(ISourceLocation uri) throws IOException {
 		return Charsets.UTF_8;
 	}
+
+	boolean supportsToFileURI();
+	URI toFileURI(ISourceLocation uri);
 }

--- a/src/org/rascalmpl/uri/JarURIResolver.java
+++ b/src/org/rascalmpl/uri/JarURIResolver.java
@@ -21,9 +21,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
-import org.rascalmpl.interpreter.asserts.NotYetImplemented;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;

--- a/src/org/rascalmpl/uri/JarURIResolver.java
+++ b/src/org/rascalmpl/uri/JarURIResolver.java
@@ -15,12 +15,15 @@ package org.rascalmpl.uri;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
+import org.rascalmpl.interpreter.asserts.NotYetImplemented;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -167,5 +170,15 @@ public class JarURIResolver implements ISourceLocationInput {
   public Charset getCharset(ISourceLocation uri) throws IOException {
     // TODO need to see if we can detect the charset inside a jar
     return null;
+  }
+
+  @Override
+  public boolean supportsToFileURI() {
+	  return false;
+  }
+
+  @Override
+  public URI toFileURI(ISourceLocation uri) {
+	  throw new UnsupportedOperationException("Cannot convert jar to File URI");
   }
 }

--- a/src/org/rascalmpl/uri/StandardInputURIResolver.java
+++ b/src/org/rascalmpl/uri/StandardInputURIResolver.java
@@ -14,9 +14,12 @@ package org.rascalmpl.uri;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.Charset;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
+import org.rascalmpl.interpreter.asserts.NotYetImplemented;
 
 public class StandardInputURIResolver implements ISourceLocationInput {
 	public boolean exists(ISourceLocation uri) {
@@ -58,5 +61,15 @@ public class StandardInputURIResolver implements ISourceLocationInput {
 	@Override
 	public Charset getCharset(ISourceLocation uri) throws IOException {
 		return null;
+	}
+
+	@Override
+	public boolean supportsToFileURI() {
+		return false;
+	}
+
+	@Override
+	public URI toFileURI(ISourceLocation uri) {
+		throw new UnsupportedOperationException("Cannot convert stdin to File URI");
 	}
 }

--- a/src/org/rascalmpl/uri/StandardInputURIResolver.java
+++ b/src/org/rascalmpl/uri/StandardInputURIResolver.java
@@ -17,9 +17,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
-import org.rascalmpl.interpreter.asserts.NotYetImplemented;
 
 public class StandardInputURIResolver implements ISourceLocationInput {
 	public boolean exists(ISourceLocation uri) {

--- a/src/org/rascalmpl/uri/StandardOutputURIResolver.java
+++ b/src/org/rascalmpl/uri/StandardOutputURIResolver.java
@@ -15,8 +15,11 @@ package org.rascalmpl.uri;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
+import org.rascalmpl.interpreter.asserts.NotYetImplemented;
 
 public class StandardOutputURIResolver implements ISourceLocationOutput {
 
@@ -42,5 +45,15 @@ public class StandardOutputURIResolver implements ISourceLocationOutput {
 	@Override
 	public boolean supportsHost() {
 		return false;
+	}
+	
+	@Override
+	public boolean supportsToFileURI() {
+		return false;
+	}
+
+	@Override
+	public URI toFileURI(ISourceLocation uri) {
+		throw new UnsupportedOperationException("Cannot convert stdout to File URI");
 	}
 }

--- a/src/org/rascalmpl/uri/StandardOutputURIResolver.java
+++ b/src/org/rascalmpl/uri/StandardOutputURIResolver.java
@@ -17,9 +17,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.imp.pdb.facts.ISourceLocation;
-import org.rascalmpl.interpreter.asserts.NotYetImplemented;
 
 public class StandardOutputURIResolver implements ISourceLocationOutput {
 

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -203,7 +203,7 @@ public class URIResolverRegistry {
 
 	private static final Pattern splitScheme = Pattern.compile("^([^\\+]*)\\+");
 
-	private ISourceLocationInput getInputResolver(String scheme) {
+	public ISourceLocationInput getInputResolver(String scheme) {
 		synchronized (inputResolvers) {
 			ISourceLocationInput result = inputResolvers.get(scheme);
 			if (result == null) {


### PR DESCRIPTION
Long time since I commited something.. I expect it to have some flaws but I would like to share my idea/work.

I attempted to fix #790 and #862 in one go, since they were in the same code region.

Input and OutputResolvers have a method supportsToFileURI and a method toFileURI now. They can be used if the scheme is a proxy for a file on disk (works at least for file, tmp, and project locs). This way the setEnvironment function can translate supported schemes to files and the sourcepaths will make sense for M3.

When calling createM3FromFile directly, one had manually to set the environment to empty, if the previous call was to createM3FromDirectory with a broken class/source path, else there would be an error. I introduced a keywork parameter to control if the environment should be reset.

Some notes:
- getInputResolver is now public. I cannot tell the consequences. In the same line, getOutputResolver should be made public I guess, but I don't know if this is required right now.
- I throw errors on actions that are not valid, is this ok or should it return null?

Let me know what you think. There is also a related pull request for rascal-eclipse.