### PR TITLE
Bump rascal-p2-dependencies-repackaged to the latest 0.5.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
 		<dependency>
 			<groupId>org.rascalmpl</groupId>
 			<artifactId>rascal-p2-dependencies-repackaged</artifactId>
-			<version>0.4.0</version>
+			<version>0.5.0</version>
 		</dependency>
 
 		<!-- Regular POM Dependencies -->


### PR DESCRIPTION
`BasicM3Tests` runs fine with the latest JDT pulled from the `0.5.0` release. We could merge.

cf. https://github.com/usethesource/rascal-p2-dependencies-repackaged/pull/2