### PR TITLE
Cleanup some forgotten file

### DIFF
--- a/src/org/rascalmpl/courses/Rascalopedia/Parser/.~lock.parse-tree.odg#
+++ b/src/org/rascalmpl/courses/Rascalopedia/Parser/.~lock.parse-tree.odg#
@@ -1,1 +1,0 @@
-,paulklint,pkmb.local,26.01.2012 21:31,file:///Users/paulklint/Library/Application%20Support/LibreOffice/3;


### PR DESCRIPTION
I wanted to include rascal as a maven dependency and assemble it with some of my Rascal sources in order to create a single .jar package. However, the assembling failed because of this hidden file for some reason.

**Update:** I later managed to assemble a jar. My error was probably also caused by older version of the `maven-assembly-plugin` that I had. But anyway, probably is better if that file is removed anyway.