### PR TITLE
Add a `pitfall` explanation for overloaded funcs

### DIFF
--- a/src/org/rascalmpl/courses/Rascal/Declarations/Function/Function.concept
+++ b/src/org/rascalmpl/courses/Rascal/Declarations/Function/Function.concept
@@ -184,3 +184,5 @@ neg(neg(f()));
 
 .Pitfalls
 
+In case of overlapping function definitions, the order in which the functions are tried is left undefined. The only exceptions are functions marked `default`, those will be tried after non-`default` functions.
+


### PR DESCRIPTION
The documentation on `Function` can use some additional explanation imho. See #1063 for context. 