### PR TITLE
Cache Method Meta-Object lookups

### DIFF
--- a/src/org/rascalmpl/library/experiments/Compiler/RVM/Interpreter/Function.java
+++ b/src/org/rascalmpl/library/experiments/Compiler/RVM/Interpreter/Function.java
@@ -3,16 +3,17 @@ package org.rascalmpl.library.experiments.Compiler.RVM.Interpreter;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.ref.SoftReference;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.rascalmpl.interpreter.TypeReifier;
 import org.nustaq.serialization.FSTBasicObjectSerializer;
 import org.nustaq.serialization.FSTClazzInfo;
 import org.nustaq.serialization.FSTClazzInfo.FSTFieldInfo;
 import org.nustaq.serialization.FSTObjectInput;
 import org.nustaq.serialization.FSTObjectOutput;
 import org.rascalmpl.interpreter.ITestResultListener;
+import org.rascalmpl.interpreter.TypeReifier;
 import org.rascalmpl.interpreter.result.util.MemoizationCache;
 import org.rascalmpl.library.cobra.TypeParameterVisitor;
 import org.rascalmpl.library.experiments.Compiler.Rascal2muRascal.RandomValueTypeVisitor;
@@ -94,6 +95,9 @@ public class Function implements Serializable {
 	
 	// transient fields 
 	transient SoftReference<MemoizationCache<IValue>> memoization;
+
+    private transient Class<?> javaClazz;
+    private transient Method javaMethod;
 	
 	public static void initSerialization(IValueFactory vfactory, TypeStore ts){
 		vf = vfactory;
@@ -399,6 +403,20 @@ public class Function implements Serializable {
       for(Type cons : ts.getConstructors()){
         System.err.println("cons: " + cons);
       }
+    }
+
+    public Class<?> getJavaClass() {
+        return javaClazz;
+    }
+
+    public Method getJavaMethod() {
+        return javaMethod;
+    }
+
+    public void setJavaMetaObjects(Class<?> clazz, Method method) {
+        assert javaClazz == null && javaMethod == null;
+        this.javaClazz = clazz;
+        this.javaMethod = method;
     }
 }
 

--- a/src/org/rascalmpl/library/experiments/Compiler/RVM/Interpreter/RVMCore.java
+++ b/src/org/rascalmpl/library/experiments/Compiler/RVM/Interpreter/RVMCore.java
@@ -58,9 +58,6 @@ import org.rascalmpl.value.type.Type;
 import org.rascalmpl.value.type.TypeFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-
 public abstract class RVMCore {
 	public final IValueFactory vf;
 
@@ -1075,71 +1072,25 @@ public abstract class RVMCore {
 		} 
 	}
 	
-	private final static class MethodSignature {
-
-        private final Class<?> clazz;
-        private final String methodName;
-        private final String className;
-        private final Type parameterTypes;
-        private final Type keywordTypes;
-        private final int reflect;
-        private final int hash;
-
-        public MethodSignature(Class<?> clazz, String methodName, String className, Type parameterTypes,
-            Type keywordTypes, int reflect) {
-            this.clazz = clazz;
-            this.methodName = methodName;
-            this.className = className;
-            this.parameterTypes = parameterTypes;
-            this.keywordTypes = keywordTypes;
-            this.reflect = reflect;
-            this.hash = clazz.hashCode() * 7
-                + methodName.hashCode() * 13
-                + (parameterTypes == null ? 43 : parameterTypes.hashCode() * 17)
-                + (keywordTypes == null ? 42 : keywordTypes.hashCode() * 23)
-                + reflect;
-        }
-
-        public Method getMethod() {
-            try {
-                return clazz.getMethod(methodName, makeJavaTypes(methodName, className, parameterTypes, keywordTypes, reflect));
-            }
-            catch (NoSuchMethodException | SecurityException e) {
-                throw new CompilerError("could not find Java method", e);
-            }
-        }
-        
-        @Override
-        public boolean equals(Object obj) {
-            if (obj instanceof MethodSignature) {
-                MethodSignature other = (MethodSignature)obj; 
-                return other.clazz == clazz
-                    && other.parameterTypes == parameterTypes
-                    && other.keywordTypes == keywordTypes
-                    && other.reflect == reflect
-                    && other.methodName.equals(methodName)
-                    ;
-            }
-            return false;
-        }
-        
-        @Override
-        public int hashCode() {
-            return hash;
-        }
-	}
-	private static final  Cache<MethodSignature, Method> methodCache = Caffeine.newBuilder()
-	    .maximumSize(2000)
-	    .build();
+	Method getJavaMethod(Class<?> clazz, String methodName, String className, Type parameterTypes, Type keywordTypes, int reflect) {
+	    try {
+	        return clazz.getMethod(methodName, makeJavaTypes(methodName, className, parameterTypes, keywordTypes, reflect));
+	    }
+	    catch (NoSuchMethodException | SecurityException e) {
+	        throw new CompilerError("could not find Java method", e);
+	    }
+    }
 	
 	int callJavaMethod(String methodName, String className, Type parameterTypes, Type keywordTypes, int reflect, Object[] stack, int sp) throws Throw, Throwable {
-		Class<?> clazz = null;
-		try {
-			clazz = getJavaClass(className);
+	    Class<?> clazz = getJavaClass(className);
+	    Method m = getJavaMethod(clazz, methodName, className, parameterTypes, keywordTypes, reflect);
+	    return callJavaMethod(clazz, m, parameterTypes, keywordTypes, reflect, stack, sp);
+	}
+
+
+    int callJavaMethod(Class<?> clazz, Method m, Type parameterTypes, Type keywordTypes, int reflect, Object[] stack, int sp) throws Throw, Throwable {
+	    try {
 			Object instance = getJavaClassInstance(clazz);
-			
-			MethodSignature sig = new MethodSignature(clazz, methodName, className, parameterTypes, keywordTypes, reflect);
-			Method m = methodCache.get(sig, s -> s.getMethod());
 			int arity = parameterTypes.getArity();
 			int kwArity = keywordTypes.getArity();
 			int kwMaps = kwArity > 0 ? 2 : 0;
@@ -1165,7 +1116,7 @@ public abstract class RVMCore {
 			}
 			
 			if(reflect == 1) {
-				parameters[arity + kwArity] = converted.contains(className + "." + methodName) ? this.rex : null /*this.getEvaluatorContext()*/; // TODO: remove CTX
+				parameters[arity + kwArity] = converted.contains(clazz.getName() + "." + m.getName()) ? this.rex : null /*this.getEvaluatorContext()*/; // TODO: remove CTX
 			}
 			stack[sp - arity - kwMaps] =  m.invoke(instance, parameters);
 			return sp - arity - kwMaps + 1;


### PR DESCRIPTION
since I've never touch this code before, I've made a pull request for review.

In general, I was profiling the compiler and noticed that except for the `dynRun` at the top, the next was calls to `Class.getMethod` (around 8-10%). And only for about 10/15 java methods.

I've added fields to the Function block that stores the calculated class and method meta object instance on first run.

It passes all tests and bootstraps succesfully.

And phase 2 and 3 were first 660-675s and went down to 652s-657s. so, around 10s improvement. 
