### PR TITLE
Rewrote custom cache to use caffeine

### DIFF
--- a/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
+++ b/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
@@ -19,10 +19,8 @@ import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -135,7 +133,11 @@ public class ExpiringFunctionResultCache<TResult> {
     }
 
 
-
+    /**
+     * Main class that joins both the positional and keyword parameters
+     * 
+     * It has two modes, one for lookup, and one for storage, only for storage do we copy the array
+     */
     private static class Parameters {
         private final int storedHash;
         private final IValue[] params;
@@ -189,6 +191,9 @@ public class ExpiringFunctionResultCache<TResult> {
         }
     }
 
+    /** 
+     * Small SoftReference wrapper that adds equality, and supports comparing with the raw Parameters object so that both can be used in a get
+    */
     private static class ParametersRef extends SoftReference<Parameters> {
         private final int hashCode;
 

--- a/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
+++ b/src/org/rascalmpl/util/ExpiringFunctionResultCache.java
@@ -16,18 +16,18 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Scheduler;
 
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -47,41 +47,22 @@ import io.usethesource.vallang.util.SecondsTicker;
  * @param <TResult> the type of values stored as result
  */
 public class ExpiringFunctionResultCache<TResult> {
-    /**
-     * Entries are inserted by the interpreter/compiler but cleared by the cleanup thread <br/>
-     * <br/>
-     * The keys in this map are bit special, we use a different class for lookup and for storing. 
-     * This is primarily to avoid allocation SoftReferences and a fresh map purely for lookup.
-     */
-    private final ConcurrentMap<Object, ResultRef<TResult>> entries;
-    
-    private static final ThreadLocal<Parameters> KEY_CACHE = new ThreadLocal<Parameters>() {
-        @Override
-        protected Parameters initialValue() {
-            return new Parameters();
+
+    private final Cache<Parameters, TResult> hotEntries;
+    private final Cache<Object, TResult> coldEntries;
+    private final ReferenceQueue<Parameters> cleared;
+
+    private static Caffeine<Object, Object> configure(int secondsTimeout, int maxEntries) {
+        var result = Caffeine.newBuilder();
+        if (secondsTimeout > 0) {
+            result = result.ticker(ExpiringFunctionResultCache::simulateNanoTicks)
+                .expireAfterAccess(Duration.ofSeconds(secondsTimeout));
         }
-    };
-
-    /**
-     * A queue of all the SoftReferences cleared, we later iterate through them to cleanup the entries in the map
-     */
-    private final ReferenceQueue<Object> cleared;
-
-    /**
-     * Threshold for when to expire entries by time
-     */
-    private int secondsTimeout;
-
-    /**
-     * Cache of the oldest entry in the map, to avoid unneeded iterating of the entry map
-     */
-    private volatile int lastOldest = 0;
-    
-    /**
-     * Threshold for maximum entries in the cache
-     */
-    private int maxEntries;
-    
+        if (maxEntries > 0) {
+            result = result.maximumSize(maxEntries);
+        }
+        return result.scheduler(Scheduler.systemScheduler());
+    }
 
     /**
      * Construct a cache of function results that expire after (optional) certain thresholds
@@ -89,11 +70,19 @@ public class ExpiringFunctionResultCache<TResult> {
      * @param maxEntries starts clearing out entries after the table gets "full". <= 0 disables this threshold
      */
     public ExpiringFunctionResultCache(int secondsTimeout, int maxEntries) {
-        this.entries =  new ConcurrentHashMap<>();
-        this.cleared =  new ReferenceQueue<Object>();
-        this.secondsTimeout = secondsTimeout <= 0 ? Integer.MAX_VALUE : secondsTimeout;
-        this.maxEntries = maxEntries <= 0 ? Integer.MAX_VALUE : maxEntries;
+        hotEntries = configure(secondsTimeout > 0 ? Math.max(secondsTimeout / 10, 1) : 120, maxEntries > 0 ? Math.max(maxEntries / 10, 10) : 10_000)
+            .softValues()
+            .build();
+
+        coldEntries = configure(secondsTimeout, maxEntries)
+            .softValues()
+            .build();
+        this.cleared =  new ReferenceQueue<>();
         Cleanup.Instance.register(this);
+    }
+
+    private static long simulateNanoTicks() {
+        return TimeUnit.SECONDS.toNanos(SecondsTicker.current());
     }
     
     /**
@@ -103,17 +92,16 @@ public class ExpiringFunctionResultCache<TResult> {
      * @return either cached result or null in case of no entry
      */
     public @Nullable TResult lookup(IValue[] args, @Nullable Map<String, IValue> kwParameters) {
-        Parameters key = KEY_CACHE.get().fill(args, kwParameters);
-        try {
-            ResultRef<TResult> result = entries.get(key);
-            if (result != null) {
-                return result.use();
-            }
-            return null;
+        Parameters key = new Parameters(args, kwParameters);
+        var result = hotEntries.getIfPresent(key);
+        if (result != null) {
+            return result;
         }
-        finally  {
-            key.clear();
+        result = coldEntries.getIfPresent(key);
+        if (result != null) {
+            hotEntries.put(key, result); // promote it back to the hot entries
         }
+        return result;
     }
     
     /**
@@ -125,136 +113,55 @@ public class ExpiringFunctionResultCache<TResult> {
      */
     public TResult store(IValue[] args, @Nullable Map<String, IValue> kwParameters, TResult result) {
         final Parameters key = new Parameters(args, kwParameters);
-        final ParametersRef keyRef = new ParametersRef(key, cleared);
-        final ResultRef<TResult> value = new ResultRef<>(result, keyRef, cleared);
-        while (true) {
-            // we "race" to insert our mapping
-            ResultRef<TResult> stored = entries.putIfAbsent(keyRef, value);
-            if (stored == null) {
-                // new entry, so we won the race
-                return result;
-            }
-            TResult otherResult = stored.use();
-            if (otherResult != null) {
-                // we officially lost the race
-                // other entry still had a valid value, so we return that instead
-                return otherResult;
-            }
-            // the entry has been cleared, so we need to remove it and try the race again
-            entries.remove(stored.key, stored);
+
+        var stored = hotEntries.get(key, k -> result);
+        if (stored == result) {
+            // new entry so we won the race
+            // so we also update the cold storage
+            coldEntries.put(new ParametersRef(key, cleared), stored);
         }
+        return stored;
     }
     
     /**
      * Clear entries and try to help GC with cleaning up memory
      */
     public void clear() {
-        entries.clear();
+        hotEntries.invalidateAll();
+        coldEntries.invalidateAll();
     }
 
     /**
      * Internal method only, used by cleanup thread
      */
     private void cleanup() {
-        removePartiallyClearedEntries();
-        removeExpiredEntries();
-        removeOverflowingEntires();
-    }
-
-    private void removePartiallyClearedEntries() {
-        Map<ParametersRef, Object> toCleanup = new IdentityHashMap<>(); // we want reference equality, since it could be that both the key & the value are cleared in the same period
         synchronized (cleared) {
             Reference<?> gced;
             while ((gced = cleared.poll()) != null) {
                 if (gced instanceof ParametersRef) {
-                    toCleanup.putIfAbsent((ParametersRef) gced, gced);
-                }
-                else if (gced instanceof ResultRef) {
-                    toCleanup.putIfAbsent(((ResultRef<?>) gced).key, gced);
+                    coldEntries.invalidate(gced);
                 }
             }
         }
-
-        toCleanup.keySet().forEach(entries::remove);
     }
 
-
-    private void removeExpiredEntries() {
-        int currentTick = SecondsTicker.current();
-        int oldestTick = currentTick - secondsTimeout;
-        // to avoid iterating over all the values everytime, we keep around the oldest use we saw the last time we iterated
-        if (lastOldest < oldestTick) {
-            // there might be an expired entry (or it could have been cleared)
-            int newOldest = currentTick; // we calculate the oldest entry that is kept in the cache
-            Iterator<ResultRef<TResult>> it = entries.values().iterator();
-            while (it.hasNext()) {
-                ResultRef<TResult> cur = it.next();
-                int lastUsed = cur.lastUsed;
-
-                if (lastUsed < oldestTick) {
-                    it.remove();
-                }
-                else if (lastUsed < newOldest) {
-                    newOldest = lastUsed;
-                }
-            }
-            lastOldest = newOldest;
-        }
-    }
-
-    private void removeOverflowingEntires() {
-        int currentSize = entries.size();
-        if (currentSize >= maxEntries) {
-            long toRemove = (long)currentSize - (long)maxEntries; // use long to avoid integer overflow in max
-            toRemove += toRemove / 4; // always cleanout 25% more than needed
-            // we have to clear some entries, since we don't keep a sorted tree based on the usage
-            // we'll just randomly clear
-            Iterator<Entry<Object, ResultRef<TResult>>> it = entries.entrySet().iterator();
-            while (toRemove > 0 && it.hasNext()) {
-                it.next();
-                it.remove();
-                toRemove--;
-            }
-        }
-        
-    }
 
 
 
     private static class Parameters {
-        private int storedHash;
-        private IValue[] params;
-        private Map<String, IValue> keyArgs;
+        private final int storedHash;
+        private final IValue[] params;
+        private final Map<String, IValue> keyArgs;
 
         
-        public Parameters() {
-            
-        }
-        
-        public Parameters fill(IValue[] params, @Nullable Map<String, IValue> keyArgs) {
-            if (keyArgs == null) {
+        public Parameters(IValue[] params, @Nullable Map<String, IValue> keyArgs) {
+            if (keyArgs == null || keyArgs.isEmpty()) {
                 keyArgs = Collections.emptyMap();
             }
-            this.params = params;
+            this.params = new IValue[params.length];
+            System.arraycopy(params, 0, this.params, 0, params.length);
             this.keyArgs = keyArgs;
-            this.storedHash = (1 + (31 * Arrays.hashCode(params))) + keyArgs.hashCode();
-            return this;
-        }
-        
-        public void clear() {
-            params = null;
-            keyArgs = null;
-        }
-
-        public Parameters(IValue[] params, @Nullable Map<String, IValue> keyArgs) {
-            IValue[] newParams = new IValue[params.length];
-            System.arraycopy(params, 0, newParams, 0, params.length);
-            if (keyArgs == null || keyArgs.isEmpty()) {
-                fill(newParams, Collections.emptyMap());
-            }
-            else {
-                fill(newParams, new HashMap<>(keyArgs));
-            }
+            this.storedHash = (1 + (31 * Arrays.hashCode(this.params))) + keyArgs.hashCode();
         }
         
         @Override
@@ -285,7 +192,7 @@ public class ExpiringFunctionResultCache<TResult> {
     private static class ParametersRef extends SoftReference<Parameters> {
         private final int hashCode;
 
-        public ParametersRef(Parameters obj, ReferenceQueue<Object> queue) {
+        public ParametersRef(Parameters obj, ReferenceQueue<? super Parameters> queue) {
             super(obj, queue);
             this.hashCode = obj.storedHash;
         }
@@ -312,23 +219,6 @@ public class ExpiringFunctionResultCache<TResult> {
 
         
     }
-
-    private static class ResultRef<T> extends SoftReference<T> {
-        private volatile int lastUsed;
-        private final ParametersRef key;
-
-        public ResultRef(T obj, ParametersRef key, ReferenceQueue<Object> queue) {
-            super(obj, queue);
-            this.lastUsed = SecondsTicker.current();
-            this.key = key;
-        } 
-        
-        public T use() {
-            lastUsed = SecondsTicker.current();
-            return get();
-        }
-    }
-    
 
     /**
      * Cleanup singleton that wraps {@linkplain CleanupThread}

--- a/test/org/rascalmpl/test/functionality/MemoizationTests.java
+++ b/test/org/rascalmpl/test/functionality/MemoizationTests.java
@@ -45,7 +45,7 @@ public class MemoizationTests extends TestFramework {
 		prepareMore("@memo=expireAfter(seconds=1) int calc(int w) { n +=1; return n; }");
 		assertTrue("Memo works", runTestInSameEvaluator("( true | it && calc(1) == 1 | i <- [0..100])"));
 		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 1"));
-		TimeUnit.SECONDS.sleep(11); // note should be more than the frequency of the cleanup thread
+		TimeUnit.SECONDS.sleep(2); // note should be more than the frequency of the cleanup thread
 		assertTrue("Entry should be cleared by now", runTestInSameEvaluator("calc(1) == 2"));
 	}
 
@@ -56,11 +56,12 @@ public class MemoizationTests extends TestFramework {
 		prepareMore("@memo=maximumSize(100) int calc(int w) { n +=1; return n; }");
 		assertTrue("Just storing something in range", runTestInSameEvaluator("( true | it && calc(i) == i + 1 | i <- [0..100])"));
 		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 2"));
-		prepareMore("for (i <- [0..100]) { calc(100 + i); }");
-		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
-		prepareMore("for (i <- [0..100]) { calc(i); }");
-		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
-		assertTrue("Memo should have been cleared", runTestInSameEvaluator("calc(1) != 2"));
+		assertTrue("Memo works", runTestInSameEvaluator("calc(2) == 3"));
+		// now we run a lot more calcs, so that the memo of old cases might be cleared
+		prepareMore("for (i <- [0..200]) { calc(100 + i); }");
+		//TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
+		// note that since the Caffeine cache is smart, it might pin 1 and 2 longer, so we ask for another result that should have been cleared by now
+		assertTrue("Memo should have been cleared", runTestInSameEvaluator("calc(3) != 4"));
 	}
 
 	@Test
@@ -71,9 +72,9 @@ public class MemoizationTests extends TestFramework {
 		assertTrue("Memo works", runTestInSameEvaluator("( true | it && calc(i) == i + 1 | i <- [0..100])"));
 		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 2"));
 		prepareMore("for (i <- [0..100]) { calc(100 + i); }");
-		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
+		TimeUnit.SECONDS.sleep(2); // note should be more than the frequency of the cleanup thread
 		prepareMore("for (i <- [0..100]) { calc(200 + i); }");
-		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
+		TimeUnit.SECONDS.sleep(2); // note should be more than the frequency of the cleanup thread
 		assertTrue("Entry should be cleared by now", runTestInSameEvaluator("calc(1) != 2"));
 	}
 

--- a/test/org/rascalmpl/test/functionality/MemoizationTests.java
+++ b/test/org/rascalmpl/test/functionality/MemoizationTests.java
@@ -45,7 +45,7 @@ public class MemoizationTests extends TestFramework {
 		prepareMore("@memo=expireAfter(seconds=1) int calc(int w) { n +=1; return n; }");
 		assertTrue("Memo works", runTestInSameEvaluator("( true | it && calc(1) == 1 | i <- [0..100])"));
 		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 1"));
-		TimeUnit.SECONDS.sleep(2); // note should be more than the frequency of the cleanup thread
+		TimeUnit.SECONDS.sleep(2); 
 		assertTrue("Entry should be cleared by now", runTestInSameEvaluator("calc(1) == 2"));
 	}
 
@@ -58,8 +58,8 @@ public class MemoizationTests extends TestFramework {
 		assertTrue("Memo works", runTestInSameEvaluator("calc(1) == 2"));
 		assertTrue("Memo works", runTestInSameEvaluator("calc(2) == 3"));
 		// now we run a lot more calcs, so that the memo of old cases might be cleared
-		prepareMore("for (i <- [0..200]) { calc(100 + i); }");
-		//TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
+		prepareMore("for (i <- [0..300]) { calc(100 + i); }");
+		TimeUnit.SECONDS.sleep(6); // note should be more than the frequency of the cleanup thread
 		// note that since the Caffeine cache is smart, it might pin 1 and 2 longer, so we ask for another result that should have been cleared by now
 		assertTrue("Memo should have been cleared", runTestInSameEvaluator("calc(3) != 4"));
 	}


### PR DESCRIPTION
Since IValues now use `equals` correctly, we can use caffeine for the caching.

This would allow in the future to expose more of the caffeine eviction features.