### PR TITLE
Optimized composition/diff for M3 models

### DIFF
--- a/src/org/rascalmpl/library/analysis/m3/Core.rsc
+++ b/src/org/rascalmpl/library/analysis/m3/Core.rsc
@@ -35,6 +35,7 @@ import util::FileSystem;
 import analysis::graphs::Graph;
 import Node;
 import Map;
+import List;
 extend analysis::m3::TypeSymbol;
  
 data Modifier;
@@ -104,10 +105,25 @@ M3 composeM3(loc id, set[M3] models) {
 
 @doc{
 	Generic function to apply a difference over the annotations of a list of M3s.
-	The substraction is applied according to the order of the models in the list.
 }
 @memo
-M3 diffM3(loc id, list[M3] models) = modifyM3(id, models, diff);
+M3 diffM3(loc id, list[M3] models) {
+	assert size(models) >= 2;
+
+	M3 first = models[0];
+	M3 others = composeM3(id, toSet(models[1..]));
+	M3 diff = m3(id);
+
+	diff.declarations = {<a, b> | <a, b> <- first.declarations, <a, b> notin others.declarations};
+	diff.types = {<a, b> | <a, b> <- first.types, <a, b> notin others.types};
+	diff.uses = {<a, b> | <a, b> <- first.uses, <a, b> notin others.uses};
+	diff.containment = {<a, b> | <a, b> <- first.containment, <a, b> notin others.containment};
+	diff.names = {<a, b> | <a, b> <- first.names, <a, b> notin others.names};
+	diff.documentation = {<a, b> | <a, b> <- first.documentation, <a, b> notin others.documentation};
+	diff.modifiers = {<a, b> | <a, b> <- first.modifiers, <a, b> notin others.modifiers};
+
+	return diff;
+}
 
 @memo
 M3 modifyM3(loc id, list[M3] models, value (&T,&T) fun) { 

--- a/src/org/rascalmpl/library/analysis/m3/Core.rsc
+++ b/src/org/rascalmpl/library/analysis/m3/Core.rsc
@@ -114,13 +114,13 @@ M3 diffM3(loc id, list[M3] models) {
 	M3 others = composeM3(id, toSet(models[1..]));
 	M3 diff = m3(id);
 
-	diff.declarations = {<a, b> | <a, b> <- first.declarations, <a, b> notin others.declarations};
-	diff.types = {<a, b> | <a, b> <- first.types, <a, b> notin others.types};
-	diff.uses = {<a, b> | <a, b> <- first.uses, <a, b> notin others.uses};
-	diff.containment = {<a, b> | <a, b> <- first.containment, <a, b> notin others.containment};
-	diff.names = {<a, b> | <a, b> <- first.names, <a, b> notin others.names};
-	diff.documentation = {<a, b> | <a, b> <- first.documentation, <a, b> notin others.documentation};
-	diff.modifiers = {<a, b> | <a, b> <- first.modifiers, <a, b> notin others.modifiers};
+	diff.declarations = first.declarations - others.declarations;
+	diff.types = first.types - others.types;
+	diff.uses = first.uses - others.uses;
+	diff.containment = first.containment - others.containment;
+	diff.names = first.names - others.names;
+	diff.documentation = first.documentation - others.documentation;
+	diff.modifiers = first.modifiers - others.modifiers;
 
 	return diff;
 }

--- a/src/org/rascalmpl/library/analysis/m3/Core.rsc
+++ b/src/org/rascalmpl/library/analysis/m3/Core.rsc
@@ -87,7 +87,20 @@ private value diff(value v1, value v2) { throw "can\'t differentiate non-collect
 	Generic function to compose the annotations of a set of M3s.
 }
 @memo
-M3 composeM3(loc id, set[M3] models) = modifyM3(id, toList(models), compose);
+M3 composeM3(loc id, set[M3] models) {
+	M3 comp = m3(id);
+
+	comp.declarations = {*model.declarations | model <- models};
+	comp.types = {*model.types | model <- models};
+	comp.uses = {*model.uses | model <- models};
+	comp.containment = {*model.containment | model <- models};
+	comp.messages = [*model.messages | model <- models];
+	comp.names = {*model.names | model <- models};
+	comp.documentation = {*model.documentation | model <- models};
+	comp.modifiers = {*model.modifiers | model <- models};
+
+	return comp;
+}
 
 @doc{
 	Generic function to apply a difference over the annotations of a list of M3s.

--- a/src/org/rascalmpl/library/lang/java/m3/Core.rsc
+++ b/src/org/rascalmpl/library/lang/java/m3/Core.rsc
@@ -42,15 +42,19 @@ data M3(
 data Language(str version="") = java();
 
 public M3 composeJavaM3(loc id, set[M3] models) {
-  m = composeM3(id, models);
-  m.extends = {*model.extends | model <- models};
-  m.implements = {*model.implements | model <- models};
-  m.methodInvocation = {*model.methodInvocation | model <- models};
-  m.fieldAccess = {*model.fieldAccess | model <- models};
-  m.typeDependency = {*model.typeDependency | model <- models};
-  m.methodOverrides = {*model.methodOverrides | model <- models};
-  m.annotations = {*model.annotations | model <- models};
-  return m;
+  // Compose the generic M3 relations first
+  M3 comp = composeM3(id, models);
+
+  // Then the Java-specific ones
+  comp.extends = {*model.extends | model <- models};
+  comp.implements = {*model.implements | model <- models};
+  comp.methodInvocation = {*model.methodInvocation | model <- models};
+  comp.fieldAccess = {*model.fieldAccess | model <- models};
+  comp.typeDependency = {*model.typeDependency | model <- models};
+  comp.methodOverrides = {*model.methodOverrides | model <- models};
+  comp.annotations = {*model.annotations | model <- models};
+
+  return comp;
 }
 
 public M3 diffJavaM3(loc id, list[M3] models) = diffM3(id, models);

--- a/src/org/rascalmpl/library/lang/java/m3/Core.rsc
+++ b/src/org/rascalmpl/library/lang/java/m3/Core.rsc
@@ -63,16 +63,16 @@ public M3 diffJavaM3(loc id, list[M3] models) {
 	M3 diff = diffM3(id, models);
 
 	M3 first = models[0];
-	M3 others = composeM3(id, toSet(models[1..]));
+	M3 others = composeJavaM3(id, toSet(models[1..]));
 
 	// Then the Java-specific ones
-	diff.extends = {<a, b> | <a, b> <- diff.extends, <a, b> notin others.extends};
-	diff.implements = {<a, b> | <a, b> <- diff.implements, <a, b> notin others.implements};
-	diff.methodInvocation = {<a, b> | <a, b> <- diff.methodInvocation, <a, b> notin others.methodInvocation};
-	diff.fieldAccess = {<a, b> | <a, b> <- diff.fieldAccess, <a, b> notin others.fieldAccess};
-	diff.typeDependency = {<a, b> | <a, b> <- diff.typeDependency, <a, b> notin others.typeDependency};
-	diff.methodOverrides = {<a, b> | <a, b> <- diff.methodOverrides, <a, b> notin others.methodOverrides};
-	diff.annotations = {<a, b> | <a, b> <- diff.annotations, <a, b> notin others.annotations};
+	diff.extends = {<a, b> | <a, b> <- first.extends, <a, b> notin others.extends};
+	diff.implements = {<a, b> | <a, b> <- first.implements, <a, b> notin others.implements};
+	diff.methodInvocation = {<a, b> | <a, b> <- first.methodInvocation, <a, b> notin others.methodInvocation};
+	diff.fieldAccess = {<a, b> | <a, b> <- first.fieldAccess, <a, b> notin others.fieldAccess};
+	diff.typeDependency = {<a, b> | <a, b> <- first.typeDependency, <a, b> notin others.typeDependency};
+	diff.methodOverrides = {<a, b> | <a, b> <- first.methodOverrides, <a, b> notin others.methodOverrides};
+	diff.annotations = {<a, b> | <a, b> <- first.annotations, <a, b> notin others.annotations};
 
 	return diff;
 }

--- a/src/org/rascalmpl/library/lang/java/m3/Core.rsc
+++ b/src/org/rascalmpl/library/lang/java/m3/Core.rsc
@@ -38,9 +38,9 @@ data M3(
 	rel[loc declaration, loc annotation] annotations = {}
 );
 
-
 data Language(str version="") = java();
 
+@memo
 public M3 composeJavaM3(loc id, set[M3] models) {
   // Compose the generic M3 relations first
   M3 comp = composeM3(id, models);
@@ -57,6 +57,7 @@ public M3 composeJavaM3(loc id, set[M3] models) {
   return comp;
 }
 
+@memo
 public M3 diffJavaM3(loc id, list[M3] models) {
 	// Diff the generic M3 relations first
 	M3 diff = diffM3(id, models);

--- a/src/org/rascalmpl/library/lang/java/m3/Core.rsc
+++ b/src/org/rascalmpl/library/lang/java/m3/Core.rsc
@@ -66,13 +66,13 @@ public M3 diffJavaM3(loc id, list[M3] models) {
 	M3 others = composeJavaM3(id, toSet(models[1..]));
 
 	// Then the Java-specific ones
-	diff.extends = {<a, b> | <a, b> <- first.extends, <a, b> notin others.extends};
-	diff.implements = {<a, b> | <a, b> <- first.implements, <a, b> notin others.implements};
-	diff.methodInvocation = {<a, b> | <a, b> <- first.methodInvocation, <a, b> notin others.methodInvocation};
-	diff.fieldAccess = {<a, b> | <a, b> <- first.fieldAccess, <a, b> notin others.fieldAccess};
-	diff.typeDependency = {<a, b> | <a, b> <- first.typeDependency, <a, b> notin others.typeDependency};
-	diff.methodOverrides = {<a, b> | <a, b> <- first.methodOverrides, <a, b> notin others.methodOverrides};
-	diff.annotations = {<a, b> | <a, b> <- first.annotations, <a, b> notin others.annotations};
+	diff.extends = first.extends - others.extends;
+	diff.implements = first.implements - others.implements;
+	diff.methodInvocation = first.methodInvocation - others.methodInvocation;
+	diff.fieldAccess = first.fieldAccess - others.fieldAccess;
+	diff.typeDependency = first.typeDependency - others.typeDependency;
+	diff.methodOverrides = first.methodOverrides - others.methodOverrides;
+	diff.annotations = first.annotations - others.annotations;
 
 	return diff;
 }

--- a/src/org/rascalmpl/library/lang/java/m3/Core.rsc
+++ b/src/org/rascalmpl/library/lang/java/m3/Core.rsc
@@ -57,7 +57,24 @@ public M3 composeJavaM3(loc id, set[M3] models) {
   return comp;
 }
 
-public M3 diffJavaM3(loc id, list[M3] models) = diffM3(id, models);
+public M3 diffJavaM3(loc id, list[M3] models) {
+	// Diff the generic M3 relations first
+	M3 diff = diffM3(id, models);
+
+	M3 first = models[0];
+	M3 others = composeM3(id, toSet(models[1..]));
+
+	// Then the Java-specific ones
+	diff.extends = {<a, b> | <a, b> <- diff.extends, <a, b> notin others.extends};
+	diff.implements = {<a, b> | <a, b> <- diff.implements, <a, b> notin others.implements};
+	diff.methodInvocation = {<a, b> | <a, b> <- diff.methodInvocation, <a, b> notin others.methodInvocation};
+	diff.fieldAccess = {<a, b> | <a, b> <- diff.fieldAccess, <a, b> notin others.fieldAccess};
+	diff.typeDependency = {<a, b> | <a, b> <- diff.typeDependency, <a, b> notin others.typeDependency};
+	diff.methodOverrides = {<a, b> | <a, b> <- diff.methodOverrides, <a, b> notin others.methodOverrides};
+	diff.annotations = {<a, b> | <a, b> <- diff.annotations, <a, b> notin others.annotations};
+
+	return diff;
+}
 
 public M3 link(M3 projectModel, set[M3] libraryModels) {
   projectModel.declarations = { <name[authority=projectModel.id.authority], src> | <name, src> <- projectModel.declarations };


### PR DESCRIPTION
`compose[Java]M3` and `diff[Java]M3` tend to become very slow on large M3 models.

This PR replaces the generic implementations of `compose[Java]M3` and `diff[Java]M3` with hard-coded composition functions that should be much faster.

On a project such as https://github.com/elastic/elasticsearch, the previous implementations take > 2 hours, the new ones < 10 seconds.

The generic `modifyM3` functions are still there.