### PR TITLE
Fix JsonValueReader calling beginObject() twice when visiting a map

### DIFF
--- a/src/org/rascalmpl/library/lang/json/io/JsonValueReader.java
+++ b/src/org/rascalmpl/library/lang/json/io/JsonValueReader.java
@@ -367,7 +367,6 @@ public class JsonValueReader {
               throw new IOException("Can not read JSon object as a map if the key type of the map (" + type + ") is not a string at " + in.getPath());
             }
             
-            in.beginObject();
             while (in.hasNext()) {
               w.put(vf.string(in.nextName()), read(in, type.getValueType()));
             }


### PR DESCRIPTION
beginObject() consumes the opening brace, however the function gets called twice for one object. I removed the second call instead of the first since the exception message inbetween them applies to the content after '{'.