### PR TITLE
Some minor documentation improvements, mainly in the 'Recipes' section.

### DIFF
--- a/src/org/rascalmpl/courses/Rascal/Statements/Assignment/Constructor/Constructor.concept
+++ b/src/org/rascalmpl/courses/Rascal/Statements/Assignment/Constructor/Constructor.concept
@@ -18,7 +18,7 @@ Assign to constructor.
 
 .Description
 First the value _Exp_ is determined and should be a data value of the form `_Name_(_V_~1~, _V_~2~, ..., _V_~n~). 
-Next the assignments `_Assignable_~i~ = _V_~i~` are performed for 1 <= i <= n.
+Next the assignments `_Assignable_~i~ = _V_~i~` are performed for 1 \<= i \<= n.
 
 .Examples
 [source,rascal-shell]

--- a/src/org/rascalmpl/courses/Recipes/Basic/Hello/Hello.concept
+++ b/src/org/rascalmpl/courses/Recipes/Basic/Hello/Hello.concept
@@ -60,6 +60,8 @@ The summit of hello-engineering can be reached by placing all the above in a sep
 include::{LibDir}demo/basic/Hello.rsc[tags=module]
 ----
 
+This module should be placed in <project dir>/src/demo/basic/Hello.rsc.
+
 Using this Hello module is now simple:
 
 [source,rascal-shell]

--- a/src/org/rascalmpl/courses/Recipes/Common/AdHocDataExploration/AdHocDataExploration.concept
+++ b/src/org/rascalmpl/courses/Recipes/Common/AdHocDataExploration/AdHocDataExploration.concept
@@ -23,9 +23,9 @@ calling `fact(1000)` at the command line.  Let's use this definition of factoria
 ----
 public int fact (int n) {
     if (n <= 1) {
-	return 1;
+	    return 1;
     } else {
-	return n * fact (n-1);
+	    return n * fact (n-1);
     }
 }
 ----
@@ -55,11 +55,11 @@ So let's define a few helper functions and see where that leads us:
 ----
 public int countZeros (int n) {
     if (n < 10) {
-	return 0;
+	    return 0;
     } else if (n % 10 == 0) {
         return 1 + countZeros (n / 10);
     } else {
-	return countZeros (n / 10);
+	    return countZeros (n / 10);
     }   
 }
 rascal> int i = fact(1000);
@@ -76,11 +76,11 @@ What did I do wrong?  Oh, right, _trailing_ zeros, and the above function counts
 ----
 public int countTrailingZeros (int n) {
     if (n < 10) {
-	return 0;
+	    return 0;
     } else if (n % 10 == 0) {
         return 1 + countTrailingZeros (n / 10);
     } else {
-	return 0 ;
+	    return 0 ;
     }   
 }
 
@@ -267,16 +267,16 @@ We can write this in Rascal as:
 public int predictZeros (int N) {
     int k = floorLogBase(N, 5);  // I wrote this
     int nz = 0;
-    for (int i <- [1..N+1] ){
-	int p5 = 1;
+    for (int i <- [1..N+1] ) {
+	    int p5 = 1;
         for (int j <- [1..k+1]) {
-    	    p5 *= 5;
+            p5 *= 5;
     	    if (i % p5 == 0) {
-		nz += 1;
-	    } else {
-    	    	break;
+		        nz += 1;
+	        } else {
+                break;
+	        }
 	    }
-	}
     }
     return nz; 
 }
@@ -294,17 +294,17 @@ public void verifyTheory (int N) {
     	int p = predictZeros(i);
     	int c = countTrailingZeros(ifact);
     	if (p != c) {
-	    failed = true;
-	    println ("Found a counter example at i=<i>");
-	    break;
+	        failed = true;
+	        println ("Found a counter example at i=<i>");
+	        break;
     	} else {
-	    if (i % checkInterval == 0) {
-		println ("<i>! has <p> trailing zeros");
+	        if (i % checkInterval == 0) {
+		        println ("<i>! has <p> trailing zeros");
+	        }
 	    }
-	}
     }
     if (!failed) {
-	println ("The theory works for i: 1..<N>");
+	    println ("The theory works for i: 1..<N>");
     }
 }
 
@@ -373,8 +373,8 @@ public int floorLogBase2 (int a, int b) {
     int remaining = a;
     int ans = 0;
     while (remaining >= b) {
-	ans += 1;
-	remaining /= b;
+	    ans += 1;
+	    remaining /= b;
     }
     return ans;		
 }

--- a/src/org/rascalmpl/courses/Recipes/Common/Derivative/Derivative.concept
+++ b/src/org/rascalmpl/courses/Recipes/Common/Derivative/Derivative.concept
@@ -38,7 +38,7 @@ include::{LibDir}demo/common/Derivative.rsc[tags=module]
 <4> Define simplification rules. 
 <5> A default rule is give for the case that no simplification applies.
 <6> Define the actual simplication function `simplify` that performs a bottom up traversal of the expression, application simplification
-rules on the the up.
+rules on the up.
 
                 
 Let's differentiate the example expression `E`:

--- a/src/org/rascalmpl/courses/Recipes/Common/WordCount/CountInLine2/CountInLine2.concept
+++ b/src/org/rascalmpl/courses/Recipes/Common/WordCount/CountInLine2/CountInLine2.concept
@@ -26,7 +26,7 @@ The pattern `/^\W*\w+<rest:.*$>/` can be understood as follows:
 *  The `^` makes it _anchored_, only matches at the begin of the substring `S`.
 *  `\W*` matches zero or more non-word characters.
 *  `\w+` matches one or more word characters.
-*  `<rest:.*$>` matches the remaining part of `S`.
+*  `<rest:.*$>` matches the remaining part of `S` and assigns the result to the variable `rest`.
 
 
 Inside the loop `count` is incremented and the new value of `S` becomes

--- a/src/org/rascalmpl/courses/Recipes/Common/WordCount/CountInLine2/CountInLine2.concept
+++ b/src/org/rascalmpl/courses/Recipes/Common/WordCount/CountInLine2/CountInLine2.concept
@@ -21,11 +21,11 @@ include::{LibDir}demo/common/WordCount/CountInLine2.rsc[tags=module]
 ----
 
                 
-The pattern `/^\W*<word:\w+><rest:.*$>/` can be understood as follows:
+The pattern `/^\W*\w+<rest:.*$>/` can be understood as follows:
 
 *  The `^` makes it _anchored_, only matches at the begin of the substring `S`.
 *  `\W*` matches zero or more non-word characters.
-*  `<word:\w+>` matches one or more word characters and assigns the result to the variable `word`.
+*  `\w+` matches one or more word characters.
 *  `<rest:.*$>` matches the remaining part of `S`.
 
 

--- a/src/org/rascalmpl/courses/Recipes/Common/WordCount/WordCount.concept
+++ b/src/org/rascalmpl/courses/Recipes/Common/WordCount/WordCount.concept
@@ -64,7 +64,9 @@ in the following alternative `wordCount2` function:
 int wordCount2(list[str] lines) = (0 | it + (0 | it + 1 | /\w+/ := line) | str line <- lines);
 wordCount2(Jabberwocky);
 ----
-Explain what is going on in this function.
+The function body contains two nested link:/Rascal#Expressions-Reducer[reducers].
+The inner reducer counts the number of words in a line, the outer reducer accumulates all line word counts.
+
 [source,rascal-shell,continue]
 ----
 ----

--- a/src/org/rascalmpl/courses/Recipes/Languages/Exp/Combined/Manual/Manual.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Exp/Combined/Manual/Manual.concept
@@ -42,8 +42,8 @@ Some comments:
 <3> Import the `Parse` module defined above.
 <4> The top level `load` function that converts a string to an abstract syntax tree.
 <5> The conversion from parse tree to abstract syntax tree start here. Note that we
-    explicitly use `demo::lang::Exp::Concrete::WithLayout::Syntax::Exp` in these
-    rules to distinguish from `demo::lang::Exp::Abstract::Syntax::Exp`.
+    explicitly use `demo::lang::Exp::Abstract::Syntax::Exp` in these
+    rules to distinguish from `demo::lang::Exp::Concrete::WithLayout::Syntax::Exp`.
 
 
 Let's try it:

--- a/src/org/rascalmpl/courses/Recipes/Languages/Exp/Concrete/WithLayout/WithLayout.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Exp/Concrete/WithLayout/WithLayout.concept
@@ -28,7 +28,7 @@ The following example extends the grammar for `Exp` in <<No Layout>> with a layo
 include::{LibDir}demo/lang/Exp/Concrete/WithLayout/Syntax.rsc[tags=module]
 ----
 
-<1> Using the `layout` definition, we defcoine that the `Whitespace` non-terminal is used _in between every symbol_ of the `syntax` productions in the current module.
+<1> Using the `layout` definition, we define that the `Whitespace` non-terminal is used _in between every symbol_ of the `syntax` productions in the current module.
 
 And now we can use spaces in our definition of the eval function as well:
 [source,rascal]

--- a/src/org/rascalmpl/courses/Recipes/Languages/Func/AbstractSyntax/AbstractSyntax.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Func/AbstractSyntax/AbstractSyntax.concept
@@ -22,7 +22,7 @@ include::{LibDir}demo/lang/Func/AST.rsc[tags=module]
 ----
 
                 
-Observe that the abstract syntax follows the structur of the <<Func-ConcreteSyntax>> but
+Observe that the abstract syntax follows the structure of the <<Func-ConcreteSyntax>> but
 omits details such as operator priorities, parentheses, and the like.
 
 .Benefits

--- a/src/org/rascalmpl/courses/Recipes/Languages/Func/Eval1/Eval1.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Func/Eval1/Eval1.concept
@@ -1,6 +1,7 @@
 # Eval1
 
 .Synopsis
+Like Eval0 but with support for let-expressions.
 
 
 .Syntax

--- a/src/org/rascalmpl/courses/Recipes/Languages/Func/Eval2/Eval2.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Func/Eval2/Eval2.concept
@@ -1,6 +1,7 @@
 # Eval2
 
 .Synopsis
+Like Eval1 but with support for sequences and assignments.
 
 
 .Syntax

--- a/src/org/rascalmpl/courses/Recipes/Languages/Func/Eval3/Eval3.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Func/Eval3/Eval3.concept
@@ -1,7 +1,7 @@
 # Eval3
 
 .Synopsis
-
+A complete Func interpreter including support for the address and dereference operators.
 
 .Syntax
 

--- a/src/org/rascalmpl/courses/Recipes/Languages/Func/Func.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Func/Func.concept
@@ -20,7 +20,7 @@ Func is a functional language with the following features:
   **  an integer constant.
   **  a variable.
   **  arithmetic operators `+`, `-`, `*` and `/`.
-  **  comparison operators `<`, `<=`, `>` and `>=`.
+  **  comparison operators `<`, `\<=`, `>` and `>=`.
   **  a call of a function.
   **  an `if` expression.
   **  a sequence of expressions (`;`).

--- a/src/org/rascalmpl/courses/Recipes/Languages/Pico/Typecheck/Typecheck.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Pico/Typecheck/Typecheck.concept
@@ -1,7 +1,7 @@
 # Typecheck
 
 .Synopsis
-Typechecker a Pico program.
+Typechecker for Pico programs.
 
 .Syntax
 

--- a/src/org/rascalmpl/courses/Recipes/Languages/Pico/Uninit/Uninit.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Pico/Uninit/Uninit.concept
@@ -36,7 +36,7 @@ include::{LibDir}demo/lang/Pico/Uninit.rsc[tags=module]
     **  `reachX` determines the reachability in a graph while excluding certain nodes, see [Rascal:Graph/reachX]. Here
         `reachX(CFG.graph, CFG.entry, rangeR(D, {occ.item}))` determines the nodes in the graph that can be reached from the
          entry point of the program without passing a definition of the current variable.
-    **  `any(CFNode N <- reachX( ... ), N has location && occ.location <= N.location)` yields true if there is such a reachable node
+    **  `any(CFNode N <- reachX( ... ), N has location && occ.location \<= N.location)` yields true if there is such a reachable node
         that covers the location of the current variable.
 <4> The complete comprehension returns the set of occurrences of uninitialized variables.
 

--- a/src/org/rascalmpl/courses/Recipes/Languages/Pico/UseDef/UseDef.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Pico/UseDef/UseDef.concept
@@ -31,7 +31,7 @@ program entities with their location.
 <1> The function `usesExp` computes a set of occurrences (uses) of Pico identifiers in a given statement:
     ** If the expression is itself an identifier, then a singleton set containing that identifier and the statement is returned.
     ** If the expression is composite, all its containing identifiers are collected using a descendant (deep) match 
-       (`/`, see [Rascal:Descendant]))  in `/u:id(PicoId Id) <- e`. 
+       (`/`, see [Rascal:Descendant]))  in `/u:id(PicoId Id) \<- e`. 
         Note that we use a labeled pattern `u:id(PicoId Id)`,
        so that we can access the whole expression that was matched and retrieve its 
        location information (`u@location`) when we are adding a <location, identifier> pair to the set of occurrences.
@@ -43,8 +43,8 @@ program entities with their location.
 <4> The function `defs`  has a Pico program as argument and returns a set of occurrences (definitions) of Pico identifiers.
     The definition consists of a single set comprehension that consists of the following parts:
 
-    **  ` ... <- P. stats` enumerates all statements in the program.
-    **  `/asgStat(PicoId Id, EXP Exp) <- P.stats` uses again a descendant match to find all assignment statements.
+    **  ` ... \<- P. stats` enumerates all statements in the program.
+    **  `/asgStat(PicoId Id, EXP Exp) \<- P.stats` uses again a descendant match to find all assignment statements.
     **  For each assignment statement a (location, identifier) pair is added to the result.
 
 .Benefits

--- a/src/org/rascalmpl/courses/Recipes/Languages/Pico/Visualize/Visualize.concept
+++ b/src/org/rascalmpl/courses/Recipes/Languages/Pico/Visualize/Visualize.concept
@@ -28,7 +28,7 @@ include::{LibDir}demo/lang/Pico/Visualize.rsc[tags=module]
 <2> An editor property is attached to each Figure node: clicking on the node opens an editor for the corresponding file.
 <3> `visNode` implements the visualization per CFG node.
 <4> Since Figure nodes in a visual graph need an `id` property, we define here a scheme to associate unique identifiers to each Figure node.
-<5> The complete visualization of a CFG is implemented by `visCFG`: it gets the CFG hraph as arguments and then
+<5> The complete visualization of a CFG is implemented by `visCFG`: it gets the CFG graph as arguments and then
     **  creates all Figure edges,
     **  creates all Figure nodes,
     **  returns a Figure graph.


### PR DESCRIPTION
1.1.3. hello as module:
        - Explanation needed: xxx::yyy::Module is located in
<project>/src/xxx/yyy/Module.rsc

2.1. Ad Hoc Data Exploration:
        - Indentation is sometimes off, this hampers readability. This
is probably a tabs/spaces issue.

2.6. Derivative:
        - "on the the up"

2.8. Word Count:
        - "Explain what is going on in this function."
        - <word:\w+> subpattern does not exist in the code. My guess is
the pattern has been simplified in the past.


3. Languages:
        - Eval1, Eval2, and Eval3 lack explanation

3.1.2: Combined:
        - "Note that we explicitly use
demo::lang::Exp::Concrete::WithLayout::Syntax::Exp in these rules to
distinguish from demo::lang::Exp::Abstract::Syntax::Exp."
        This sentence should be the other way around,
"demo::lang::Exp::Abstract::Syntax::Exp" is explicitly used.

3.1.3. Concrete:
        - "defcoine" -> "define"

3.2. Func:
        - comparison operators: <= is too small, looks like a single
symbol
                - A backslash before '<' fixed this
                - Solved this in several other locations, including
Rascal/Statements/Assignment/Constructor/Constructor.concept
       - "structur" -> "structure"

3.4.9. Typecheck:
        - "Typechecker a Pico program." -> "Typechecker for Pico
programs."

3.4.10. UseDef
        - "'… ← P. stats` enumerates all statements in the program.":
Same problem as with <= above, <- is replaced by a "left arrow" symbol.

3.4.12. Visualize:
        "hraph" -> "graph"