### PR TITLE
Inlined rascal-shell project into rascal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bootstrap/
 .DS_Store
 /.apt_generated/
 
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,41 @@
 					</includes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.4.1</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Main-Class>org.rascalmpl.shell.RascalShell</Main-Class>
+									</manifestEntries>
+								</transformer>
+							</transformers>
+							<!--
+								http://zhentao-li.blogspot.nl/2012/06/maven-shade-plugin-invalid-signature.html
+							-->
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>							
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>

--- a/src/org/rascalmpl/shell/ManifestRunner.java
+++ b/src/org/rascalmpl/shell/ManifestRunner.java
@@ -1,0 +1,59 @@
+package org.rascalmpl.shell;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.rascalmpl.value.IInteger;
+import org.rascalmpl.value.IValue;
+import org.rascalmpl.value.io.StandardTextWriter;
+import org.rascalmpl.debug.IRascalMonitor;
+import org.rascalmpl.interpreter.Evaluator;
+import org.rascalmpl.interpreter.NullRascalMonitor;
+import org.rascalmpl.interpreter.staticErrors.CommandlineError;
+import org.rascalmpl.interpreter.utils.RascalManifest;
+import org.rascalmpl.uri.URIUtil;
+
+public class ManifestRunner implements ShellRunner {
+    private final RascalManifest mf;
+    private final Evaluator eval;
+
+
+    public ManifestRunner(RascalManifest mf, PrintWriter stdout, PrintWriter stderr) {
+        assert mf.hasManifest(ManifestRunner.class);
+        this.mf = mf;
+        this.eval = ShellEvaluatorFactory.getDefaultEvaluator(stdout, stderr);
+        addExtraSourceFolders();
+    } 
+
+    void addExtraSourceFolders() {
+        for (String root : mf.getSourceRoots(ManifestRunner.class)) {
+            eval.addRascalSearchPath(URIUtil.getChildLocation(URIUtil.rootLocation("manifest"), root)); 
+        }
+    }
+
+    @Override
+    public void run(String[] args) throws IOException {
+        IRascalMonitor monitor = new NullRascalMonitor();
+        String module = mf.getMainModule(ManifestRunner.class);
+        assert module != null;
+        eval.doImport(monitor, module);
+
+        String main = mf.getMainFunction(ManifestRunner.class);
+        main = main != null ? main : RascalManifest.DEFAULT_MAIN_FUNCTION;
+
+        try {
+            IValue v = eval.main(monitor, module, main, args);
+
+            if (v.getType().isInteger()) {
+                System.exit(((IInteger) v).intValue());
+            } else {
+                new StandardTextWriter(true).write(v, eval.getStdOut());
+                eval.getStdOut().flush();
+                System.exit(0);
+            }
+        } catch (CommandlineError e) {
+            System.err.println(e.getMessage());
+            System.err.println(e.help("java -jar ..."));
+        }
+    }
+}

--- a/src/org/rascalmpl/shell/ManifestURIResolver.java
+++ b/src/org/rascalmpl/shell/ManifestURIResolver.java
@@ -1,0 +1,9 @@
+package org.rascalmpl.shell;
+
+import org.rascalmpl.uri.libraries.ClassResourceInput;
+
+public class ManifestURIResolver extends ClassResourceInput {
+    public ManifestURIResolver() {
+        super("manifest", ManifestURIResolver.class, "/");
+    }    
+}

--- a/src/org/rascalmpl/shell/ModuleRunner.java
+++ b/src/org/rascalmpl/shell/ModuleRunner.java
@@ -1,0 +1,42 @@
+package org.rascalmpl.shell;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.rascalmpl.value.IValue;
+import org.rascalmpl.value.IInteger;
+import org.rascalmpl.value.io.StandardTextWriter;
+import org.rascalmpl.interpreter.Evaluator;
+
+public class ModuleRunner implements ShellRunner {
+
+  private final Evaluator eval;
+
+  public ModuleRunner(PrintWriter stdout, PrintWriter stderr) {
+    eval = ShellEvaluatorFactory.getDefaultEvaluator(stdout, stderr);
+  }
+
+  @Override
+  public void run(String args[]) throws IOException {
+    String module = args[0];
+    if (module.endsWith(".rsc")) {
+      module = module.substring(0, module.length() - 4);
+    }
+    module = module.replaceAll("/", "::");
+
+    eval.doImport(null, module);
+    String[] realArgs = new String[args.length - 1];
+    System.arraycopy(args, 1, realArgs, 0, args.length - 1);
+
+    IValue v = eval.main(null, module, "main", realArgs);
+
+    if (v != null && !(v instanceof IInteger)) {
+      new StandardTextWriter(true).write(v, eval.getStdOut());
+      eval.getStdOut().flush();
+    }
+
+    System.exit(v instanceof IInteger ? ((IInteger) v).intValue() : 0);
+    return;
+  }
+
+}

--- a/src/org/rascalmpl/shell/REPLRunner.java
+++ b/src/org/rascalmpl/shell/REPLRunner.java
@@ -1,0 +1,46 @@
+package org.rascalmpl.shell;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.net.URISyntaxException;
+
+import jline.TerminalFactory;
+
+import org.rascalmpl.interpreter.Evaluator;
+import org.rascalmpl.repl.RascalInterpreterREPL;
+
+public class REPLRunner extends RascalInterpreterREPL  implements ShellRunner {
+
+  private static File getHistoryFile() throws IOException {
+    File home = new File(System.getProperty("user.home"));
+    File rascal = new File(home, ".rascal");
+    if (!rascal.exists()) {
+      rascal.mkdirs();
+    }
+    File historyFile = new File(rascal, ".repl-history-rascal-terminal");
+    if (!historyFile.exists()) {
+      historyFile.createNewFile();
+    }
+    return historyFile;
+  }
+
+  public REPLRunner(InputStream stdin, OutputStream stdout) throws IOException, URISyntaxException {
+    super(stdin, stdout, true, true, getHistoryFile(), TerminalFactory.get());
+    setMeasureCommandTime(false);
+  }
+
+  @Override
+  protected Evaluator constructEvaluator(Writer stdout, Writer stderr) {
+    return ShellEvaluatorFactory.getDefaultEvaluator(new PrintWriter(stdout), new PrintWriter(stderr));
+  }
+
+  @Override
+  public void run(String[] args) throws IOException {
+    // there are no args for now
+    run();
+  }
+}

--- a/src/org/rascalmpl/shell/RascalShell.java
+++ b/src/org/rascalmpl/shell/RascalShell.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2015 CWI
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+
+ *   * Jurgen J. Vinju - Jurgen.Vinju@cwi.nl - CWI
+ *   * Tijs van der Storm - Tijs.van.der.Storm@cwi.nl
+ *   * Paul Klint - Paul.Klint@cwi.nl - CWI
+ *   * Arnold Lankamp - Arnold.Lankamp@cwi.nl
+ *******************************************************************************/
+package org.rascalmpl.shell;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.jar.Manifest;
+
+import org.rascalmpl.interpreter.utils.RascalManifest;
+import org.rascalmpl.library.experiments.Compiler.Commands.Rascal;
+import org.rascalmpl.library.experiments.Compiler.Commands.RascalC;
+import org.rascalmpl.library.experiments.Compiler.Commands.RascalTests;
+import org.rascalmpl.library.experiments.Compiler.RVM.Interpreter.NoSuchRascalFunction;
+import org.rascalmpl.shell.compiled.CompiledRascalShell;
+
+
+public class RascalShell  {
+
+    private static void printVersionNumber(){
+        try {
+            Enumeration<URL> resources = RascalShell.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
+            while (resources.hasMoreElements()) {
+                Manifest manifest = new Manifest(resources.nextElement().openStream());
+                String bundleName = manifest.getMainAttributes().getValue("Bundle-Name");
+                if (bundleName != null && bundleName.equals("rascal-shell")) {
+                    String result = manifest.getMainAttributes().getValue("Bundle-Version");
+                    if (result != null) {
+                        System.out.println("Version: " + result);
+                        return;
+                    }
+                }
+            }
+        } catch (IOException E) {
+        }
+        System.out.println("Version: unknown");
+    }
+
+
+    public static void main(String[] args) throws IOException {
+        printVersionNumber();
+        RascalManifest mf = new RascalManifest();
+
+        try {
+            ShellRunner runner; 
+            if (mf.hasManifest(RascalShell.class) && mf.hasMainModule(RascalShell.class)) {
+                runner = new ManifestRunner(mf, new PrintWriter(System.out), new PrintWriter(System.err, true));
+            } 
+            else if (args.length > 0) {            	
+            	if (args[0].equals("--help")) {
+                    System.err.println("Usage: java -jar rascal-version.jar [{--rascalc, --rascal, --rascalTests, --compiledREPL}] [Module]");
+                    System.err.println("\ttry also the --help options of the respective commands.");
+                    System.err.println("\tjava -jar rascal-version.jar [Module]: runs the main function of the module using the interpreter");
+                    return;
+                }
+            	else if (args[0].equals("--rascalc")) {
+                    runner = new ShellRunner() {
+                        @Override
+                        public void run(String[] args) {
+                            RascalC.main(Arrays.copyOfRange(args, 1, args.length));
+                        }
+                    };
+                }
+                else if (args[0].equals("--rascal")) {
+                    runner = new ShellRunner() {
+                        @Override
+                        public void run(String[] args) throws IOException {
+                            Rascal.main(Arrays.copyOfRange(args, 1, args.length));
+                        }
+                    };
+                }
+                else if (args[0].equals("--rascalTests")) {
+                    runner = new ShellRunner() {
+                        @Override
+                        public void run(String[] args) throws IOException {
+                            try {
+                                RascalTests.main(Arrays.copyOfRange(args, 1, args.length));
+                            } catch (NoSuchRascalFunction | URISyntaxException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                    };
+                }
+                else if (args[0].equals("--compiledREPL")) {
+                    runner = new ShellRunner() {
+                        @Override
+                        public void run(String[] args) throws IOException {
+                            CompiledRascalShell.main(Arrays.copyOfRange(args, 1, args.length));
+                        }
+                    };
+                    
+                }
+                else {
+                    runner = new ModuleRunner(new PrintWriter(System.out), new PrintWriter(System.err, true));
+                }
+            } 
+            else {
+                runner = new REPLRunner(System.in, System.out);
+            }
+            runner.run(args);
+
+            System.exit(0);
+        }
+        catch (Throwable e) {
+            System.err.println("\n\nunexpected error: " + e.getMessage());
+            e.printStackTrace(System.err);
+            System.exit(1);
+        }
+        finally {
+            System.out.flush();
+            System.err.flush();
+        }
+    }
+}

--- a/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
+++ b/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
@@ -1,0 +1,25 @@
+package org.rascalmpl.shell;
+
+import java.io.PrintWriter;
+
+import org.rascalmpl.value.IValueFactory;
+import org.rascalmpl.interpreter.ConsoleRascalMonitor;
+import org.rascalmpl.interpreter.Evaluator;
+import org.rascalmpl.interpreter.env.GlobalEnvironment;
+import org.rascalmpl.interpreter.env.ModuleEnvironment;
+import org.rascalmpl.interpreter.load.StandardLibraryContributor;
+import org.rascalmpl.values.ValueFactoryFactory;
+
+public class ShellEvaluatorFactory {
+
+  public static Evaluator getDefaultEvaluator(PrintWriter stdout, PrintWriter stderr) {
+    GlobalEnvironment heap = new GlobalEnvironment();
+    ModuleEnvironment root = heap.addModule(new ModuleEnvironment(ModuleEnvironment.SHELL_MODULE, heap));
+    IValueFactory vf = ValueFactoryFactory.getValueFactory();
+    Evaluator evaluator = new Evaluator(vf, stderr, stdout, root, heap);
+    evaluator.addRascalSearchPathContributor(StandardLibraryContributor.getInstance());
+    evaluator.setMonitor(new ConsoleRascalMonitor());
+    return evaluator;
+  }
+
+}

--- a/src/org/rascalmpl/shell/ShellRunner.java
+++ b/src/org/rascalmpl/shell/ShellRunner.java
@@ -1,0 +1,7 @@
+package org.rascalmpl.shell;
+
+import java.io.IOException;
+
+public interface ShellRunner {
+  void run(String[] args) throws IOException;
+}

--- a/src/org/rascalmpl/shell/compiled/CompiledREPLRunner.java
+++ b/src/org/rascalmpl/shell/compiled/CompiledREPLRunner.java
@@ -1,0 +1,53 @@
+package org.rascalmpl.shell.compiled;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.net.URISyntaxException;
+
+import org.rascalmpl.library.experiments.Compiler.RVM.Interpreter.NoSuchRascalFunction;
+import org.rascalmpl.library.experiments.Compiler.RVM.Interpreter.repl.CommandExecutor;
+import org.rascalmpl.library.experiments.Compiler.RVM.Interpreter.repl.CompiledRascalREPL;
+import org.rascalmpl.shell.ShellRunner;
+import org.rascalmpl.library.experiments.Compiler.RVM.Interpreter.repl.debug.DebugREPLFrameObserver;
+import org.rascalmpl.library.util.PathConfig;
+
+import jline.TerminalFactory;
+
+public class CompiledREPLRunner extends CompiledRascalREPL  implements ShellRunner {
+	
+	private final DebugREPLFrameObserver debugObserver;
+	
+	public CompiledREPLRunner(PathConfig pcfg, InputStream stdin, OutputStream stdout) throws IOException, URISyntaxException {
+		super(pcfg, stdin, stdout, true, true, getHistoryFile(), TerminalFactory.get());
+		debugObserver = new DebugREPLFrameObserver(pcfg, reader.getInput(), stdout, true, true, getHistoryFile(), TerminalFactory.get());
+		executor.setDebugObserver(debugObserver);
+		setMeasureCommandTime(true);
+	}
+
+	private static File getHistoryFile() throws IOException {
+		File home = new File(System.getProperty("user.home"));
+		File rascal = new File(home, ".rascal");
+		if (!rascal.exists()) {
+			rascal.mkdirs();
+		}
+		File historyFile = new File(rascal, ".repl-history-rascal-terminal");
+		if (!historyFile.exists()) {
+			historyFile.createNewFile();
+		}
+		return historyFile;
+	}
+
+	@Override
+	protected CommandExecutor constructCommandExecutor(PathConfig pcfg, PrintWriter stdout, PrintWriter stderr) throws IOException, NoSuchRascalFunction, URISyntaxException {
+		return new CommandExecutor(pcfg, stdout, stderr);
+	}
+
+	@Override
+	public void run(String[] args) throws IOException {
+		// there are no args for now
+		run();
+	}
+}

--- a/src/org/rascalmpl/shell/compiled/CompiledRascalShell.java
+++ b/src/org/rascalmpl/shell/compiled/CompiledRascalShell.java
@@ -1,0 +1,97 @@
+package org.rascalmpl.shell.compiled;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Manifest;
+
+import org.rascalmpl.interpreter.utils.RascalManifest;
+import org.rascalmpl.library.experiments.Compiler.Commands.CommandOptions;
+import org.rascalmpl.library.util.PathConfig;
+import org.rascalmpl.shell.ManifestRunner;
+import org.rascalmpl.shell.ModuleRunner;
+import org.rascalmpl.shell.ShellRunner;
+import org.rascalmpl.value.IValueFactory;
+import org.rascalmpl.values.ValueFactoryFactory;
+
+
+public class CompiledRascalShell  {
+
+  private static void printVersionNumber(){
+    try {
+      Enumeration<URL> resources = CompiledRascalShell.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
+      while (resources.hasMoreElements()) {
+        Manifest manifest = new Manifest(resources.nextElement().openStream());
+        String bundleName = manifest.getMainAttributes().getValue("Bundle-Name");
+        if (bundleName != null && bundleName.equals("rascal-shell")) {
+          String result = manifest.getMainAttributes().getValue("Bundle-Version");
+          if (result != null) {
+            System.out.println("Version: " + result);
+            return;
+          }
+        }
+      }
+    } catch (IOException E) {
+    }
+    System.out.println("Version: unknown");
+  }
+
+
+  public static void main(String[] args) throws IOException {
+
+	IValueFactory vf = ValueFactoryFactory.getValueFactory();
+	CommandOptions cmdOpts = new CommandOptions("CompiledRascalShell");
+	try {
+		cmdOpts
+		.locsOption("src").locsDefault(cmdOpts.getDefaultStdlocs().isEmpty() ? vf.list(cmdOpts.getDefaultStdlocs()) : cmdOpts.getDefaultStdlocs())
+		.help("Add (absolute!) source location, use multiple --src arguments for multiple locations")
+
+		.locOption("bin").locDefault(vf.sourceLocation("home", "", "bin"))
+		.help("Directory for Rascal binaries")
+		
+		.locsOption("lib").locsDefault((co) -> vf.list(co.getCommandLocOption("bin")))
+		.help("Add new lib location, use multiple --lib arguments for multiple locations")
+
+		.locOption("boot").locDefault(cmdOpts.getDefaultBootLocation())
+		.help("Rascal boot directory")
+
+		.boolOption("help")
+		.help("Print help message for this command")
+		.noModuleArgument()
+		.handleArgs(args);
+		
+	} catch (URISyntaxException e1) {
+		e1.printStackTrace();
+		System.exit(1);
+	}  
+
+	printVersionNumber();
+    RascalManifest mf = new RascalManifest();
+    try {
+      ShellRunner runner; 
+      if (mf.hasManifest(CompiledRascalShell.class) && mf.hasMainModule(CompiledRascalShell.class)) {
+        runner = new ManifestRunner(mf, new PrintWriter(System.out), new PrintWriter(System.err));
+      } 
+//      else if (args.length > 0) {
+//        runner = new ModuleRunner(new PrintWriter(System.out), new PrintWriter(System.err));
+//      } 
+      else {
+        runner = new CompiledREPLRunner(cmdOpts.getPathConfig(), System.in, System.out);
+      }
+      runner.run(args);
+
+      System.exit(0);
+    }
+    catch (Throwable e) {
+      System.err.println("\n\nunexpected error: " + e.getMessage());
+      e.printStackTrace(System.err);
+      System.exit(1);
+    }
+    finally {
+      System.out.flush();
+      System.err.flush();
+    }
+  }
+}

--- a/src/org/rascalmpl/uri/resolvers.config
+++ b/src/org/rascalmpl/uri/resolvers.config
@@ -14,3 +14,4 @@ org.rascalmpl.uri.libraries.TestDataURIResolver
 org.rascalmpl.uri.libraries.BenchmarkURIResolver
 org.rascalmpl.uri.libraries.TutorURIResolver
 org.rascalmpl.uri.libraries.CoursesURIResolver
+org.rascalmpl.shell.ManifestURIResolver


### PR DESCRIPTION
We've discussed this before, and now I did it.

The rascal project now compiles to a shaded jar that is directly the shell. No more separate need for [usethesource/rascal-shell](/usethesource/rascal-shell). The separate project was created to split eclipse en command-line code. That split is now gone, since rascal-eclipse embeds the `rascal-shell.jar`.

I've done some git rewriting to keep the history and commits on the old code.

After this has been merged, we need to remove rascal-shell and move the dependency of rascal-eclipse to just rascal.

@msteindorfer & @joukestoel is there a problem that we are now pushing this shaded jar to nexus?