### PR TITLE
Added optional support to the ast generator

### DIFF
--- a/src/org/rascalmpl/ast/AbstractAST.java
+++ b/src/org/rascalmpl/ast/AbstractAST.java
@@ -69,6 +69,9 @@ public abstract class AbstractAST implements IVisitable, Cloneable {
 	 * Used in generated clone methods to avoid case distinctions in the code generator
 	 */
 	protected <T extends AbstractAST> T clone(T in) {
+	    if (in == null) {
+	        return null;
+	    }
 		return (T) in.clone();
 	}
 	

--- a/src/org/rascalmpl/library/lang/rascal/grammar/SyntaxTreeGenerator.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/grammar/SyntaxTreeGenerator.rsc
@@ -327,7 +327,7 @@ list[Arg] productionArgs(str pkg, Production p) {
        
      }
      if (a.isOptional) {
-        a.typ = "@org.checkerframework.checker.nullness.qual.Nullable <a.typ>";
+        a.typ = replaceAll(a.typ, "<pkg>.", "<pkg>.@org.checkerframework.checker.nullness.qual.Nullable ");
      }
      append a;   
    }

--- a/src/org/rascalmpl/library/lang/rascal/grammar/SyntaxTreeGenerator.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/grammar/SyntaxTreeGenerator.rsc
@@ -301,7 +301,7 @@ list[Arg] productionArgs(str pkg, Production p) {
      a = arg("", name);
      if (\opt(Symbol ss) := sym) {
         a.isOptional = true;
-        sym := ss;
+        sym = ss;
      }
      switch (sym) {
        case \sort(str s): a.typ = "<pkg>.<s>"; 

--- a/src/org/rascalmpl/parser/ASTBuilder.java
+++ b/src/org/rascalmpl/parser/ASTBuilder.java
@@ -153,6 +153,15 @@ public class ASTBuilder {
 			}
 			return buildLexicalNode((org.rascalmpl.values.uptr.ITree) ((IList) ((org.rascalmpl.values.uptr.ITree) arg).get("args")).get(0));
 		}
+		
+		if (TreeAdapter.isOpt(tree)) {
+			IList args = TreeAdapter.getArgs(tree);
+			if (args.isEmpty()) {
+			    return null;
+			}
+			return buildValue(args.get(0));
+		    
+		}
 
 		if (sortName(tree).equals("Pattern")) {
 			if (isNewEmbedding(tree)) {


### PR DESCRIPTION
I'm using the AST generator for the Typhon project, and I wanted to extend it in two ways:

1. Make the license header configurable (sorry I swoop this under the same PR 😉  )
2. Add support for optional arguments in a production.

As test I ran the bootstrap generator on the rascal grammar, and the exact same java code still comes out.

I've added optionals in the following style:
- An optional is a nullable field (Should we generate `@Nullable`?)
- all internal code is changed so that in the case of a nullable fields, we call code that is safe around null values
- The getter changes to an `Optional<T>`, to avoid null pointer errors on the user side. Note that the costs of the `ofNullable` are negligible, since the jitter often optimized the heap allocation away. 

The reason for not doing `Optional` fields is that there is quite some overhead in constructing them all the time when for most cases you don't need them.