### PR TITLE
Fixed Bootstrap on Windows. In this case the Scheme Specific Part of …

### DIFF
--- a/src/org/rascalmpl/library/experiments/Compiler/Commands/Bootstrap.java
+++ b/src/org/rascalmpl/library/experiments/Compiler/Commands/Bootstrap.java
@@ -244,7 +244,7 @@ public class Bootstrap {
                 };
                    
                 if (!realBootstrap) {
-                  FileSystem jar = FileSystems.newFileSystem(new URI("jar:file", rvm[0], null), Collections.singletonMap("create", true));
+                  FileSystem jar = FileSystems.newFileSystem(new URI("jar", new File(rvm[0]).toURI().toString(), null), Collections.singletonMap("create", true));
                   time("Copying downloaded files", () -> copyJar(jar.getPath("boot"), targetFolder));
                   System.exit(0);
                 }


### PR DESCRIPTION
Running `mvn install` for the first time on Windows caused the following exception:

```
sourceFolder: d:\projecten\software\Rascal\master\rascal\src
courseSource: d:\projecten\software\Rascal\master\rascal\src\org\rascalmpl\courses
BOOTSTRAP:Removing files in d:\projecten\software\Rascal\master\rascal\bootstrap
BOOTSTRAP:bootstrap folder: d:\projecten\software\Rascal\master\rascal\bootstrap
BOOTSTRAP:deployed version ready: d:\projecten\software\Rascal\master\rascal\bootstrap\rascal-0.8.3-bs6.jar
Exception in thread "main" java.lang.IllegalArgumentException: URI is not hierarchical
	at sun.nio.fs.WindowsUriSupport.fromUri(WindowsUriSupport.java:122)
	at sun.nio.fs.WindowsFileSystemProvider.getPath(WindowsFileSystemProvider.java:92)
	at java.nio.file.Paths.get(Paths.java:138)
	at com.sun.nio.zipfs.ZipFileSystemProvider.uriToPath(ZipFileSystemProvider.java:85)
	at com.sun.nio.zipfs.ZipFileSystemProvider.newFileSystem(ZipFileSystemProvider.java:107)
	at java.nio.file.FileSystems.newFileSystem(FileSystems.java:326)
	at java.nio.file.FileSystems.newFileSystem(FileSystems.java:276)
	at org.rascalmpl.library.experiments.Compiler.Commands.Bootstrap.lambda$3(Bootstrap.java:247)
	at org.rascalmpl.library.experiments.Compiler.Commands.Bootstrap$ThrowingSideEffectOnly.call(Bootstrap.java:115)
	at org.rascalmpl.library.experiments.Compiler.Commands.Bootstrap.lambda$0(Bootstrap.java:110)
	at org.rascalmpl.library.experiments.Compiler.Commands.Bootstrap.time(Bootstrap.java:104)
	at org.rascalmpl.library.experiments.Compiler.Commands.Bootstrap.time(Bootstrap.java:110)
	at org.rascalmpl.library.experiments.Compiler.Commands.Bootstrap.main(Bootstrap.java:232)
```

This is caused by the URI constructed in Bootstrap.java (line 247) in the form of : 
`jar:file:d:/projecten/software/Rascal/master/rascal/bootstrap/rascal-0.8.3-bs6.jar`
But it should be : 
`jar:file:/d:/projecten/software/Rascal/master/rascal/bootstrap/rascal-0.8.3-bs6.jar`

My fix is based on the assumption that `toURI()` of a `File` created with an absolute file path will return a hierarchical URI on both Windows and Linux. I have not tested this on Linux.