### PR TITLE
M3 model uses properties instead of annotations

### DIFF
--- a/src/org/rascalmpl/courses/Recipes/Metrics/MeasuringJava/MeasuringClasses/MeasuringClasses.concept
+++ b/src/org/rascalmpl/courses/Recipes/Metrics/MeasuringJava/MeasuringClasses/MeasuringClasses.concept
@@ -40,17 +40,17 @@ myModel = createM3FromEclipseProject(|project://example-project|);
 Next, let's focus on the _containment_ relation. This defines what parts of the source code are parts of which other parts:
 [source,rascal-shell,continue]
 ----
-myModel@containment
+myModel.containment
 ----
 As you can read, classes contain methods, methods contain variables, etc. Classes could also contain other classes (nested classes), and methods can even contain classes (anonymous classes). Let's focus on a specific class, and project what it contains from the relation:
 [source,rascal-shell,continue]
 ----
-myModel@containment[|java+class:///HelloWorld|]
+myModel.containment[|java+class:///HelloWorld|]
 ----
 Let's filter the methods:
 [source,rascal-shell,continue]
 ----
-helloWorldMethods = [ e | e <- myModel@containment[|java+class:///HelloWorld|], e.scheme == "java+method"];
+helloWorldMethods = [ e | e <- myModel.containment[|java+class:///HelloWorld|], e.scheme == "java+method"];
 ----
 And we are ready to compute our first metric. How many methods does this class contain?
 [source,rascal-shell,continue]
@@ -61,18 +61,18 @@ size(helloWorldMethods)
 No magic applied! It is just a little query on a model that knows everything about the code. Let's generalize and compute the number of methods for all classes in one big expression. First a function to compute the number for a given class:
 [source,rascal-shell,continue]
 ----
-int numberOfMethods(loc cl, M3 model) = size([ m | m <- model@containment[cl], isMethod(m)]);
+int numberOfMethods(loc cl, M3 model) = size([ m | m <- model.containment[cl], isMethod(m)]);
 ----
 then we apply this new function to give us a map from classes to integers:
 [source,rascal-shell,continue]
 ----
-map[loc class, int methodCount] numberOfMethodsPerClass = (cl:numberOfMethods(cl, myModel) | <cl,_> <- myModel@containment, isClass(cl));
+map[loc class, int methodCount] numberOfMethodsPerClass = (cl:numberOfMethods(cl, myModel) | <cl,_> <- myModel.containment, isClass(cl));
 ----
 how about the number of fields?
 [source,rascal-shell,continue]
 ----
-int numberOfFields(loc cl, M3 model) = size([ m | m <- model@containment[cl], isField(m)]);
-map[loc class, int fieldCount] numberOfFieldsPerClass = (cl:numberOfFields(cl, myModel) | <cl,_> <- myModel@containment, isClass(cl));
+int numberOfFields(loc cl, M3 model) = size([ m | m <- model.containment[cl], isField(m)]);
+map[loc class, int fieldCount] numberOfFieldsPerClass = (cl:numberOfFields(cl, myModel) | <cl,_> <- myModel.containment, isClass(cl));
 ----
 what is the ratio between fields and methods for each class?
 [source,rascal-shell,continue]

--- a/src/org/rascalmpl/library/analysis/m3/Registry.rsc
+++ b/src/org/rascalmpl/library/analysis/m3/Registry.rsc
@@ -36,7 +36,7 @@ programmer should take care to call <<unregisterProject>> to prevent memory leak
 }
 void registerProject(loc project, M3 model) {
     rel[str scheme, loc name, loc src] perScheme 
-      = {<name.scheme, name, src> | <name, src> <- model@declarations};
+      = {<name.scheme, name, src> | <name, src> <- model.declarations};
     
     for (str scheme <- perScheme<scheme>)
        registerLocations(scheme, project.authority, (name : src | <name, src> <- perScheme[scheme]));

--- a/src/org/rascalmpl/library/lang/java/m3/TypeHierarchy.rsc
+++ b/src/org/rascalmpl/library/lang/java/m3/TypeHierarchy.rsc
@@ -4,7 +4,7 @@ import lang::java::m3::Core;
 import lang::java::m3::TypeSymbol;
 
 rel[loc from, loc to] getDeclaredTypeHierarchy(M3 model) {
-  typeHierarchy = model@extends + model@implements;
+  typeHierarchy = model.extends + model.implements;
   typesWithoutParent = classes(model) + interfaces(model) - typeHierarchy<from>;
   
   return typesWithoutParent * {|java+class:///java/lang/Object|} + typeHierarchy;


### PR DESCRIPTION
Given the change from commit c6d4dba70a83e2a0c34554a20f9a549bf950de01 the M3 model is now using properties defined on the M3 datatype itself.

This means that I now get a rather annoying error when building a model from a location:

```
rascal>createM3FromDirectory(|file:///home/kevin/src/nanohttpd|, dependencyUpdateSites = (), version = "1.7");
|std:///analysis/m3/Registry.rsc|(1302,5,<39,51>,<39,56>): Undeclared annotation: declarations on M3
Advice: |http://tutor.rascal-mpl.org/Errors/Static/UndeclaredAnnotation/UndeclaredAnnotation.html|
```