### PR TITLE
re-implementation of the access modifiers

### DIFF
--- a/src/org/rascalmpl/interpreter/Evaluator.java
+++ b/src/org/rascalmpl/interpreter/Evaluator.java
@@ -1688,7 +1688,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
             for (AbstractFunction f : p.getSecond()) {
                 String module = ((ModuleEnvironment)f.getEnv()).getName();
                 
-                if (skipPrivate && !f.isPublic()) {
+                if (skipPrivate && env.isNamePrivate(f.getName())) {
                     continue;
                 }
                 
@@ -1700,7 +1700,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
         boolean inQualifiedModule = env.getName().equals(qualifier) || qualifier.isEmpty();
         if (inQualifiedModule) {
             for (Entry<String, Result<IValue>> entry : env.getVariables().entrySet()) {
-                if (skipPrivate && !entry.getValue().isPublic()) {
+                if (skipPrivate && env.isNamePrivate(entry.getKey())) {
                     continue;
                 }
                 addIt(result, entry.getKey(), qualifier, partialIdentifier);

--- a/src/org/rascalmpl/interpreter/TypeDeclarationEvaluator.java
+++ b/src/org/rascalmpl/interpreter/TypeDeclarationEvaluator.java
@@ -178,7 +178,6 @@ public class TypeDeclarationEvaluator {
 				
 				try {
 					ConstructorFunction cons = env.constructorFromTuple(var, eval, adt, altName, tf.tupleType(fields, labels), local);
-					cons.setPublic(true); // TODO: implement declared visibility
 					
 					if (local.size() > 0) {
 						Type kwType = computeKeywordParametersType(local, eval);

--- a/src/org/rascalmpl/interpreter/env/Environment.java
+++ b/src/org/rascalmpl/interpreter/env/Environment.java
@@ -73,15 +73,15 @@ public class Environment implements IRascalFrame {
 		}
 
 		public NameFlags makeFinal() {
-			return new NameFlags(flags & FINAL_NAME);
+			return new NameFlags(flags | FINAL_NAME);
 		}
 
 		public NameFlags makePrivate() {
-			return new NameFlags(flags & PRIVATE_NAME);
+			return new NameFlags(flags | PRIVATE_NAME);
 		}
 
 		public NameFlags makeOverloadable() {
-			return new NameFlags(flags & OVERLOADABLE_NAME);
+			return new NameFlags(flags | OVERLOADABLE_NAME);
 		}
 
 		boolean isFinal() {

--- a/src/org/rascalmpl/interpreter/env/ModuleEnvironment.java
+++ b/src/org/rascalmpl/interpreter/env/ModuleEnvironment.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.rascalmpl.ast.AbstractAST;
 import org.rascalmpl.ast.KeywordFormal;
@@ -512,7 +513,7 @@ public class ModuleEnvironment extends Environment {
 			if (mod != null && mod.variableEnvironment != null) 
 				r = mod.variableEnvironment.get(name);
 			
-			if (r != null && r.isPublic()) {
+			if (r != null && !mod.isNamePrivate(name)) {
 				return mod.variableEnvironment;
 			}
 		}
@@ -556,7 +557,7 @@ public class ModuleEnvironment extends Environment {
 			var = variableEnvironment.get(name);
 		}
 		
-		if (var != null && var.isPublic()) {
+		if (var != null && !isNamePrivate(name)) {
 			return var;
 		}
 		
@@ -567,22 +568,20 @@ public class ModuleEnvironment extends Environment {
 		if (functionEnvironment != null) {
 			List<AbstractFunction> lst = functionEnvironment.get(name);
 			if (lst != null) {
-				for (AbstractFunction func : lst) {
-					if (func.isPublic()) {
-						collection.add(func);
-					}
+				if (!isNamePrivate(name)) {
+					collection.addAll(lst);
 				}
 			}
 		}
 	}
 	
 	private void getLocalPublicFunctions(Type returnType, String name, List<AbstractFunction> collection) {
-		if (functionEnvironment != null) {
+		if (functionEnvironment != null && !isNamePrivate(name)) {
 			List<AbstractFunction> lst = functionEnvironment.get(name);
 			
 			if (lst != null) {
 				for (AbstractFunction func : lst) {
-					if (func.isPublic() && returnType.isSubtypeOf(func.getReturnType())) {
+					if (returnType.isSubtypeOf(func.getReturnType())) {
 						collection.add(func);
 					}
 				}
@@ -932,12 +931,12 @@ public class ModuleEnvironment extends Environment {
 	}
 
 	@Override
-	protected boolean isNameFlagged(QualifiedName name, int flags) {
+	protected boolean isNameFlagged(QualifiedName name, Predicate<NameFlags> tester) {
 		String modulename = Names.moduleName(name);
 		String cons = Names.name(Names.lastName(name));
 		if (modulename != null) {
 			if (modulename.equals(getName())) {
-				return isNameFlagged(cons, flags);
+				return isNameFlagged(cons, tester);
 			}
 			
 			ModuleEnvironment imported = getImport(modulename);
@@ -947,14 +946,14 @@ public class ModuleEnvironment extends Environment {
 				return false;
 			}
 			
-			return imported.isNameFlagged(cons, flags);
+			return imported.isNameFlagged(cons, tester);
 		}
 		
-		return isNameFlagged(cons, flags);
+		return isNameFlagged(cons, tester);
 	}
 
 	@Override
-	protected void flagName(QualifiedName name, int flags) {
+	protected void flagName(QualifiedName name, NameFlags flags) {
 		String modulename = Names.moduleName(name);
 		String cons = Names.name(Names.lastName(name));
 		if (modulename != null) {

--- a/src/org/rascalmpl/interpreter/matching/VariableBecomesPattern.java
+++ b/src/org/rascalmpl/interpreter/matching/VariableBecomesPattern.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.rascalmpl.ast.AbstractAST;
 import org.rascalmpl.ast.Expression;
 import org.rascalmpl.interpreter.IEvaluatorContext;
 import org.rascalmpl.interpreter.env.Environment;

--- a/src/org/rascalmpl/interpreter/result/AbstractPatternDispatchedFunction.java
+++ b/src/org/rascalmpl/interpreter/result/AbstractPatternDispatchedFunction.java
@@ -74,11 +74,6 @@ public class AbstractPatternDispatchedFunction extends AbstractFunction {
 		return new AbstractPatternDispatchedFunction(getEval(), index, name, newAlts);
 	}
 	
-	@Override
-	public boolean isPublic() {
-		throw new UnsupportedOperationException();
-	}
-	
 	public Map<String,List<AbstractFunction>> getMap() {
 		return alternatives;
 	}

--- a/src/org/rascalmpl/interpreter/result/ConcretePatternDispatchedFunction.java
+++ b/src/org/rascalmpl/interpreter/result/ConcretePatternDispatchedFunction.java
@@ -81,11 +81,6 @@ public class ConcretePatternDispatchedFunction extends AbstractFunction {
 	}
 	
 	@Override
-	public boolean isPublic() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public boolean isConcretePatternDispatched() {
 		return true;
 	}

--- a/src/org/rascalmpl/interpreter/result/ConstructorFunction.java
+++ b/src/org/rascalmpl/interpreter/result/ConstructorFunction.java
@@ -71,9 +71,7 @@ public class ConstructorFunction extends NamedFunction {
 
 	@Override
 	public ConstructorFunction cloneInto(Environment env) {
-		ConstructorFunction c = new ConstructorFunction(getAst(), getEval(), env, constructorType, initializers);
-		c.setPublic(isPublic());
-		return c;
+		return new ConstructorFunction(getAst(), getEval(), env, constructorType, initializers);
 	}
 	
 	// TODO: refactor and make small. For now this does the job.

--- a/src/org/rascalmpl/interpreter/result/FunctionResultFacade.java
+++ b/src/org/rascalmpl/interpreter/result/FunctionResultFacade.java
@@ -114,15 +114,6 @@ public final class FunctionResultFacade extends Result<IValue> {
 		return wrapped.equalToRascalFunction(that);
 	}
 
-	
-	public boolean isPublic() {
-		return wrapped.isPublic();
-	}
-	
-	public void setPublic(boolean isPublic) {
-		wrapped.setPublic(isPublic);
-	}
-
 	public void setInferredType(boolean inferredType) {
 		wrapped.setInferredType(inferredType);
 	}

--- a/src/org/rascalmpl/interpreter/result/JavaMethod.java
+++ b/src/org/rascalmpl/interpreter/result/JavaMethod.java
@@ -98,9 +98,7 @@ public class JavaMethod extends NamedFunction {
 
 	@Override
 	public JavaMethod cloneInto(Environment env) {
-		JavaMethod jm = new JavaMethod(getEval(), getFunctionType(), getType(), (FunctionDeclaration)getAst(), isDefault, isTest, hasVarArgs, env, javaBridge);
-		jm.setPublic(isPublic());
-		return jm;
+		return new JavaMethod(getEval(), getFunctionType(), getType(), (FunctionDeclaration)getAst(), isDefault, isTest, hasVarArgs, env, javaBridge);
 	}
 	
 	@Override

--- a/src/org/rascalmpl/interpreter/result/OverloadedFunction.java
+++ b/src/org/rascalmpl/interpreter/result/OverloadedFunction.java
@@ -180,9 +180,8 @@ public class OverloadedFunction extends Result<IValue> implements IExternalValue
         for (AbstractFunction f: defaultCandidates) {
             newDefaultCandidates.add((AbstractFunction) f.cloneInto(env));
         }
-        OverloadedFunction of = new OverloadedFunction(name, getStaticType(), newCandidates, newDefaultCandidates, isStatic, ctx);
-        of.setPublic(isPublic());
-        return of;
+        
+        return new OverloadedFunction(name, getStaticType(), newCandidates, newDefaultCandidates, isStatic, ctx);
     }
 
     /**

--- a/src/org/rascalmpl/interpreter/result/RascalFunction.java
+++ b/src/org/rascalmpl/interpreter/result/RascalFunction.java
@@ -74,24 +74,24 @@ public class RascalFunction extends NamedFunction {
     private final IConstructor indexedProduction;
     private final List<KeywordFormal> initializers;
 
-    public RascalFunction(IEvaluator<Result<IValue>> eval, FunctionDeclaration.Default func, boolean varargs, boolean isPublic, Environment env, Stack<Accumulator> accumulators) {
+    public RascalFunction(IEvaluator<Result<IValue>> eval, FunctionDeclaration.Default func, boolean varargs, Environment env, Stack<Accumulator> accumulators) {
         this(func, eval,
             Names.name(func.getSignature().getName()),
             func.getSignature().typeOf(env, eval, false),
             func.getSignature().typeOf(env, eval, false).instantiate(env.getDynamicTypeBindings()),
             getFormals(func),
-            varargs, isDefault(func), hasTestMod(func.getSignature()), isPublic,
+            varargs, isDefault(func), hasTestMod(func.getSignature()),
             func.getBody().getStatements(), env, accumulators);
     }
 
-    public RascalFunction(IEvaluator<Result<IValue>> eval, FunctionDeclaration.Expression func, boolean varargs, boolean isPublic, Environment env,
+    public RascalFunction(IEvaluator<Result<IValue>> eval, FunctionDeclaration.Expression func, boolean varargs,  Environment env,
         Stack<Accumulator> accumulators) {
         this(func, eval,
             Names.name(func.getSignature().getName()),
             func.getSignature().typeOf(env, eval, false), 
             func.getSignature().typeOf(env, eval, false).instantiate(env.getDynamicTypeBindings()),
             getFormals(func),
-            varargs, isDefault(func), hasTestMod(func.getSignature()), isPublic, 
+            varargs, isDefault(func), hasTestMod(func.getSignature()), 
             Arrays.asList(new Statement[] { ASTBuilder.makeStat("Return", func.getLocation(), ASTBuilder.makeStat("Expression", func.getLocation(), func.getExpression()))}),
             env, accumulators);
     }
@@ -99,7 +99,7 @@ public class RascalFunction extends NamedFunction {
     @SuppressWarnings("unchecked")
     public RascalFunction(AbstractAST ast, IEvaluator<Result<IValue>> eval, String name, Type staticType, Type dynamicType,
         List<KeywordFormal> initializers,
-        boolean varargs, boolean isDefault, boolean isTest, boolean isPublic, List<Statement> body, Environment env, Stack<Accumulator> accumulators) {
+        boolean varargs, boolean isDefault, boolean isTest, List<Statement> body, Environment env, Stack<Accumulator> accumulators) {
         super(ast, eval, staticType, dynamicType, initializers, name, varargs, isDefault, isTest, env);
         this.body = body;
        
@@ -110,8 +110,6 @@ public class RascalFunction extends NamedFunction {
         this.indexedLabel = computeIndexedLabel(indexedPosition, ast);
         this.indexedProduction = computeIndexedProduction(indexedPosition, ast);
         this.initializers = initializers;
-        
-        setPublic(isPublic);
     }
 
     @Override
@@ -119,9 +117,7 @@ public class RascalFunction extends NamedFunction {
         AbstractAST clone = cloneAst();
         List<Statement> clonedBody = cloneBody();
         // TODO: accumulators are not cloned? @tvdstorm check this out:
-        RascalFunction rf = new RascalFunction(clone, getEval(), getName(), getFunctionType(), getType(), initializers, hasVarArgs(), isDefault(), isTest(), isPublic(), clonedBody, env, accumulators);
-        rf.setPublic(isPublic()); // TODO: should be in constructors
-        return rf;
+        return new RascalFunction(clone, getEval(), getName(), getFunctionType(), getType(), initializers, hasVarArgs(), isDefault(), isTest(), clonedBody, env, accumulators);
     }
 
     private AbstractAST cloneAst() {

--- a/src/org/rascalmpl/interpreter/result/Result.java
+++ b/src/org/rascalmpl/interpreter/result/Result.java
@@ -82,7 +82,6 @@ public abstract class Result<T extends IValue> implements Iterator<Result<IValue
 	private Iterator<Result<IValue>> iterator = null;
 	protected final Type type;
 	protected T value;
-	private boolean isPublic;
 	private boolean inferredType = false;
 	protected IEvaluatorContext ctx;
 
@@ -143,10 +142,6 @@ public abstract class Result<T extends IValue> implements Iterator<Result<IValue
 	protected <U extends IValue> Result<U> makeIntegerResult(int i) {
 		return makeResult(getTypeFactory().integerType(), getValueFactory().integer(i), ctx);
 	}
-	
-	/// TODO: Factory access:
-	//this should probably access fields initialized by constructor invocations
-	//passed into them by ResultFactory.
 	
 	protected TypeFactory getTypeFactory() {
 		return TypeFactory.getInstance();
@@ -639,8 +634,8 @@ public abstract class Result<T extends IValue> implements Iterator<Result<IValue
 	}
 	
 	protected Result<IBool> equalToListRelation(ListRelationResult that) {
-    return bool(false, ctx);
-  }
+        return bool(false, ctx);
+    }
 	
 	protected Result<IBool> equalToSet(SetResult that) {
 		return bool(false, ctx);
@@ -1045,14 +1040,6 @@ public abstract class Result<T extends IValue> implements Iterator<Result<IValue
 		return undefinedError(IS_DEFINED_STRING, this);
 	}
 	
-	public boolean isPublic() {
-		return isPublic;
-	}
-	
-	public void setPublic(boolean isPublic) {
-		this.isPublic = isPublic;
-	}
-
 	public void setInferredType(boolean inferredType) {
 		this.inferredType  = inferredType;
 	}

--- a/src/org/rascalmpl/interpreter/result/ResultFactory.java
+++ b/src/org/rascalmpl/interpreter/result/ResultFactory.java
@@ -13,10 +13,8 @@ package org.rascalmpl.interpreter.result;
 
 import org.rascalmpl.exceptions.ImplementationError;
 import org.rascalmpl.interpreter.IEvaluatorContext;
-import org.rascalmpl.interpreter.utils.TreeAsNode;
 import org.rascalmpl.types.RascalType;
 import org.rascalmpl.values.RascalValueFactory;
-import org.rascalmpl.values.parsetrees.ITree;
 
 import io.usethesource.vallang.IBool;
 import io.usethesource.vallang.IConstructor;

--- a/src/org/rascalmpl/library/lang/java/m3/internal/JarConverter.java
+++ b/src/org/rascalmpl/library/lang/java/m3/internal/JarConverter.java
@@ -266,7 +266,6 @@ public class JarConverter extends M3Converter {
             ISourceLocation classLogical = resolver.resolveBinding(classNode, null);
             ISourceLocation classPhysical = M3LocationUtil.makeLocation(compUnitPhysical, classReader.header, classReader.b.length);
             IConstructor cons = resolver.resolveType(classNode, null);
-            @SuppressWarnings("unchecked")
             List<AnnotationNode> annotations = composeAnnotations(classNode.visibleAnnotations, classNode.invisibleAnnotations);
 
             addToContainment(compUnitLogical, classLogical);
@@ -291,7 +290,6 @@ public class JarConverter extends M3Converter {
      */
     private void setInnerClassRelations(ClassNode classNode, ISourceLocation classLogical) {
         // cn.innerClasses and cn.outerClass are not providing consistent information. 
-        @SuppressWarnings("unchecked")
         List<InnerClassNode> innerClasses = classNode.innerClasses;
         
         if (innerClasses != null) {
@@ -322,7 +320,6 @@ public class JarConverter extends M3Converter {
      * @param classNode - class node where fields are declared
      * @param classLogical - class location
      */
-    @SuppressWarnings("unchecked")
     private void setFieldRelations(ClassNode classNode, ISourceLocation classLogical) {
         List<FieldNode> fields = classNode.fields;
         
@@ -356,7 +353,6 @@ public class JarConverter extends M3Converter {
      * @param classNode - class node where fields are declared
      * @param classLogical - class location
      */
-    @SuppressWarnings("unchecked")
     private void setMethodRelations(ClassNode classNode, ISourceLocation classLogical) {
         List<MethodNode> methods = classNode.methods;
         
@@ -400,7 +396,6 @@ public class JarConverter extends M3Converter {
         if (classReader != null) {
             ClassNode classNode = new ClassNode();
             classReader.accept(classNode, ClassReader.SKIP_DEBUG);
-            @SuppressWarnings("unchecked")
             List<MethodNode> superMethods = classNode.methods;
             
             if (superMethods != null) {
@@ -425,7 +420,6 @@ public class JarConverter extends M3Converter {
      * @param methodLogical - logical location of the method
      */
     private void setExceptionRelations(MethodNode methodNode, ISourceLocation methodLogical) {
-        @SuppressWarnings("unchecked")
         List<String> exceptions = methodNode.exceptions;
         
         for (String exception : exceptions) {
@@ -468,7 +462,6 @@ public class JarConverter extends M3Converter {
         InsnList instructions = methodNode.instructions;
         
         if(instructions != null) {
-            @SuppressWarnings("unchecked")
             ListIterator<AbstractInsnNode> iterator = instructions.iterator();
 
             while (iterator.hasNext()) {

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/FunctionAssignment.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/FunctionAssignment.rsc
@@ -1,0 +1,13 @@
+module lang::rascal::tests::basic::FunctionAssignment
+
+import String;
+
+public int i = 0;
+
+test bool triggerAssignmentBug() {
+    str(str) stealTheFunction = toUpperCase;
+    
+    // by now the interpreter would fail with an exception: 
+    //   Undeclared variable: toUpperCase
+    return toUpperCase("abc") == "ABC";
+}

--- a/src/org/rascalmpl/semantics/dynamic/Declaration.java
+++ b/src/org/rascalmpl/semantics/dynamic/Declaration.java
@@ -157,9 +157,12 @@ public abstract class Declaration extends org.rascalmpl.ast.Declaration {
 				} else {
 					eval.getCurrentModuleEnvironment().storeVariable(var.getName(), ResultFactory.nothing(declaredType));
 				}
+				
+				if (!getVisibility().isPublic()) {
+	                eval.getCurrentModuleEnvironment().markNamePrivate(Names.name(var.getName()));
+	            }
 			}
-
-			r.setPublic(this.getVisibility().isPublic());
+			
 			return r;
 		}
 	}

--- a/src/org/rascalmpl/semantics/dynamic/Expression.java
+++ b/src/org/rascalmpl/semantics/dynamic/Expression.java
@@ -604,7 +604,7 @@ public abstract class Expression extends org.rascalmpl.ast.Expression {
 					TF.functionType(returnType, formals, kwParams).instantiate(__eval.getCurrentEnvt().getDynamicTypeBindings()),
 					kwd,
 					this.getParameters()
-					.isVarArgs(), false, false, false, this.getStatements(), env, __eval.__getAccumulators());
+					.isVarArgs(), false, false, this.getStatements(), env, __eval.__getAccumulators());
 		}
 
 		@Override
@@ -2948,7 +2948,6 @@ public abstract class Expression extends org.rascalmpl.ast.Expression {
 				TF.functionType(TF.voidType(), formals, kwParams).instantiate(eval.getCurrentEnvt().getDynamicTypeBindings()),
 				kws, 
 				this.getParameters().isVarArgs(), 
-				false, 
 				false, 
 				false, 
 				this.getStatements0(), 

--- a/src/org/rascalmpl/semantics/dynamic/FunctionDeclaration.java
+++ b/src/org/rascalmpl/semantics/dynamic/FunctionDeclaration.java
@@ -51,7 +51,6 @@ public abstract class FunctionDeclaration extends
 
 		@Override
 		public Result<IValue> interpret(IEvaluator<Result<IValue>> __eval) {
-
 			boolean varArgs = this.getSignature().getParameters().isVarArgs();
 
 			if (!hasJavaModifier(this)) {
@@ -62,12 +61,16 @@ public abstract class FunctionDeclaration extends
 					__eval.getCurrentEnvt(), __eval.__getJavaBridge());
 			String name = org.rascalmpl.interpreter.utils.Names.name(this
 					.getSignature().getName());
-		
+			boolean isPublic = this.getVisibility().isPublic() || this.getVisibility().isDefault();
+
 			__eval.getCurrentEnvt().storeFunction(name, lambda);
 			__eval.getCurrentEnvt().markNameFinal(lambda.getName());
 			__eval.getCurrentEnvt().markNameOverloadable(lambda.getName());
 
-			lambda.setPublic(this.getVisibility().isPublic() || this.getVisibility().isDefault());
+			if (!isPublic) {
+				__eval.getCurrentEnvt().markNamePrivate(lambda.getName());
+			}
+
 			return lambda;
 
 		}
@@ -97,11 +100,14 @@ public abstract class FunctionDeclaration extends
 			}
 
 			
-            lambda = new RascalFunction(__eval, this, hasVarArgs, isPublic, __eval.getCurrentEnvt(), __eval.__getAccumulators());
+            lambda = new RascalFunction(__eval, this, hasVarArgs, __eval.getCurrentEnvt(), __eval.__getAccumulators());
 
 			__eval.getCurrentEnvt().storeFunction(lambda.getName(), lambda);
 			__eval.getCurrentEnvt().markNameFinal(lambda.getName());
 			__eval.getCurrentEnvt().markNameOverloadable(lambda.getName());
+			if (!isPublic) {
+				__eval.getCurrentEnvt().markNamePrivate(lambda.getName());
+			}
 
 			return lambda;
 
@@ -135,12 +141,16 @@ public abstract class FunctionDeclaration extends
 				throw new NonAbstractJavaFunction(this);
 			}
 
-			lambda = new RascalFunction(__eval, this, hasVarArgs, isPublic, __eval.getCurrentEnvt(), __eval.__getAccumulators());
+			lambda = new RascalFunction(__eval, this, hasVarArgs, __eval.getCurrentEnvt(), __eval.__getAccumulators());
 			
 			__eval.getCurrentEnvt().markNameFinal(lambda.getName());
 			__eval.getCurrentEnvt().markNameOverloadable(lambda.getName());
 			__eval.getCurrentEnvt().storeFunction(lambda.getName(), lambda);
 			
+			if (!isPublic) {
+				__eval.getCurrentEnvt().markNamePrivate(lambda.getName());
+			}
+
 			return lambda;
 		}
 
@@ -176,12 +186,16 @@ public abstract class FunctionDeclaration extends
 			FunctionDeclaration.Default func = ASTBuilder.make("FunctionDeclaration", "Default", src, getTags(), getVisibility(), getSignature(), body);
 			boolean isPublic = this.getVisibility().isPublic() || this.getVisibility().isDefault();
 			
-			lambda = new RascalFunction(__eval, func, hasVarArgs, isPublic, __eval.getCurrentEnvt(), __eval.__getAccumulators());
+			lambda = new RascalFunction(__eval, func, hasVarArgs, __eval.getCurrentEnvt(), __eval.__getAccumulators());
 
 			__eval.getCurrentEnvt().storeFunction(lambda.getName(), lambda);
 			__eval.getCurrentEnvt().markNameFinal(lambda.getName());
 			__eval.getCurrentEnvt().markNameOverloadable(lambda.getName());
 
+			if (!isPublic) {
+				__eval.getCurrentEnvt().markNamePrivate(lambda.getName());
+			}
+			
 			return lambda;
 		}
 

--- a/src/org/rascalmpl/semantics/dynamic/Tree.java
+++ b/src/org/rascalmpl/semantics/dynamic/Tree.java
@@ -27,15 +27,17 @@ import org.rascalmpl.interpreter.matching.IBooleanResult;
 import org.rascalmpl.interpreter.matching.IMatchingResult;
 import org.rascalmpl.interpreter.matching.LiteralPattern;
 import org.rascalmpl.interpreter.matching.NodePattern;
-import org.rascalmpl.interpreter.matching.QualifiedNamePattern;
 import org.rascalmpl.interpreter.matching.SetPattern;
 import org.rascalmpl.interpreter.matching.TypedVariablePattern;
 import org.rascalmpl.interpreter.result.Result;
 import org.rascalmpl.interpreter.staticErrors.UndeclaredVariable;
 import org.rascalmpl.interpreter.staticErrors.UninitializedVariable;
-import org.rascalmpl.interpreter.utils.Names;
 import org.rascalmpl.types.NonTerminalType;
 import org.rascalmpl.types.RascalTypeFactory;
+import org.rascalmpl.values.RascalValueFactory;
+import org.rascalmpl.values.parsetrees.ProductionAdapter;
+import org.rascalmpl.values.parsetrees.SymbolAdapter;
+import org.rascalmpl.values.parsetrees.TreeAdapter;
 
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IList;
@@ -44,11 +46,6 @@ import io.usethesource.vallang.ISetWriter;
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.type.Type;
-
-import org.rascalmpl.values.RascalValueFactory;
-import org.rascalmpl.values.parsetrees.ProductionAdapter;
-import org.rascalmpl.values.parsetrees.SymbolAdapter;
-import org.rascalmpl.values.parsetrees.TreeAdapter;
 
 /**
  * These classes special case Expression.CallOrTree for concrete syntax patterns

--- a/src/org/rascalmpl/util/HeapDumper.java
+++ b/src/org/rascalmpl/util/HeapDumper.java
@@ -25,7 +25,6 @@ import com.sun.management.HotSpotDiagnosticMXBean;
  * 
  * Use it to dump the heap to a file for further analysis.
  */
-@SuppressWarnings("restriction")
 public class HeapDumper {
     private static final class InstanceKeeper {
         /*package*/ 


### PR DESCRIPTION
both for variables and functions we moved this implementation
from the Result class to the Environment class. We extended
the NameFlags class with the possibility to make certain names
private.

The big collatoral damage here is that a name string will
become private for an entire module if only one of the alternatives
was labeled private.

It should also fix #1588 which was the point.
