### PR TITLE
Source code refactoring.

### DIFF
--- a/src/org/rascalmpl/interpreter/Evaluator.java
+++ b/src/org/rascalmpl/interpreter/Evaluator.java
@@ -552,14 +552,14 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
   }
 
   public Map<String, IValue> parseKeywordCommandLineArgs(IRascalMonitor monitor, String[] commandline, AbstractFunction func) {
-    Map<String, Type> expectedTypes = new HashMap<String,Type>();
+    Map<String, Type> expectedTypes = new HashMap<>();
     Type kwTypes = func.getKeywordArgumentTypes(getCurrentEnvt());
     
     for (String kwp : kwTypes.getFieldNames()) {
       expectedTypes.put(kwp, kwTypes.getFieldType(kwp));
     }
 
-    Map<String, IValue> params = new HashMap<String,IValue>();
+    Map<String, IValue> params = new HashMap<>();
     
     for (int i = 0; i < commandline.length; i++) {
       if (commandline[i].equals("-help")) {
@@ -707,7 +707,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
 		
 		for (IValue prod : robust) {
 			robustProds[i] = (IConstructor) prod;
-			List<Integer> chars = new LinkedList<Integer>();
+			List<Integer> chars = new LinkedList<>();
 			IList ranges = (IList) robust.get(prod);
 			
 			for (IValue range : ranges) {
@@ -1263,8 +1263,8 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
 	 * @return
 	 */
 	private Set<String> getImportingModules(Set<String> names) {
-		Set<String> found = new HashSet<String>();
-		LinkedList<String> todo = new LinkedList<String>(names);
+		Set<String> found = new HashSet<>();
+		LinkedList<String> todo = new LinkedList<>(names);
 		
 		while (!todo.isEmpty()) {
 			String mod = todo.pop();
@@ -1278,8 +1278,8 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
 	}
 	
 	private Set<String> getExtendingModules(Set<String> names) {
-		Set<String> found = new HashSet<String>();
-		LinkedList<String> todo = new LinkedList<String>(names);
+		Set<String> found = new HashSet<>();
+		LinkedList<String> todo = new LinkedList<>(names);
 		
 		while (!todo.isEmpty()) {
 			String mod = todo.pop();

--- a/src/org/rascalmpl/interpreter/JavaToRascal.java
+++ b/src/org/rascalmpl/interpreter/JavaToRascal.java
@@ -134,7 +134,7 @@ public class JavaToRascal {
 	}
 
 	private Object[] _listValue(IList q) {
-		ArrayList<Object> r = new ArrayList<Object>();
+		ArrayList<Object> r = new ArrayList<>();
 		for (IValue v : q) {
 			r.add(javaObject(v));
 		}
@@ -223,7 +223,7 @@ public class JavaToRascal {
 			evaluator.doImport(null, moduleName);
 			ModuleEnvironment env = evaluator.getCurrentEnvt().getImport(
 					moduleName);
-			ArrayList<AbstractFunction> funcs = new ArrayList<AbstractFunction>();
+			ArrayList<AbstractFunction> funcs = new ArrayList<>();
 			Type typ = getType(env, procedureResultType);
 			if (typ == null)
 				return false;

--- a/src/org/rascalmpl/interpreter/env/GlobalEnvironment.java
+++ b/src/org/rascalmpl/interpreter/env/GlobalEnvironment.java
@@ -201,7 +201,7 @@ public class GlobalEnvironment {
 	}
 	
 	public Set<String> getImportingModules(String mod) {
-		Set<String> result = new HashSet<String>();
+		Set<String> result = new HashSet<>();
 		
 		for (ModuleEnvironment env : moduleEnvironment.values()) {
 			if (env.getImports().contains(mod)) {
@@ -213,8 +213,8 @@ public class GlobalEnvironment {
 	}
 	
 	public Set<String> getExtendingModules(String mod) {
-		Set<String> result = new HashSet<String>();
-		List<String> todo = new LinkedList<String>();
+		Set<String> result = new HashSet<>();
+		List<String> todo = new LinkedList<>();
 		todo.add(mod);
 		
 		while (!todo.isEmpty()) {

--- a/src/org/rascalmpl/interpreter/matching/AbstractMatchingResult.java
+++ b/src/org/rascalmpl/interpreter/matching/AbstractMatchingResult.java
@@ -89,7 +89,7 @@ public abstract class AbstractMatchingResult extends AbstractBooleanResult imple
 	
 	public HashMap<String,IVarPattern> merge(HashMap<String,IVarPattern> left, List<IVarPattern> right){
 		if(left == null){
-			HashMap<String,IVarPattern> res = new  HashMap<String,IVarPattern>();
+			HashMap<String,IVarPattern> res = new HashMap<>();
 			for(IVarPattern vpr: right){
 				res.put(vpr.name(), vpr);
 			}

--- a/src/org/rascalmpl/interpreter/matching/RegExpPatternValue.java
+++ b/src/org/rascalmpl/interpreter/matching/RegExpPatternValue.java
@@ -174,7 +174,7 @@ public class RegExpPatternValue extends AbstractMatchingResult  {
 	
 	@Override
 	public List<IVarPattern> getVariables(){
-		List<IVarPattern> res = new LinkedList<IVarPattern>();
+		List<IVarPattern> res = new LinkedList<>();
 		for(String name : patternVars){
 			res.add(new RegExpVar(name));
 		}

--- a/src/org/rascalmpl/interpreter/matching/TypedVariablePattern.java
+++ b/src/org/rascalmpl/interpreter/matching/TypedVariablePattern.java
@@ -92,7 +92,7 @@ public class TypedVariablePattern extends AbstractMatchingResult implements IVar
 			
 			try {
 				// type checking code for formal parameters; the static type of the actual should be a sub-type of the type of the formal
-				Map<Type, Type> bindings = new HashMap<Type,Type>();
+				Map<Type, Type> bindings = new HashMap<>();
 				bindings.putAll(ctx.getCurrentEnvt().getTypeBindings());
 				declaredType.match(subject.getType(), bindings);
 

--- a/src/org/rascalmpl/interpreter/result/NamedFunction.java
+++ b/src/org/rascalmpl/interpreter/result/NamedFunction.java
@@ -180,7 +180,7 @@ abstract public class NamedFunction extends AbstractFunction {
     }
 
     protected Map<String, IValue> parseTags(FunctionDeclaration declaration) {
-        final Map<String, IValue> result = new HashMap<String, IValue>();
+        final Map<String, IValue> result = new HashMap<>();
         Tags tags = declaration.getTags();
         if (tags.hasTags()) {
             for (Tag tag : tags.getTags()) {

--- a/src/org/rascalmpl/interpreter/result/OverloadedFunction.java
+++ b/src/org/rascalmpl/interpreter/result/OverloadedFunction.java
@@ -197,7 +197,7 @@ public class OverloadedFunction extends Result<IValue> implements IExternalValue
 		Map<String, List<AbstractFunction>>[] constructors = new Map[10];
 		@SuppressWarnings("unchecked")
 		Map<IConstructor, List<AbstractFunction>>[] productions = new Map[10];
-		List<AbstractFunction> other = new LinkedList<AbstractFunction>();
+		List<AbstractFunction> other = new LinkedList<>();
 
 
 		for (AbstractFunction func : candidates) {
@@ -354,7 +354,7 @@ public class OverloadedFunction extends Result<IValue> implements IExternalValue
 	}
 
 	private static Type lub(List<AbstractFunction> candidates) {
-		Set<FunctionType> alternatives = new HashSet<FunctionType>();
+		Set<FunctionType> alternatives = new HashSet<>();
 		Iterator<AbstractFunction> iter = candidates.iterator();
 		if(!iter.hasNext()) {
 			return TF.voidType();
@@ -436,8 +436,8 @@ public class OverloadedFunction extends Result<IValue> implements IExternalValue
 		if (other == null) {
 			return this;
 		}
-		List<AbstractFunction> joined = new ArrayList<AbstractFunction>(other.primaryCandidates.size() + primaryCandidates.size());
-		List<AbstractFunction> defJoined = new ArrayList<AbstractFunction>(other.defaultCandidates.size() + defaultCandidates.size());
+		List<AbstractFunction> joined = new ArrayList<>(other.primaryCandidates.size() + primaryCandidates.size());
+		List<AbstractFunction> defJoined = new ArrayList<>(other.defaultCandidates.size() + defaultCandidates.size());
 
 		joined.addAll(primaryCandidates);
 		defJoined.addAll(defaultCandidates);
@@ -458,9 +458,9 @@ public class OverloadedFunction extends Result<IValue> implements IExternalValue
 	}
 
 	public OverloadedFunction add(AbstractFunction candidate) {
-		List<AbstractFunction> joined = new ArrayList<AbstractFunction>(primaryCandidates.size() + 1);
+		List<AbstractFunction> joined = new ArrayList<>(primaryCandidates.size() + 1);
 		joined.addAll(primaryCandidates);
-		List<AbstractFunction> defJoined = new ArrayList<AbstractFunction>(defaultCandidates.size() + 1);
+		List<AbstractFunction> defJoined = new ArrayList<>(defaultCandidates.size() + 1);
 		defJoined.addAll(defaultCandidates);
 
 		if (candidate.isDefault() && !defJoined.contains(candidate)) {
@@ -565,7 +565,7 @@ public class OverloadedFunction extends Result<IValue> implements IExternalValue
 	}
 
 	public List<AbstractFunction> getFunctions(){
-		List<AbstractFunction> result = new LinkedList<AbstractFunction>();
+		List<AbstractFunction> result = new LinkedList<>();
 		for (AbstractFunction f : primaryCandidates) {
 			result.add(f);
 		}
@@ -578,7 +578,7 @@ public class OverloadedFunction extends Result<IValue> implements IExternalValue
 	}
 
 	public List<AbstractFunction> getTests() {
-		List<AbstractFunction> result = new LinkedList<AbstractFunction>();
+		List<AbstractFunction> result = new LinkedList<>();
 		for (AbstractFunction f : getFunctions()) {
 			if (f.isTest()) {
 				result.add(f);

--- a/src/org/rascalmpl/interpreter/types/FunctionType.java
+++ b/src/org/rascalmpl/interpreter/types/FunctionType.java
@@ -273,7 +273,7 @@ public class FunctionType extends RascalType {
 	    // because the argument types are co-variant. This would be weird since
 	    // instantiated functions are supposed to be substitutable for their generic
 	    // counter parts. So, we try to instantiate first, and then check again.
-	    Map<Type,Type> bindings = new HashMap<Type,Type>();
+	    Map<Type,Type> bindings = new HashMap<>();
 
 	    if (!otherType.match(this, bindings)) {
 	      return false;
@@ -456,7 +456,7 @@ public class FunctionType extends RascalType {
 		if (right.isBottom()) {
 			return right;
 		}
-		Set<FunctionType> newAlternatives = new HashSet<FunctionType>();
+		Set<FunctionType> newAlternatives = new HashSet<>();
 		
 		if(right instanceof FunctionType) {
 			if(TF.tupleType(((FunctionType) right).returnType).isSubtypeOf(this.argumentTypes)) {

--- a/src/org/rascalmpl/interpreter/types/OverloadedFunctionType.java
+++ b/src/org/rascalmpl/interpreter/types/OverloadedFunctionType.java
@@ -252,7 +252,7 @@ public class OverloadedFunctionType extends RascalType {
 	  
 	  OverloadedFunctionType of = (OverloadedFunctionType) type;
 
-	  Set<FunctionType> newAlternatives = new HashSet<FunctionType>();
+	  Set<FunctionType> newAlternatives = new HashSet<>();
 	  
 	  for(FunctionType f : getAlternatives()) {
 		  for(FunctionType g : of.getAlternatives()) {
@@ -272,7 +272,7 @@ public class OverloadedFunctionType extends RascalType {
 	protected Type lubWithFunction(RascalType type) {
 	  FunctionType f = (FunctionType) type;
 
-	  Set<FunctionType> newAlternatives = new HashSet<FunctionType>();
+	  Set<FunctionType> newAlternatives = new HashSet<>();
 	  newAlternatives.add(f);
 	  
 	  return this.lubWithOverloadedFunction((RascalType)RTF.overloadedFunctionType(newAlternatives));
@@ -286,7 +286,7 @@ public class OverloadedFunctionType extends RascalType {
 		  
 	  OverloadedFunctionType of = (OverloadedFunctionType) type;
 		  
-	  Set<FunctionType> newAlternatives = new HashSet<FunctionType>();
+	  Set<FunctionType> newAlternatives = new HashSet<>();
 	  
 	  if(getReturnType() == of.getReturnType()) {
 	    newAlternatives.addAll(getAlternatives());
@@ -311,7 +311,7 @@ public class OverloadedFunctionType extends RascalType {
 	protected Type glbWithFunction(RascalType type) {
 	  FunctionType f = (FunctionType) type;
 
-	  Set<FunctionType> newAlternatives = new HashSet<FunctionType>();
+	  Set<FunctionType> newAlternatives = new HashSet<>();
 	  newAlternatives.add(f);
 		  
 	  return this.glbWithOverloadedFunction((RascalType)RTF.overloadedFunctionType(newAlternatives));
@@ -362,7 +362,7 @@ public class OverloadedFunctionType extends RascalType {
 		if (right.isBottom()) {
 			return right;
 		}
-		Set<FunctionType> newAlternatives = new HashSet<FunctionType>();
+		Set<FunctionType> newAlternatives = new HashSet<>();
 		if(right instanceof FunctionType) {
 			for(FunctionType ftype : this.alternatives) {
 				if(TF.tupleType(((FunctionType) right).getReturnType()).isSubtypeOf(ftype.getArgumentTypes())) {


### PR DESCRIPTION
Using the diamond operator instead of specifying the type parameters in the RHS of assignments.

This simple transformation was built using Rascal-MPL. It is one of the transformations we implemented to evolve Java legacy systems towards the use of new constructs of the language. More details in our repository:

https://github.com/refactoring-towards-language-evolution/rascal-Java8

It seems that worked with the build command "mvn -Drascal.boot=--validating -B clean test"