### PR TITLE
Added general test mode to RascalJUnitTestRunner

### DIFF
--- a/src/org/rascalmpl/test/RunAllRascalTests.java
+++ b/src/org/rascalmpl/test/RunAllRascalTests.java
@@ -1,0 +1,7 @@
+package org.rascalmpl.test;
+
+import org.junit.runner.RunWith;
+import org.rascalmpl.test.infrastructure.RascalJUnitTestRunner;
+
+@RunWith(RascalJUnitTestRunner.class)
+public class RunAllRascalTests { }

--- a/test/org/rascalmpl/test/RunAllRascalTests.java
+++ b/test/org/rascalmpl/test/RunAllRascalTests.java
@@ -1,0 +1,7 @@
+package org.rascalmpl.test;
+
+import org.junit.runner.RunWith;
+import org.rascalmpl.test.infrastructure.RascalJUnitTestRunner;
+
+@RunWith(RascalJUnitTestRunner.class)
+public class RunAllRascalTests { }


### PR DESCRIPTION
By running RunAllRascalTests using
`mvn test -Dtest=org.rascalmpl.test.RunAllRascalTest` the test runner
will run all the tests available from the source modules in the current
mvn project. Currently this requires setting
`-Drascal.test.root=${project.basedir}`
