### PR TITLE
Extend the memo feature with optional parameters for expiring entries

### DIFF
--- a/src/org/rascalmpl/interpreter/result/JavaMethod.java
+++ b/src/org/rascalmpl/interpreter/result/JavaMethod.java
@@ -164,7 +164,7 @@ public class JavaMethod extends NamedFunction {
 			Type resultType = getReturnType().instantiate(env.getTypeBindings());
 			
 			resultValue = ResultFactory.makeResult(resultType, result, eval);
-			storeMemoizedResult(actuals, keyArgValues, resultValue);
+			resultValue = storeMemoizedResult(actuals, keyArgValues, resultValue);
 			printEndTrace(resultValue.value);
 			return resultValue;
 		}

--- a/src/org/rascalmpl/interpreter/result/NamedFunction.java
+++ b/src/org/rascalmpl/interpreter/result/NamedFunction.java
@@ -142,7 +142,7 @@ abstract public class NamedFunction extends AbstractFunction {
 
     protected Result<IValue> storeMemoizedResult(IValue[] argValues, Map<String, IValue> keyArgValues, Result<IValue> result) {
         if (hasMemoization()) {
-            getMemoizationCache(true).store(argValues, keyArgValues, result);
+            return getMemoizationCache(true).store(argValues, keyArgValues, result);
         }
         return result;
     }
@@ -154,7 +154,7 @@ abstract public class NamedFunction extends AbstractFunction {
         Result<IValue> result = getMemoizedResult(argValues, keyArgValues);
         if (result == null) {
             result = super.call(argTypes, argValues, keyArgValues);
-            storeMemoizedResult(argValues, keyArgValues, result);
+            return storeMemoizedResult(argValues, keyArgValues, result);
         }
         return result;
     }

--- a/src/org/rascalmpl/interpreter/result/RascalFunction.java
+++ b/src/org/rascalmpl/interpreter/result/RascalFunction.java
@@ -295,7 +295,7 @@ public class RascalFunction extends NamedFunction {
           bindKeywordArgs(keyArgValues);
           
           result = runBody();
-          storeMemoizedResult(actuals,keyArgValues, result);
+          result = storeMemoizedResult(actuals,keyArgValues, result);
           if (callTracing) {
         	  printEndTrace(result.getValue());
           }

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -55,6 +55,7 @@ import java.util.LinkedList;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.Set;
@@ -3774,6 +3775,14 @@ public class Prelude {
 
 	        return d0 < d1 ? -1 : ((d0 == d1) ? 0 : 1);
 	    }
+	}
+	
+	public void sleep(IInteger seconds) {
+	    try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(seconds.longValue()));
+        }
+        catch (InterruptedException e) {
+        }
 	}
 
 }

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -3779,7 +3779,7 @@ public class Prelude {
 	
 	public void sleep(IInteger seconds) {
 	    try {
-            Thread.sleep(TimeUnit.SECONDS.toMillis(seconds.longValue()));
+            TimeUnit.SECONDS.sleep(seconds.longValue());
         }
         catch (InterruptedException e) {
         }

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Memoization.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Memoization.rsc
@@ -3,6 +3,7 @@ This module test the memoization feature
 }
 module lang::rascal::tests::basic::Memoization
 
+import util::Memo;
 import Set;
 
 // over the test we can have duplicate random values, so prefix the test run 
@@ -14,6 +15,7 @@ private int callCount;
 private void call(value _) {
 	callCount += 1;
 }
+
 
 test bool memoCalledCorrectly(set[value] x) {
 	callCount = 0;
@@ -33,4 +35,42 @@ test bool memoCalledCorrectly2(set[value] x) {
 	}
 	testCount += 1;
 	return callCount == size(x);
+}
+
+test bool memoExpire() {
+    int callCount2 = 0;
+
+    @memo=maximumSize(10)
+    int call2(int i) {
+        callCount2 += 1;
+        return callCount2;
+    }
+
+    for (i <- [0..5]) {
+        call2(i);
+    }
+    
+    for (i <- [0..5]) {
+        if (call2(i) != i + 1) {
+            return false;
+        }
+    }
+
+    for (i <- [10..10000]) {
+        // this should take long as to at least hit the cache limit cleanup
+        call2(i);
+    }
+
+    @javaClass{org.rascalmpl.library.Prelude}
+    java void sleep(int seconds);
+    
+    sleep(6);
+
+    for (i <- [0..5]) {
+        if (call2(i) == i + 1) {
+            // should be dropped from cache by now
+            return false;
+        }
+    }
+    return true;
 }

--- a/src/org/rascalmpl/library/util/Memo.rsc
+++ b/src/org/rascalmpl/library/util/Memo.rsc
@@ -1,0 +1,12 @@
+module util::Memo
+
+data MemoExpireConfiguration
+    = expireAfter( // expires entries when <x> times has passed since last access
+            // define only one of these limits
+            int seconds = -1,
+            int minutes = -1,
+            int hours = -1
+        )
+   | maximumSize(int entries) // expires entries when the cache get's fuller than a certain size
+   ;
+        

--- a/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
+++ b/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
@@ -213,8 +213,11 @@ public class ExpiringFunctionResultCache<TResult> {
         private final IValue[] params;
         private final Map<String, IValue> keyArgs;
 
-        public KeyTuple(IValue[] params, Map<String, IValue> keyArgs, boolean copy) {
-            this.storedHash =  (1 + (31 * Arrays.hashCode(params))) + keyArgs.hashCode();
+        public KeyTuple(IValue[] params, @Nullable Map<String, IValue> keyArgs, boolean copy) {
+            if (keyArgs == null) {
+                keyArgs = Collections.emptyMap();
+            }
+            this.storedHash =  (1 + (31 * Arrays.hashCode(params))) +  keyArgs.hashCode();
             if (copy) {
                 this.params = new IValue[params.length];
                 System.arraycopy(params, 0, this.params, 0, params.length);

--- a/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
+++ b/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
@@ -1,0 +1,397 @@
+/** 
+ * Copyright (c) 2020, Davy Landman, swat.engineering 
+ * All rights reserved. 
+ *  
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+ *  
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+ *  
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+ *  
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */ 
+package org.rascalmpl.util;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import org.checkerframework.checker.initialization.qual.UnknownInitialization;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import io.usethesource.vallang.IValue;
+
+/**
+ * Cache of Rascal function results. <br/>
+ * <br/>
+ * Can be configured in multiple expiring strategies, but will always use SoftReferences to avoid OOM. <br/>
+ * <br/>
+ * This class is safe to use from multiple threads, use the result of
+ * {@link ExpiringFunctionResultCache#store(IValue[], Map, Object)} if you want to make sure you all agree on the same
+ * result.
+ * 
+ * @param <TResult> the type of values stored as result
+ */
+public class ExpiringFunctionResultCache<TResult> {
+    /**
+     * Entries are inserted by the interpreter/compiler but cleared by the cleanup thread <br/>
+     * <br/>
+     * The keys in this map are bit special, we use a different class for lookup and for storing. 
+     * This is primarily to avoid allocation SoftReferences and a fresh map purely for lookup.
+     */
+    private final ConcurrentMap<Object, LastUsedTracker<TResult>> entries;
+
+    /**
+     * A queue of all the SoftReferences cleared, we later iterate through them to cleanup the entries in the map
+     */
+    @SuppressWarnings("rawtypes")
+	private final ReferenceQueue cleared;
+
+    /**
+     * Threshold for when to expire entries by time
+     */
+    private int secondsTimeout;
+
+    /**
+     * Cache of the oldest entry in the map, to avoid unneeded iterating of the entry map
+     */
+    private volatile int lastOldest = 0;
+    
+    /**
+     * Threshold for maximum entries in the cache
+     */
+    private int maxEntries;
+    
+
+    /**
+     * Construct a cache of function results that expire after (optional) certain thresholds
+     * @param secondsTimeout clear entries that haven't been used for this amount of seconds, <= 0 disables this expiration behavoir
+     * @param maxEntries starts clearing out entries after the table gets "full". <= 0 disables this threshold
+     */
+    @SuppressWarnings("rawtypes")
+	public ExpiringFunctionResultCache(int secondsTimeout, int maxEntries) {
+        this.entries =  new ConcurrentHashMap<>();
+	    this.cleared =  new ReferenceQueue();
+	    this.secondsTimeout = secondsTimeout <= 0 ? Integer.MAX_VALUE : secondsTimeout;
+        this.maxEntries = maxEntries <= 0 ? Integer.MAX_VALUE : maxEntries;
+        Cleanup.Instance.register(this);
+    }
+    
+	/**
+	 * Get cached function result
+	 * @param args positional arguments
+	 * @param kwParameters (nullable) keyword arguments
+	 * @return either cached result or null in case of no entry
+	 */
+    public @Nullable TResult lookup(IValue[] args, @Nullable Map<String, IValue> kwParameters) {
+        LastUsedTracker<TResult> result = entries.get(new LookupKey(args, kwParameters));
+        if (result != null) {
+            return result.use();
+        }
+        return null;
+    }
+    
+    /**
+     * Store result of the function call in the map
+     * @param args
+     * @param kwParameters
+     * @param result
+     * @return
+     */
+    public TResult store(IValue[] args, @Nullable Map<String, IValue> kwParameters, TResult result) {
+        final CacheKey key = new CacheKey(args, kwParameters, cleared);
+        final LastUsedTracker<TResult> value = new LastUsedTracker<>(result, key, cleared);
+        while (true) {
+            // we "race" to insert our mapping
+            LastUsedTracker<TResult> stored = entries.putIfAbsent(key, value);
+            if (stored == null) {
+                // new entry, so we won the race
+                return result;
+            }
+            TResult otherResult = stored.use();
+            if (otherResult != null) {
+                // we officially lost the race
+                // other entry still had a valid value, so we return that instead
+                return otherResult;
+            }
+            // the entry has been cleared, so we need to remove it and try the race again
+            entries.remove(stored.key, stored);
+        }
+    }
+    
+    /**
+     * Clear entries and try to help GC with cleaning up memory
+     */
+    public void clear() {
+        // note, we do not clear the key references, since the map is used in a concurrent setting, 
+        // and we have to wait for the GC to cleanup to be sure there aren't equals happing on another thread
+        entries.values().forEach(LastUsedTracker::clear);
+	    entries.clear();
+    }
+
+    /**
+     * Internal method only, used by cleanup thread
+     */
+    private void cleanup() {
+        removePartiallyClearedEntries();
+        removeExpiredEntries();
+        removeOverflowingEntires();
+    }
+
+    private void removePartiallyClearedEntries() {
+        Map<CacheKey, Object> toCleanup = new IdentityHashMap<>(); // we can have GC cleared multiple soft references in the same CacheKey, but we don't want reference equality!
+		synchronized (cleared) {
+			Reference<?> gced = null;
+			do {
+				gced = cleared.poll();
+				if (gced != null && gced instanceof LastUsedTracker<?>) {
+					toCleanup.put(((LastUsedTracker<?>)gced).key, gced);
+				}
+			}
+			while (gced != null);
+		}
+
+		for (CacheKey ck : toCleanup.keySet()) {
+			entries.remove(ck);
+		}
+    }
+
+
+    private void removeExpiredEntries() {
+		int currentTick = SecondsTicker.current();
+        int oldestTick = currentTick - secondsTimeout;
+        // to avoid iterating over all the values everytime, we keep around the oldest use we saw the last time we iterated
+		if (lastOldest < oldestTick) {
+		    // there might be an expired entry (or it could have been cleared)
+		    int newOldest = currentTick; // we calculate the oldest entry that is kept in the cache
+		    Iterator<LastUsedTracker<TResult>> it = entries.values().iterator();
+		    while (it.hasNext()) {
+		        LastUsedTracker<TResult> cur = it.next();
+		        int lastUsed = cur.lastUsed;
+
+		        if (lastUsed < oldestTick) {
+		            it.remove();
+		        }
+		        else if (lastUsed < newOldest) {
+		            newOldest = lastUsed;
+		        }
+		    }
+		    lastOldest = newOldest;
+		}
+    }
+
+    private void removeOverflowingEntires() {
+        int toRemove = entries.size() - maxEntries;
+		if (toRemove > 0) {
+		    // we have to clear some entries, since we don't keep a sorted tree based on the usage
+		    // we'll just randomly clear
+		    Iterator<Entry<Object, LastUsedTracker<TResult>>> it = entries.entrySet().iterator();
+		    while (toRemove > 0 && it.hasNext()) {
+		        it.next();
+		        it.remove();
+		        toRemove--;
+		    }
+		}
+        
+    }
+
+
+    /**
+     * Class used to store the tuple of positional and keyword arguments
+     * 
+     * Take care to not clear the SoftReferences, as it might partially used on a differen thread.
+     */
+	private static class CacheKey {
+		private final int storedHash;
+		@SuppressWarnings("rawtypes")
+		private final LastUsedTracker[] params;
+		private final @Nullable Map<String, LastUsedTracker<IValue>> keyArgs;
+		
+		public CacheKey(IValue[] params, @Nullable Map<String, IValue> keyArgs, @SuppressWarnings("rawtypes") ReferenceQueue queue) {
+			this.storedHash = calculateHash(params, keyArgs);
+			
+			this.params = new LastUsedTracker[params.length];
+			for (int i = 0; i < params.length; i++) {
+				this.params[i] = new LastUsedTracker<>(params[i], this, queue);
+			}
+			
+			if (keyArgs != null) {
+				this.keyArgs = new HashMap<>(keyArgs.size());
+				for (Entry<String, IValue> e : keyArgs.entrySet()) {
+					this.keyArgs.put(e.getKey(), new LastUsedTracker<>(e.getValue(), this, queue));
+				}
+			}
+			else {
+			    this.keyArgs = null;
+			}
+		}
+
+        @Override
+		public int hashCode() {
+			return storedHash;
+		}
+		
+        @SuppressWarnings("unlikely-arg-type")
+        @Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj instanceof LookupKey) {
+				return ((LookupKey)obj).equals(this);
+			}
+			return false;
+		}
+	}
+
+
+	// Special Version of the Key data
+	// need to make sure the lookup key references
+	// aren't released during lookup
+	// and avoid creating extra SoftReferences
+	private static class LookupKey {
+		private final int storedHash;
+		private final IValue[] params;
+		private final @Nullable Map<String, IValue> keyArgs;
+
+		public LookupKey(IValue[] params, @Nullable Map<String, IValue> keyArgs) {
+			this.storedHash = calculateHash(params, keyArgs);
+			this.params = params;
+			this.keyArgs = keyArgs;
+		}
+		
+		@Override
+		public int hashCode() {
+			return storedHash;
+		}
+		
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof CacheKey) {
+				CacheKey other = (CacheKey)obj;
+				if (other.storedHash != this.storedHash || other.params.length != this.params.length) {
+					return false;
+				}
+
+				for (int i = 0; i < params.length; i++) {
+					if (nullOrNotEquals(params[i], (IValue)other.params[i].get())) {
+						return false; 
+					}
+				}
+				
+				if (keyArgs != null && other.keyArgs != null) {
+					for (Entry<String, IValue> kv: keyArgs.entrySet()) {
+						if (nullOrNotEquals(kv.getValue(), other.keyArgs.get(kv.getKey()).get())) {
+							return false; 
+						}
+					}
+					return true;
+				}
+				// if they aren't both set, than they should both be empty
+				return keyArgs == null && other.keyArgs == null;
+			}
+			return false;
+		}
+
+        private static boolean nullOrNotEquals(IValue a, IValue b) {
+            return a == null || b == null || !a.isEqual(b);
+        }
+	}
+
+	private static final class LastUsedTracker<T> extends SoftReference<T> {
+        private volatile int lastUsed;
+		private final CacheKey key;
+
+        @SuppressWarnings({"unchecked", "initialization"})
+        public LastUsedTracker(T obj, @UnknownInitialization CacheKey key, @SuppressWarnings("rawtypes") ReferenceQueue queue) {
+            super(obj, queue);
+	        this.lastUsed = SecondsTicker.current();
+	        this.key = key;
+        } 
+        
+        public T use() {
+            lastUsed = SecondsTicker.current();
+            return get();
+        }
+        
+	}
+	private static int calculateHash(IValue[] params, Map<String, IValue> keyArgs) {
+	    if (keyArgs == null) {
+	        return Arrays.hashCode(params);
+	    }
+	    return (1 + (31 * Arrays.hashCode(params))) + keyArgs.hashCode();
+	}
+
+    /**
+     * Cleanup singleton that wraps {@linkplain CleanupThread}
+     */
+    private static enum Cleanup {
+        Instance;
+
+        private final CleanupThread thread;
+
+        private Cleanup() {
+            thread = new CleanupThread();
+            thread.start();
+        }
+
+        public void register(@UnknownInitialization ExpiringFunctionResultCache<?> cache) {
+            thread.register(cache);
+        }
+
+    }
+
+    private static class CleanupThread extends Thread {
+        private final ConcurrentLinkedQueue<WeakReference<ExpiringFunctionResultCache<?>>> caches = new ConcurrentLinkedQueue<>();
+        
+        public CleanupThread() {
+            super("Cleanup Thread for " + ExpiringFunctionResultCache.class.getName());
+            setDaemon(true);
+        }
+
+        @SuppressWarnings("initialization") // passed in reference might not be completly initialized
+        public void register(@UnknownInitialization ExpiringFunctionResultCache<?> cache) {
+            caches.add(new WeakReference<>(cache));
+        }
+        
+        @Override
+        public void run() {
+            while (true) {
+                try {
+                    TimeUnit.SECONDS.sleep(5);
+                } catch (InterruptedException e) {
+                    return;
+                }
+                try {
+                    Iterator<WeakReference<ExpiringFunctionResultCache<?>>> it = caches.iterator();
+                    while (it.hasNext()) {
+                        ExpiringFunctionResultCache<?> cur = it.next().get();
+                        if (cur == null) {
+                            it.remove();
+                        }
+                        else {
+                            cur.cleanup();
+                        }
+                    }
+                }
+                catch (Throwable e) {
+                    System.err.println("Cleanup thread failed with: " + e.getMessage());
+                    e.printStackTrace(System.err);
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
+++ b/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
@@ -193,6 +193,7 @@ public class ExpiringFunctionResultCache<TResult> {
 
     private void removeOverflowingEntires() {
         int toRemove = entries.size() - maxEntries;
+        toRemove += toRemove / 4; // always cleanout 25% more than needed
 		if (toRemove > 0) {
 		    // we have to clear some entries, since we don't keep a sorted tree based on the usage
 		    // we'll just randomly clear

--- a/src/org/rascalmpl/util/SecondsTicker.java
+++ b/src/org/rascalmpl/util/SecondsTicker.java
@@ -1,0 +1,52 @@
+/** 
+ * Copyright (c) 2020, Davy Landman, swat.engineering 
+ * All rights reserved. 
+ *  
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+ *  
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+ *  
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+ *  
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */ 
+package org.rascalmpl.util;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A monotonic ticker that fast to frequently access and is updated roughly once every second
+ */
+public class SecondsTicker {
+
+    private static volatile int tick = 0;
+    
+    static {
+
+        Thread t = new Thread(() -> {
+            try {
+                final long tickRate = TimeUnit.SECONDS.toNanos(1);
+                long nextTick = System.nanoTime() + tickRate;
+                while (true) {
+                    // sleep in "small" increments towards the next tick to avoid thread starvation skewing the ticks too much
+                    while (System.nanoTime() < nextTick) {
+                        TimeUnit.MILLISECONDS.sleep(100);
+                    }
+                    nextTick += tickRate;
+                    tick++; // safe enough, since we are the only thread writing to the field
+                }
+            }
+            catch (InterruptedException e) {
+                return;
+            }
+        });
+        t.setName("SecondsTicker");
+        t.setDaemon(true);
+        t.start();
+    }
+    
+    public static int current() {
+        return tick;
+    }
+
+}

--- a/src/org/rascalmpl/util/SecondsTicker.java
+++ b/src/org/rascalmpl/util/SecondsTicker.java
@@ -15,7 +15,9 @@ package org.rascalmpl.util;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A monotonic ticker that fast to frequently access and is updated roughly once every second
+ * A monotonic ticker that fast to frequently access and is updated roughly once every second<br/>
+ * <br/>
+ * For more reasons why we want a fast time field, see <a href="http://pzemtsov.github.io/2017/07/23/the-slow-currenttimemillis.html">this discussion</a>.
  */
 public class SecondsTicker {
 
@@ -45,6 +47,9 @@ public class SecondsTicker {
         t.start();
     }
     
+    /**
+     * Get a monotonic increasing integer that increments roughly every second
+     */
     public static int current() {
         return tick;
     }

--- a/test/org/rascalmpl/test/functionality/MemoizationTests.java
+++ b/test/org/rascalmpl/test/functionality/MemoizationTests.java
@@ -59,6 +59,18 @@ public class MemoizationTests extends TestFramework {
 	}
 
 	@Test
+	public void memoryIsReleasedCombination() throws InterruptedException {
+	    prepare("int n = 0;");
+	    prepareMore("import util::Memo;");
+		prepareMore("@memo={expireAfter(seconds=1),maximumSize(200)} int calc(int w) { n +=1; return n; }");
+		assertTrue("Memo works", runTestInSameEvaluator("( true | it && calc(i) == i + 1 | i <- [0..100])"));
+		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 2"));
+		prepareMore("for (i <- [0..100]) { calc(100 + i); }");
+		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
+		assertTrue("Entry should be cleared by now", runTestInSameEvaluator("calc(1) != 2"));
+	}
+
+	@Test
 	public void manyEntries() throws InterruptedException {
 		prepare("import String;");
 		prepareMore("@memo str dup(str s) = s + s;");

--- a/test/org/rascalmpl/test/functionality/MemoizationTests.java
+++ b/test/org/rascalmpl/test/functionality/MemoizationTests.java
@@ -36,7 +36,8 @@ public class MemoizationTests extends TestFramework {
 	@Test
 	public void memoryIsReleasedTimeout() throws InterruptedException {
 	    prepare("int n = 0;");
-		prepareMore("@memo{expire(seconds=1)} int calc(int w) { n +=1; return n; }");
+	    prepareMore("import util::Memo;");
+		prepareMore("@memo=expireAfter(seconds=1) int calc(int w) { n +=1; return n; }");
 		assertTrue("Memo works", runTestInSameEvaluator("( true | it && calc(1) == 1 | i <- [0..100])"));
 		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 1"));
 		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
@@ -46,7 +47,8 @@ public class MemoizationTests extends TestFramework {
 	@Test
 	public void memoryIsReleasedEntries() throws InterruptedException {
 	    prepare("int n = 0;");
-		prepareMore("@memo{expire(entries=100)} int calc(int w) { n +=1; return n; }");
+	    prepareMore("import util::Memo;");
+		prepareMore("@memo=maximumSize(100) int calc(int w) { n +=1; return n; }");
 		assertTrue("Just storing something in range", runTestInSameEvaluator("( true | it && calc(i) == i + 1 | i <- [0..100])"));
 		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 2"));
 		prepareMore("for (i <- [0..100]) { calc(100 + i); }");

--- a/test/org/rascalmpl/test/functionality/MemoizationTests.java
+++ b/test/org/rascalmpl/test/functionality/MemoizationTests.java
@@ -1,53 +1,53 @@
 package org.rascalmpl.test.functionality;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.rascalmpl.test.infrastructure.TestFramework;
 
 
 public class MemoizationTests extends TestFramework {
-	@Test
-	public void memoryIsReleased() throws InterruptedException {
-		prepare("@memo list[int] OneMB(int w) = [ w | i <- [0..(1024*1024/8)]];");
-		runTestInSameEvaluator("( true | it && OneMB(i)[0] == i | i <- [0..10])");
-		// Force an OoM
-		// use all memory to cause the memoization to cleanup
-	    try {
-	        final ArrayList<Object[]> allocations = new ArrayList<Object[]>();
-	        while(true)
-	            allocations.add( new Object[(int) Math.min(Integer.MAX_VALUE, Runtime.getRuntime().maxMemory())] );
-	    } catch( OutOfMemoryError e ) {
-	        // great!
-	    }
-		// actually hit the cache to cause a cleanup
-		runTestInSameEvaluator("OneMB(1)[0]==1");
-	}
 	
 	@Test
-	public void memoryIsReleased2() {
+	public void memoryIsReleased() throws InterruptedException {
 	    prepare("int n = 0;");
-		prepareMore("@memo list[int] OneMB(int w) { n += 1; return [ n | i <- [0..(1024*1024/8)]];}");
-		runTestInSameEvaluator("( true | it && OneMB(1)[0] == 1 | i <- [0..10])");
-		runTestInSameEvaluator("OneMB(1)[0]==1");
+		prepareMore("@memo list[int] OneMB(int w) { n += 1; return [ n | i <- [0..(1024*1024*3)]];}");
+		assertTrue("Let's fill up the memory a bit", runTestInSameEvaluator("( true | it && OneMB(i)[0] == i + 1 | i <- [0..5])"));
 		// Force an OoM
 		// use all memory to cause the memoization to cleanup
-	    try {
-	        final ArrayList<Object[]> allocations = new ArrayList<Object[]>();
-	        while(true)
-	            allocations.add( new Object[(int) Math.min(Integer.MAX_VALUE, Runtime.getRuntime().maxMemory())] );
-	    } catch( OutOfMemoryError e ) {
-	        // great!
-	    }
+		for (int i =0; i< 5; i++) {
+            try {
+                final ArrayList<Object[]> allocations = new ArrayList<Object[]>();
+                while(true)
+                    allocations.add( new Object[(int) Math.min(Integer.MAX_VALUE, Runtime.getRuntime().maxMemory())] );
+            } catch( OutOfMemoryError e ) {
+                // great!
+            }
+            System.gc();
+            Thread.sleep(10);
+		}
 		// actually hit the cache to cause a cleanup
-		runTestInSameEvaluator("OneMB(1)[0]==2");
+		assertTrue("Should be run again, since GC happened", runTestInSameEvaluator("OneMB(1)[0] != 2"));
+	}
+
+	@Test
+	public void memoryIsReleasedTimeout() throws InterruptedException {
+	    prepare("int n = 0;");
+		prepareMore("@memo{(\"expireSeconds\":1)} int calc(int w) { n +=1; return n; }");
+		assertTrue("Memo works", runTestInSameEvaluator("( true | it && calc(1) == 1 | i <- [0..100])"));
+		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 1"));
+		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
+		assertTrue("Entry should be cleared by now", runTestInSameEvaluator("calc(1) == 2"));
 	}
 
 	@Test
 	public void manyEntries() throws InterruptedException {
 		prepare("import String;");
 		prepareMore("@memo str dup(str s) = s + s;");
-		runTestInSameEvaluator("(true | it && dup(s) == s + s | i <- [0..30000], str s := stringChar(i))");   ;
+		assertTrue(runTestInSameEvaluator("(true | it && dup(s) == s + s | i <- [0..30000], str s := stringChar(i))"));  
 	}
 
 }

--- a/test/org/rascalmpl/test/functionality/MemoizationTests.java
+++ b/test/org/rascalmpl/test/functionality/MemoizationTests.java
@@ -36,11 +36,24 @@ public class MemoizationTests extends TestFramework {
 	@Test
 	public void memoryIsReleasedTimeout() throws InterruptedException {
 	    prepare("int n = 0;");
-		prepareMore("@memo{(\"expireSeconds\":1)} int calc(int w) { n +=1; return n; }");
+		prepareMore("@memo{expire(seconds=1)} int calc(int w) { n +=1; return n; }");
 		assertTrue("Memo works", runTestInSameEvaluator("( true | it && calc(1) == 1 | i <- [0..100])"));
 		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 1"));
 		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
 		assertTrue("Entry should be cleared by now", runTestInSameEvaluator("calc(1) == 2"));
+	}
+
+	@Test
+	public void memoryIsReleasedEntries() throws InterruptedException {
+	    prepare("int n = 0;");
+		prepareMore("@memo{expire(entries=100)} int calc(int w) { n +=1; return n; }");
+		assertTrue("Just storing something in range", runTestInSameEvaluator("( true | it && calc(i) == i + 1 | i <- [0..100])"));
+		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 2"));
+		prepareMore("for (i <- [0..100]) { calc(100 + i); }");
+		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
+		prepareMore("for (i <- [0..100]) { calc(i); }");
+		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
+		assertTrue("Memo should have been cleared", runTestInSameEvaluator("calc(1) != 2"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR does 2 things:

- Memo entries now expire after 1 hour of not being used
- you can configure the memo tag with function specific expire strategies.

```rascal
import util::Memo; // new module that you have to import to get these parameters

@memo=expireAfter(minutes=10) // expires entries after they haven't been used for 10 minutes
int calc(int y) = y * 2;

@memo=maximumSize(4000) // after the table is more than 4000 entries, we start clearing it to make room (in a random order)
int calc2(int y) = y * 3;

@memo={maximumSize(4000), expireAfter(minutes=10)} // can be combined
int calc3(int y) = y * 4;
```

The only other reason why memo caches are cleared is due to running out of memory.

Future improvements:

- Implement a more LRU like structure so that the `maximumSize` can also take into account usage of entries
- Currently retiring entries happens every 5 seconds, especially with the maximumSize, this can run quite a bit behind, but I have no real idea how to schedule this without causing quite a call overhead.


Since I know at  least @joukestoel and @rodinaarssen have talked about this at some point, will you take a look before I merge into master?
