### PR TITLE
Fallback resolvers added to the URIRegistryResolver

### DIFF
--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -1333,10 +1333,13 @@ public class Prelude {
 		try {
 			sloc = reg.logicalToPhysical(sloc);
 
-			if (reg.supportsInputScheme(sloc.getScheme())) {
-				if (sloc.hasOffsetLength()) {
+
+			if (sloc.hasOffsetLength()) {
+				try {
 					prefix = new UnicodeOffsetLengthReader(reg.getCharacterReader(sloc.top(), charset.getValue()), 0, sloc.getOffset() + ( append ? sloc.getLength()  : 0 ));
 					postfix = new UnicodeOffsetLengthReader(reg.getCharacterReader(sloc.top(), charset.getValue()),  sloc.getOffset() + sloc.getLength(), -1);
+				} catch (UnsupportedSchemeException e) {
+					// silently ignoring that we cannot do an append for this scheme as there is no input stream resolver defined for this scheme
 				}
 			}
 

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -388,7 +388,8 @@ public class URIResolverRegistry {
 	}
 
 	private ISourceLocation physicalLocation(ISourceLocation loc) throws IOException {
-		while (logicalResolvers.containsKey(loc.getScheme())) {
+		ISourceLocation original = loc;
+		while (loc != null && logicalResolvers.containsKey(loc.getScheme())) {
 			Map<String, ILogicalSourceLocationResolver> map = logicalResolvers.get(loc.getScheme());
 			String auth = loc.hasAuthority() ? loc.getAuthority() : "";
 			ILogicalSourceLocationResolver resolver = map.get(auth);
@@ -396,7 +397,7 @@ public class URIResolverRegistry {
 		}
 		var fallBack = fallbackLogicalResolver;
 		if (fallBack != null) {
-			return resolveAndFixOffsets(loc, fallBack, Collections.emptyList());
+			return resolveAndFixOffsets(loc == null ? original : loc, fallBack, Collections.emptyList());
 		}
 		return loc;
 	}


### PR DESCRIPTION
The goal of this PR is to add a new functionality to the URIResolverRegistry (the base class that delegates all IO operations to the right resolvers) so that we can define default behavior for scheme's not registered with rascal.

The current main feature is exposing virtual file systems from VSCode inside rascal, but I'm sure we'll identify new ways to use this feature.

The fallback resolvers have to take care to throw either `SchemeNotSupported` exception or `IOExceptions`.

Regarding the changes: the biggest parts are some refactoring to avoid cloning logic, the only change was that the `supportsInputScheme` and `supportOuputScheme` was removed as they don't work anymore. `supportsInputScheme` was used in exactly 1 function in Prelude, that has been fixed, and `supportsOutputScheme` was never used.