### PR TITLE
refactored parser function generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.23.3-SNAPSHOT</version>
+    <version>0.24.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/org/rascalmpl/interpreter/Evaluator.java
+++ b/src/org/rascalmpl/interpreter/Evaluator.java
@@ -61,7 +61,6 @@ import org.rascalmpl.debug.IRascalRuntimeInspection;
 import org.rascalmpl.debug.IRascalSuspendTrigger;
 import org.rascalmpl.debug.IRascalSuspendTriggerListener;
 import org.rascalmpl.exceptions.ImplementationError;
-import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.exceptions.StackTrace;
 import org.rascalmpl.ideservices.IDEServices;
 import org.rascalmpl.interpreter.asserts.NotYetImplemented;
@@ -95,20 +94,16 @@ import org.rascalmpl.library.lang.rascal.syntax.RascalParser;
 import org.rascalmpl.parser.ASTBuilder;
 import org.rascalmpl.parser.Parser;
 import org.rascalmpl.parser.ParserGenerator;
-import org.rascalmpl.parser.gtd.IGTD;
 import org.rascalmpl.parser.gtd.io.InputConverter;
-import org.rascalmpl.parser.gtd.recovery.IRecoverer;
 import org.rascalmpl.parser.gtd.result.action.IActionExecutor;
 import org.rascalmpl.parser.gtd.result.out.DefaultNodeFlattener;
 import org.rascalmpl.parser.uptr.UPTRNodeFactory;
 import org.rascalmpl.parser.uptr.action.NoActionExecutor;
-import org.rascalmpl.parser.uptr.action.RascalFunctionActionExecutor;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.values.RascalFunctionValueFactory;
 import org.rascalmpl.values.functions.IFunction;
 import org.rascalmpl.values.parsetrees.ITree;
-import org.rascalmpl.values.parsetrees.TreeAdapter;
 
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IList;
@@ -916,7 +911,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
         if (!noBacktickOutsideStringConstant(command)) {
             ModuleEnvironment curMod = getCurrentModuleEnvironment();
             IFunction parsers = parserForCurrentModule(vf, curMod);
-            tree = org.rascalmpl.semantics.dynamic.Import.parseFragments(vf, parsers, tree, location, getCurrentModuleEnvironment());
+            tree = org.rascalmpl.semantics.dynamic.Import.parseFragments(vf, getMonitor(), parsers, tree, location, getCurrentModuleEnvironment());
         }
 
         Command stat = new ASTBuilder().buildCommand(tree);
@@ -946,7 +941,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
 
         if (!noBacktickOutsideStringConstant(command)) {
             IFunction parsers = parserForCurrentModule(vf, getCurrentModuleEnvironment());
-            tree = org.rascalmpl.semantics.dynamic.Import.parseFragments(vf, parsers, tree, location, getCurrentModuleEnvironment());
+            tree = org.rascalmpl.semantics.dynamic.Import.parseFragments(vf, getMonitor(), parsers, tree, location, getCurrentModuleEnvironment());
         }
 
         Commands stat = new ASTBuilder().buildCommands(tree);
@@ -995,7 +990,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
         IActionExecutor<ITree> actionExecutor =  new NoActionExecutor();
         ITree tree =  new RascalParser().parse(Parser.START_COMMAND, location.getURI(), command.toCharArray(), actionExecutor, new DefaultNodeFlattener<IConstructor, ITree, ISourceLocation>(), new UPTRNodeFactory(false));
         if (!noBacktickOutsideStringConstant(command)) {
-            tree = org.rascalmpl.semantics.dynamic.Import.parseFragments(vf, parserForCurrentModule(vf, getCurrentModuleEnvironment()), tree, location, getCurrentModuleEnvironment());
+            tree = org.rascalmpl.semantics.dynamic.Import.parseFragments(vf, getMonitor(), parserForCurrentModule(vf, getCurrentModuleEnvironment()), tree, location, getCurrentModuleEnvironment());
         }
 
         return tree;
@@ -1010,7 +1005,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
             ITree tree = new RascalParser().parse(Parser.START_COMMANDS, location.getURI(), commands.toCharArray(), actionExecutor, new DefaultNodeFlattener<IConstructor, ITree, ISourceLocation>(), new UPTRNodeFactory(false));
 
             if (!noBacktickOutsideStringConstant(commands)) {
-                tree = parseFragments(vf, parserForCurrentModule(vf, getCurrentModuleEnvironment()), tree, location, getCurrentModuleEnvironment());
+                tree = parseFragments(vf, getMonitor(), parserForCurrentModule(vf, getCurrentModuleEnvironment()), tree, location, getCurrentModuleEnvironment());
             }
 
             return tree;

--- a/src/org/rascalmpl/interpreter/Evaluator.java
+++ b/src/org/rascalmpl/interpreter/Evaluator.java
@@ -828,7 +828,6 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
                 throw new ImplementationError("Cyclic bootstrapping is occurring, probably because a module in the bootstrap dependencies is using the concrete syntax feature.");
             }
 
-
             Evaluator self = this;
             job("Loading parser generator", () -> {
                 synchronized (self) {

--- a/src/org/rascalmpl/interpreter/IEvaluator.java
+++ b/src/org/rascalmpl/interpreter/IEvaluator.java
@@ -144,17 +144,6 @@ public interface IEvaluator<T> extends IEvaluatorContext {
 	 */
 	public IValue call(String adt, String name, IValue... args);
 
-	public IConstructor parseObject(IConstructor startSort, ISet filters, ISourceLocation location, char[] input,  boolean allowAmbiguity, boolean hasSideEffects);
-
-	public IConstructor parseObject(IRascalMonitor monitor, IConstructor startSort,
-			ISet filters, String input, ISourceLocation loc,  boolean allowAmbiguity, boolean hasSideEffects);
-
-	public IConstructor parseObject(IRascalMonitor monitor, IConstructor startSort,
-			ISet filters, String input, boolean allowAmbiguity, boolean hasSideEffects);
-
-	public IConstructor parseObject(IRascalMonitor monitor, IConstructor startSort,
-			ISet filters, ISourceLocation location, boolean allowAmbiguity, boolean hasSideEffects);
-
 	/**
 	 *  Freeze the global state of this evaluator so that it can no longer be updated.
 	 * 

--- a/src/org/rascalmpl/interpreter/IEvaluatorContext.java
+++ b/src/org/rascalmpl/interpreter/IEvaluatorContext.java
@@ -29,6 +29,7 @@ import org.rascalmpl.exceptions.StackTrace;
 import org.rascalmpl.interpreter.env.Environment;
 import org.rascalmpl.interpreter.env.GlobalEnvironment;
 import org.rascalmpl.interpreter.result.Result;
+import org.rascalmpl.values.RascalFunctionValueFactory;
 
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.IValueFactory;
@@ -65,6 +66,7 @@ public interface IEvaluatorContext extends IRascalMonitor {
 	public boolean runTests(IRascalMonitor monitor);
 	
 	public IValueFactory getValueFactory();
+	public RascalFunctionValueFactory getFunctionValueFactory();
 	
 	public void setAccumulators(Stack<Accumulator> accumulators);
 	public Stack<Accumulator> getAccumulators();

--- a/src/org/rascalmpl/interpreter/env/GlobalEnvironment.java
+++ b/src/org/rascalmpl/interpreter/env/GlobalEnvironment.java
@@ -21,9 +21,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.rascalmpl.ast.AbstractAST;
@@ -33,12 +31,6 @@ import org.rascalmpl.interpreter.result.AbstractFunction;
 import org.rascalmpl.interpreter.result.ICallableValue;
 import org.rascalmpl.interpreter.staticErrors.UndeclaredModule;
 import org.rascalmpl.interpreter.utils.Names;
-import org.rascalmpl.parser.gtd.IGTD;
-import org.rascalmpl.values.parsetrees.ITree;
-
-import io.usethesource.vallang.IConstructor;
-import io.usethesource.vallang.IMap;
-import io.usethesource.vallang.ISourceLocation;
 
 
 /**
@@ -65,10 +57,6 @@ public class GlobalEnvironment {
 	 */
 	private final HashMap<String, ICallableValue> sourceResolvers = new HashMap<String, ICallableValue>();
 	
-	/** Keeping track of generated parsers */
-	private final Map<String,ParserTuple> objectParsersForModules = new ConcurrentHashMap<String,ParserTuple>();
-	private final Map<String,ParserTuple> rascalParsersForModules = new ConcurrentHashMap<String,ParserTuple>();
-
 	private boolean bootstrapper;
 	
 	public void pushExtend(String module) {
@@ -88,8 +76,6 @@ public class GlobalEnvironment {
 		moduleLocations.clear();
 		locationModules.clear();
 		sourceResolvers.clear();
-		objectParsersForModules.clear();
-		rascalParsersForModules.clear();
 	}
 	
 	/**
@@ -194,34 +180,6 @@ public class GlobalEnvironment {
 		return current;
 	}
 	
-	public Class<IGTD<IConstructor, ITree, ISourceLocation>> getObjectParser(String module, IMap productions) {
-		return getParser(objectParsersForModules, module, productions);
-	}
-	
-	/**
-	 * Retrieves a parser for a module.
-	 * 
-	 * @param module
-	 * @param productions
-	 */
-	private Class<IGTD<IConstructor, ITree, ISourceLocation>> getParser(Map<String,ParserTuple> store, String module, IMap productions) {
-		ParserTuple parser = store.get(module);
-		if(parser != null && parser.getProductions().equals(productions)) {
-			return parser.getParser();
-		}
-		
-		return null;
-	}
-	
-	public void storeObjectParser(String module, IMap productions, Class<IGTD<IConstructor, ITree, ISourceLocation>> parser) {
-		storeParser(objectParsersForModules, module, productions, parser);
-	}
-	
-	private static void storeParser(Map<String, ParserTuple> store, String module, IMap productions, Class<IGTD<IConstructor, ITree, ISourceLocation>> parser) {
-		ParserTuple newT = new ParserTuple(productions, parser);
-		store.put(module, newT);
-	}
-	
 	public Set<String> getImportingModules(String mod) {
 		Set<String> result = new HashSet<>();
 		
@@ -258,24 +216,6 @@ public class GlobalEnvironment {
 		
 		result.remove(mod);
 		return result;
-	}
-	
-	private static class ParserTuple {
-		private final IMap production;
-		private final Class<IGTD<IConstructor, ITree, ISourceLocation>> parser;
-
-		public ParserTuple(IMap productions, Class<IGTD<IConstructor, ITree, ISourceLocation>> parser) {
-			this.production = productions;
-			this.parser = parser;
-		}
-		
-		public IMap getProductions() {
-			return production;
-		}
-		
-		public Class<IGTD<IConstructor, ITree, ISourceLocation>> getParser() {
-			return parser;
-		}
 	}
 	
 	public AbstractFunction getResourceImporter(String resourceScheme) {

--- a/src/org/rascalmpl/interpreter/env/ModuleEnvironment.java
+++ b/src/org/rascalmpl/interpreter/env/ModuleEnvironment.java
@@ -75,7 +75,6 @@ public class ModuleEnvironment extends Environment {
 	private boolean initialized;
 	private boolean syntaxDefined;
 	private boolean bootstrap;
-	private Map<IMap,String> cachedParser = new HashMap<>();
 	private String deprecated;
 	protected Map<String, AbstractFunction> resourceImporters;
 	
@@ -113,7 +112,6 @@ public class ModuleEnvironment extends Environment {
 		this.syntaxDefined = env.syntaxDefined;
 		this.bootstrap = env.bootstrap;
 		this.resourceImporters = env.resourceImporters;
-		this.cachedParser = env.cachedParser;
 		this.deprecated = env.deprecated;
 	}
 
@@ -122,7 +120,6 @@ public class ModuleEnvironment extends Environment {
 		super.reset();
 		this.importedModules = new HashSet<String>();
 		this.concreteSyntaxTypes = new HashMap<String, NonTerminalType>();
-		this.cachedParser = new HashMap<>();
 		this.typeStore = new TypeStore();
 		this.productions = new HashSet<IValue>();
 		this.initialized = false;
@@ -915,19 +912,6 @@ public class ModuleEnvironment extends Environment {
 	
 	public boolean getBootstrap() {
 		return bootstrap;
-	}
-
-	// todo: bootstrap must go and use this
-	public void setCachedParser(IMap grammar, String cachedParser) {
-		this.cachedParser.put(grammar, cachedParser);
-	}
-	
-	public String getCachedParser(IMap grammar) {
-		return cachedParser.get(grammar);
-	}
-
-	public boolean hasCachedParser(IMap grammar) {
-		return cachedParser.containsKey(grammar);
 	}
 
 	@Override

--- a/src/org/rascalmpl/interpreter/staticErrors/UndeclaredNonTerminal.java
+++ b/src/org/rascalmpl/interpreter/staticErrors/UndeclaredNonTerminal.java
@@ -15,6 +15,8 @@ package org.rascalmpl.interpreter.staticErrors;
 
 import org.rascalmpl.ast.AbstractAST;
 
+import io.usethesource.vallang.ISourceLocation;
+
 public class UndeclaredNonTerminal extends StaticError {
 	private static final long serialVersionUID = -5617996489458337612L;
 	private final String name;
@@ -24,6 +26,11 @@ public class UndeclaredNonTerminal extends StaticError {
 		this.name = name;
 	}
 
+	public UndeclaredNonTerminal(String name, String module, ISourceLocation ast) {
+		super("Undeclared non-terminal: " + name + " in module " + module, ast);
+		this.name = name;
+	}
+	
 	public String getName() {
 		return name;
 	}

--- a/src/org/rascalmpl/interpreter/utils/JavaBridge.java
+++ b/src/org/rascalmpl/interpreter/utils/JavaBridge.java
@@ -386,7 +386,7 @@ public class JavaBridge {
 					        args[i] = new ListClassLoader(loaders, getClass().getClassLoader()); 
 					    }
 					    else if (formals[i].isAssignableFrom(IRascalValueFactory.class)) {
-					        args[i] = new RascalFunctionValueFactory(ctx);
+					        args[i] = ctx.getFunctionValueFactory();
 					    }
 						else if (formals[i].isAssignableFrom(IDEServices.class)) {
 							if (monitor instanceof IDEServices) {

--- a/src/org/rascalmpl/library/lang/rascal/grammar/definition/Priorities.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/grammar/definition/Priorities.rsc
@@ -5,6 +5,7 @@
   which accompanies this distribution, and is available at
   http://www.eclipse.org/legal/epl-v10.html
 }
+@bootstrapParser
 module lang::rascal::grammar::definition::Priorities
 
 extend ParseTree;

--- a/src/org/rascalmpl/library/lang/rascal/grammar/definition/Symbols.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/grammar/definition/Symbols.rsc
@@ -5,6 +5,7 @@
   which accompanies this distribution, and is available at
   http://www.eclipse.org/legal/epl-v10.html
 }
+@bootstrapParser
 module lang::rascal::grammar::definition::Symbols
 
 import lang::rascal::grammar::definition::Literals;

--- a/src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc
@@ -11,6 +11,7 @@
 @contributor{Arnold Lankamp - Arnold.Lankamp@cwi.nl}
 @contributor{Michael Steindorfer - Michael.Steindorfer@cwi.nl - CWI}
 @doc{The syntax definition of Rascal, excluding concrete syntax fragments}
+@bootstrapParser
 module lang::rascal::\syntax::Rascal
 
 lexical BooleanLiteral

--- a/src/org/rascalmpl/library/util/Monitor.rsc
+++ b/src/org/rascalmpl/library/util/Monitor.rsc
@@ -10,6 +10,7 @@
 .Synopsis
 Monitor the progress of a task/job.
 }
+@bootstrapParser
 module util::Monitor
 
 @doc{

--- a/src/org/rascalmpl/semantics/dynamic/Expression.java
+++ b/src/org/rascalmpl/semantics/dynamic/Expression.java
@@ -90,7 +90,10 @@ import org.rascalmpl.types.NonTerminalType;
 import org.rascalmpl.types.RascalTypeFactory;
 import org.rascalmpl.types.TypeReifier;
 import org.rascalmpl.values.IRascalValueFactory;
+import org.rascalmpl.values.RascalFunctionValueFactory;
 import org.rascalmpl.values.RascalValueFactory;
+import org.rascalmpl.values.functions.IFunction;
+import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.SymbolAdapter;
 
 import io.usethesource.vallang.IBool;
@@ -98,6 +101,7 @@ import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IListWriter;
 import io.usethesource.vallang.IMap;
 import io.usethesource.vallang.IMapWriter;
+import io.usethesource.vallang.ISet;
 import io.usethesource.vallang.ISetWriter;
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IString;
@@ -1057,6 +1061,20 @@ public abstract class Expression extends org.rascalmpl.ast.Expression {
 			return new GuardedPattern(eval, this, type, absPat);
 		}
 
+    	private ITree parseObject(IEvaluatorContext eval, IConstructor grammar, ISet filters, ISourceLocation location, char[] input,  boolean allowAmbiguity, boolean hasSideEffects) {
+        	RascalFunctionValueFactory vf = eval.getFunctionValueFactory();
+        	IFunction parser = vf.parser(grammar, vf.bool(allowAmbiguity), vf.bool(hasSideEffects), vf.bool(false), filters);
+
+        	return (ITree) parser.call(vf.string(new String(input)), location);
+    	}
+
+		private ITree parseObject(IEvaluatorContext eval, IConstructor grammar, ISet filters, ISourceLocation location, boolean allowAmbiguity, boolean hasSideEffects) {
+        	RascalFunctionValueFactory vf = eval.getFunctionValueFactory();
+        	IFunction parser = vf.parser(grammar, vf.bool(allowAmbiguity), vf.bool(hasSideEffects), vf.bool(false), filters);
+
+        	return (ITree) parser.call(location, location);
+    	}
+
 		@Override
 		public Result<IValue> interpret(IEvaluator<Result<IValue>> __eval) {
 			
@@ -1087,13 +1105,11 @@ public abstract class Expression extends org.rascalmpl.ast.Expression {
 				IConstructor value = ((IRascalValueFactory) __eval.getValueFactory()).reifiedType(symbol, gr);
             
 				if (result.getStaticType().isString()) {
-					tree = __eval.parseObject(value, VF.set(),
-						this.getLocation(),
+					tree = parseObject(__eval, value, VF.set(), this.getLocation(),
 						((IString) result.getValue()).getValue().toCharArray(), true, false);
 				}
 				else if (result.getStaticType().isSourceLocation()) {
-					tree = __eval.parseObject(__eval, value, VF.set(),
-							((ISourceLocation) result.getValue()), true, false);
+					tree = parseObject(__eval, value, VF.set(), (ISourceLocation) result.getValue(), true, false);
 				}
 				
 				assert tree != null; // because we checked earlier

--- a/src/org/rascalmpl/semantics/dynamic/Import.java
+++ b/src/org/rascalmpl/semantics/dynamic/Import.java
@@ -57,8 +57,6 @@ import org.rascalmpl.interpreter.utils.Names;
 import org.rascalmpl.library.lang.rascal.syntax.RascalParser;
 import org.rascalmpl.parser.ASTBuilder;
 import org.rascalmpl.parser.Parser;
-import org.rascalmpl.parser.ParserGenerator;
-import org.rascalmpl.parser.gtd.IGTD;
 import org.rascalmpl.parser.gtd.exception.ParseError;
 import org.rascalmpl.parser.gtd.exception.UndeclaredNonTerminalException;
 import org.rascalmpl.parser.gtd.result.action.IActionExecutor;
@@ -67,7 +65,9 @@ import org.rascalmpl.parser.uptr.UPTRNodeFactory;
 import org.rascalmpl.parser.uptr.action.NoActionExecutor;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.values.RascalFunctionValueFactory;
 import org.rascalmpl.values.RascalValueFactory;
+import org.rascalmpl.values.functions.IFunction;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.ProductionAdapter;
 import org.rascalmpl.values.parsetrees.SymbolAdapter;
@@ -325,10 +325,6 @@ public abstract class Import {
 	        handleLoadError(heap, env, eval, name, e.getMessage(), e.getLocation(), x);
 	        throw e;
 	    }
-	    catch (ParseError e) {
-	        handleLoadError(heap, env, eval, name, e.getMessage(), e.getLocation(), x);
-	        throw e;
-	    }
 	    catch (StaticError e) {
 	        handleLoadError(heap, env, eval, name, e.getMessage(), e.getLocation(), x);
 	        throw e;
@@ -459,7 +455,21 @@ private static boolean isDeprecated(Module preModule){
       // parse the embedded concrete syntax fragments of the current module
       ITree result = tree;
       if (!eval.getHeap().isBootstrapper() && (needBootstrapParser(data) || (env.definesSyntax() && containsBackTick(data, 0)))) {
-          result = parseFragments(eval, tree, location, env);
+          RascalFunctionValueFactory vf = eval.getFunctionValueFactory();
+          IFunction parsers = null;
+          
+          if (env.getBootstrap()) {
+             parsers = vf.bootstrapParsers();
+          }
+          else {
+            IConstructor dummy = TreeAdapter.getType(tree); // I just need _any_ ok non-terminal
+            IMap syntaxDefinition = env.getSyntaxDefinition();
+            IMap grammar = (IMap) eval.getParserGenerator().getGrammarFromModules(eval.getMonitor(),env.getName(), syntaxDefinition).get("rules");
+            IConstructor reifiedType = vf.reifiedType(dummy, grammar);
+            parsers = vf.parsers(reifiedType, vf.bool(false), vf.bool(false), vf.bool(false), vf.set()); 
+          }
+      
+          result = parseFragments(vf, parsers, tree, location, env);
       }
 
       return result;
@@ -500,16 +510,14 @@ public static void evalImport(IEvaluator<Result<IValue>> eval, IConstructor mod)
    * @param parser is the parser to use for the concrete literals
    * @return parse tree of a module with structured concrete literals, or parse errors
    */
-  public static ITree parseFragments(final IEvaluator<Result<IValue>> eval, IConstructor module, final ISourceLocation location, final ModuleEnvironment env) {
+  public static ITree parseFragments(final RascalFunctionValueFactory vf, final IFunction parsers, IConstructor module, final ISourceLocation location, final ModuleEnvironment env) {
      return (ITree) module.accept(new IdentityTreeVisitor<ImplementationError>() {
-       final IValueFactory vf = eval.getValueFactory();
-       
        @Override
        public ITree visitTreeAppl(ITree tree)  {
          IConstructor pattern = getConcretePattern(tree);
          
          if (pattern != null) {
-           ITree parsedFragment = parseFragment(eval, env, (ITree) TreeAdapter.getArgs(tree).get(0), location);
+           ITree parsedFragment = parseFragment(vf, parsers, (ITree) TreeAdapter.getArgs(tree).get(0), location);
            return TreeAdapter.setArgs(tree, vf.list(parsedFragment));
          }
          else {
@@ -542,99 +550,42 @@ public static void evalImport(IEvaluator<Result<IValue>> eval, IConstructor mod)
      });
   }
   
-  @SuppressWarnings("unchecked")
-  public static IGTD<IConstructor, ITree, ISourceLocation> getParser(IEvaluator<Result<IValue>> eval, ModuleEnvironment currentModule, ISourceLocation caller, IMap grammar, boolean force) {
-    if (currentModule.getBootstrap()) {
-      return new RascalParser();
-    }
-    
-    if (currentModule.hasCachedParser(grammar)) {
-      String className = currentModule.getCachedParser(grammar);
-      Class<?> clazz;
-      for (ClassLoader cl: eval.getClassLoaders()) {
-        try {
-          clazz = cl.loadClass(className);
-          return (IGTD<IConstructor, ITree, ISourceLocation>) clazz.newInstance();
-        } catch (ClassNotFoundException e) {
-          continue;
-        } catch (InstantiationException e) {
-          throw new ImplementationError("could not instantiate " + className + " to valid IGTD parser", e);
-        } catch (IllegalAccessException e) {
-          throw new ImplementationError("not allowed to instantiate " + className + " to valid IGTD parser", e);
-        }
-      }
-      throw new ImplementationError("class for cached parser " + className + " could not be found");
-    }
-
-    ParserGenerator pg = eval.getParserGenerator();
-    IMap definitions = grammar;
-    
-    String parserName = currentModule.getName() + "_" + Math.abs(grammar.hashCode());
-    Class<IGTD<IConstructor, ITree, ISourceLocation>> parser = eval.getHeap().getObjectParser(parserName, definitions);
-
-    if (parser == null || force) {
-        parser = eval.getHeap().getObjectParser(parserName, definitions);
-        if (parser == null || force) {
-          // TODO: this hashCode is not good enough!
-          parser = pg.getNewParser(eval, caller, parserName, definitions);
-          eval.getHeap().storeObjectParser(parserName, definitions, parser);
-        }
-    }
-
-    try {
-      return parser.newInstance();
-    } catch (InstantiationException e) {
-      throw new ImplementationError(e.getMessage(), e);
-    } catch (IllegalAccessException e) {
-      throw new ImplementationError(e.getMessage(), e);
-    } catch (ExceptionInInitializerError e) {
-      throw new ImplementationError(e.getMessage(), e);
-    }
-  }
-  
-  private static ITree parseFragment(IEvaluator<Result<IValue>> eval, ModuleEnvironment env, ITree tree, ISourceLocation uri) {
-    IConstructor symTree = TreeAdapter.getArg(tree, "symbol");
+  private static ITree parseFragment(RascalFunctionValueFactory vf, IFunction parsers, ITree tree, ISourceLocation uri) {
+    ITree symTree = TreeAdapter.getArg(tree, "symbol");
     ITree lit = TreeAdapter.getArg(tree, "parts");
     Map<String, ITree> antiquotes = new HashMap<>();
      
-    IMap syntaxDefinition = env.getSyntaxDefinition();
-    IMap grammar = (IMap) eval.getParserGenerator().getGrammarFromModules(eval.getMonitor(),env.getName(), syntaxDefinition).get("rules");
-    IGTD<IConstructor, ITree, ISourceLocation> parser = env.getBootstrap() ? new RascalParser() : getParser(eval, env, TreeAdapter.getLocation(lit), grammar, false);
-    
     try {
-      String parserMethodName = eval.getParserGenerator().getParserMethodName(symTree);
-      DefaultNodeFlattener<IConstructor, ITree, ISourceLocation> converter = new DefaultNodeFlattener<IConstructor, ITree, ISourceLocation>();
-      UPTRNodeFactory nodeFactory = new UPTRNodeFactory(false);
+      IConstructor reifiedSym = vf.reifiedType(vf.sym2symbol(symTree), vf.map());
     
       SortedMap<Integer,Integer> corrections = new TreeMap<>();
-      char[] input = replaceAntiQuotesByHoles(eval, lit, antiquotes, corrections);
+      char[] input = replaceAntiQuotesByHoles(vf, lit, antiquotes, corrections);
       
-      ITree fragment = (ITree) parser.parse(parserMethodName, uri.getURI(), input, converter, nodeFactory);
+      ITree fragment = (ITree) parsers.call(reifiedSym, vf.string(new String(input)), uri);
       
       // Adjust locations before replacing the holes back to the original anti-quotes,
       // since these anti-quotes already have the right location (!).
-      fragment = (ITree) fragment.accept(new AdjustLocations(corrections, eval.getValueFactory()));
-      fragment = replaceHolesByAntiQuotes(eval, fragment, antiquotes, corrections);
+      fragment = (ITree) fragment.accept(new AdjustLocations(corrections, vf));
+      fragment = replaceHolesByAntiQuotes(vf, fragment, antiquotes, corrections);
       
       
       IConstructor prod = TreeAdapter.getProduction(tree);
       IConstructor sym = ProductionAdapter.getDefined(prod);
       sym = SymbolAdapter.delabel(sym); 
-      IValueFactory vf = eval.getValueFactory();
       prod = ProductionAdapter.setDefined(prod, vf.constructor(RascalValueFactory.Symbol_Label, vf.string("$parsed"), sym));
       return TreeAdapter.setProduction(TreeAdapter.setArg(tree, "parts", fragment), prod);
     }
     catch (ParseError e) {
       ISourceLocation loc = TreeAdapter.getLocation(tree);
-      ISourceLocation src = eval.getValueFactory().sourceLocation(loc.top(), loc.getOffset() + e.getOffset(), loc.getLength(), loc.getBeginLine() + e.getBeginLine() - 1, loc.getEndLine() + e.getEndLine() - 1, loc.getBeginColumn() + e.getBeginColumn(), loc.getBeginColumn() + e.getEndColumn());
-      eval.getMonitor().warning("parse error in concrete syntax: "+ src, src);
+      ISourceLocation src = vf.sourceLocation(loc.top(), loc.getOffset() + e.getOffset(), loc.getLength(), loc.getBeginLine() + e.getBeginLine() - 1, loc.getEndLine() + e.getEndLine() - 1, loc.getBeginColumn() + e.getBeginColumn(), loc.getBeginColumn() + e.getEndColumn());
+      // eval.getMonitor().warning("parse error in concrete syntax: "+ src, src);
       return (ITree) tree.asWithKeywordParameters().setParameter("parseError", src);
     }
     catch (Ambiguous e) {
         ISourceLocation ambLocation = e.getLocation();
         ISourceLocation loc = TreeAdapter.getLocation(tree);
         ISourceLocation src = ambLocation.hasOffsetLength() 
-            ? eval.getValueFactory().sourceLocation(loc.top(), 
+            ? vf.sourceLocation(loc.top(), 
                 loc.getOffset() + ambLocation.getOffset() , 
                 loc.getLength(), 
                 loc.getBeginLine() + ambLocation.getBeginLine() - 1, 
@@ -643,19 +594,19 @@ public static void evalImport(IEvaluator<Result<IValue>> eval, IConstructor mod)
                 loc.getBeginColumn() + ambLocation.getEndColumn()) 
             : loc;
         
-        eval.getMonitor().warning("ambiguity in concrete syntax", src);
+        // eval.getMonitor().warning("ambiguity in concrete syntax", src);
         return (ITree) tree.asWithKeywordParameters().setParameter("parseError", src);
     }
     catch (StaticError e) {
       ISourceLocation loc = TreeAdapter.getLocation(tree);
-      ISourceLocation src = eval.getValueFactory().sourceLocation(loc.top(), loc.getOffset(), loc.getLength(), loc.getBeginLine(), loc.getEndLine(), loc.getBeginColumn(), loc.getBeginColumn());
-      eval.getMonitor().warning(e.getMessage(), e.getLocation());
+      ISourceLocation src = vf.sourceLocation(loc.top(), loc.getOffset(), loc.getLength(), loc.getBeginLine(), loc.getEndLine(), loc.getBeginColumn(), loc.getBeginColumn());
+      // eval.getMonitor().warning(e.getMessage(), e.getLocation());
       return (ITree) tree.asWithKeywordParameters().setParameter("can not parse fragment due to " + e.getMessage(), src);
     }
     catch (UndeclaredNonTerminalException e) {
       ISourceLocation loc = TreeAdapter.getLocation(tree);
-      ISourceLocation src = eval.getValueFactory().sourceLocation(loc.top(), loc.getOffset(), loc.getLength(), loc.getBeginLine(), loc.getEndLine(), loc.getBeginColumn(), loc.getBeginColumn());
-      eval.getMonitor().warning(e.getMessage(), src);
+      ISourceLocation src = vf.sourceLocation(loc.top(), loc.getOffset(), loc.getLength(), loc.getBeginLine(), loc.getEndLine(), loc.getBeginColumn(), loc.getBeginColumn());
+      // eval.getMonitor().warning(e.getMessage(), src);
       return (ITree) tree.asWithKeywordParameters().setParameter("can not parse fragment due to " + e.getMessage(), src);
     }
   }
@@ -725,8 +676,7 @@ public static void evalImport(IEvaluator<Result<IValue>> eval, IConstructor mod)
     }
   }
   
-  private static char[] replaceAntiQuotesByHoles(IEvaluator<Result<IValue>> eval, 
-  		ITree lit, Map<String, ITree> antiquotes, SortedMap<Integer, Integer> corrections ) {
+  private static char[] replaceAntiQuotesByHoles(RascalFunctionValueFactory vf, ITree lit, Map<String, ITree> antiquotes, SortedMap<Integer, Integer> corrections ) {
     IList parts = TreeAdapter.getArgs(lit);
     StringBuilder b = new StringBuilder();
     
@@ -771,7 +721,7 @@ public static void evalImport(IEvaluator<Result<IValue>> eval, IConstructor mod)
       	b.append('\\');
       }
       else if (cons.equals("hole")) {
-        String hole = createHole(eval, part, antiquotes);
+        String hole = createHole(vf, part, antiquotes);
         shift += partLen - hole.length();
 				offset += hole.length();
 				corrections.put(offset, shift);
@@ -782,22 +732,20 @@ public static void evalImport(IEvaluator<Result<IValue>> eval, IConstructor mod)
     return b.toString().toCharArray();
   }
 
-  private static String createHole(IEvaluator<Result<IValue>> ctx, ITree part, Map<String, ITree> antiquotes) {
-    String ph = ctx.getParserGenerator().createHole(part, antiquotes.size());
-    antiquotes.put(ph, part);
-    return ph;
+  private static String createHole(RascalFunctionValueFactory vf, ITree part, Map<String, ITree> antiquotes) {
+    IString ph = vf.createHole(part, vf.integer(antiquotes.size()));
+    antiquotes.put(ph.getValue(), part);
+    return ph.getValue();
   }
 
-  private static ITree replaceHolesByAntiQuotes(final IEvaluator<Result<IValue>> eval, ITree fragment, 
-  		final Map<String, ITree> antiquotes, final SortedMap<Integer,Integer> corrections) {
+  private static ITree replaceHolesByAntiQuotes(final IValueFactory vf, ITree fragment, final Map<String, ITree> antiquotes, final SortedMap<Integer,Integer> corrections) {
       return (ITree) fragment.accept(new IdentityTreeVisitor<ImplementationError>() {
-        private final IValueFactory vf = eval.getValueFactory();
         
         @Override
         public ITree visitTreeAppl(ITree tree)  {
           String cons = TreeAdapter.getConstructorName(tree);
           if (cons == null || !cons.equals("$MetaHole") ) {
-            IListWriter w = eval.getValueFactory().listWriter();
+            IListWriter w = vf.listWriter();
             IList args = TreeAdapter.getArgs(tree);
             for (IValue elem : args) {
               w.append(elem.accept(this));

--- a/src/org/rascalmpl/semantics/dynamic/Import.java
+++ b/src/org/rascalmpl/semantics/dynamic/Import.java
@@ -492,8 +492,6 @@ public static void evalImport(IEvaluator<Result<IValue>> eval, IConstructor mod)
 	  }
   }
   
-  
-
   /**
    * This function will reconstruct a parse tree of a module, where all nested concrete syntax fragments
    * have been parsed and their original flat literal strings replaced by fully structured parse trees.

--- a/src/org/rascalmpl/semantics/dynamic/Module.java
+++ b/src/org/rascalmpl/semantics/dynamic/Module.java
@@ -57,21 +57,6 @@ public abstract class Module {
 			try {
 			  // the header is already evaluated at parse time, 
 			  // including imports and extends and syntax definitions
-//			  getHeader().interpret(eval);
-				for (Tag tag : getHeader().getTags().getTags()) {
-
-					if (((Name.Lexical) tag.getName()).getString().equals("cachedParser")) {
-
-						String tagString = ((TagString.Lexical)tag.getContents()).getString();
-
-						String cachedParser =tagString.substring(1, tagString.length() - 1);
-						
-						// this assumes the cached parser still defines the same
-						// syntax as the current definitions in the module
-						env.setCachedParser(env.getSyntaxDefinition(), cachedParser);
-					}
-				}
-
 			  List<Toplevel> decls = this.getBody().getToplevels();
 			  eval.__getTypeDeclarator().evaluateDeclarations(decls, eval.getCurrentEnvt(), false);
 

--- a/src/org/rascalmpl/values/RascalFunctionValueFactory.java
+++ b/src/org/rascalmpl/values/RascalFunctionValueFactory.java
@@ -14,16 +14,21 @@ package org.rascalmpl.values;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
+import org.rascalmpl.exceptions.ImplementationError;
 import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.exceptions.Throw;
 import org.rascalmpl.interpreter.IEvaluator;
 import org.rascalmpl.interpreter.IEvaluatorContext;
+import org.rascalmpl.interpreter.NullRascalMonitor;
 import org.rascalmpl.interpreter.asserts.Ambiguous;
 import org.rascalmpl.interpreter.control_exceptions.MatchFailed;
 import org.rascalmpl.interpreter.env.Environment;
@@ -32,9 +37,17 @@ import org.rascalmpl.interpreter.result.ICallableValue;
 import org.rascalmpl.interpreter.result.Result;
 import org.rascalmpl.interpreter.result.ResultFactory;
 import org.rascalmpl.interpreter.staticErrors.UndeclaredNonTerminal;
+import org.rascalmpl.parser.ParserGenerator;
+import org.rascalmpl.parser.gtd.IGTD;
 import org.rascalmpl.parser.gtd.exception.ParseError;
 import org.rascalmpl.parser.gtd.exception.UndeclaredNonTerminalException;
 import org.rascalmpl.parser.gtd.io.InputConverter;
+import org.rascalmpl.parser.gtd.recovery.IRecoverer;
+import org.rascalmpl.parser.gtd.result.action.IActionExecutor;
+import org.rascalmpl.parser.gtd.result.out.DefaultNodeFlattener;
+import org.rascalmpl.parser.uptr.UPTRNodeFactory;
+import org.rascalmpl.parser.uptr.action.NoActionExecutor;
+import org.rascalmpl.parser.uptr.action.RascalFunctionActionExecutor;
 import org.rascalmpl.types.NonTerminalType;
 import org.rascalmpl.types.RascalTypeFactory;
 import org.rascalmpl.types.ReifiedType;
@@ -45,8 +58,12 @@ import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.SymbolAdapter;
 import org.rascalmpl.values.parsetrees.TreeAdapter;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
 import io.usethesource.vallang.IBool;
 import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.IMap;
 import io.usethesource.vallang.ISet;
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IString;
@@ -56,6 +73,12 @@ import io.usethesource.vallang.type.Type;
 import io.usethesource.vallang.type.TypeFactory;
 
 public class RascalFunctionValueFactory extends RascalValueFactory {
+    private ParserGenerator generator;
+    private final LoadingCache<IMap, Class<IGTD<IConstructor, ITree, ISourceLocation>>> parserCache = Caffeine.newBuilder()
+        .softValues()
+        .maximumSize(100) // a 100 cached parsers is quit a lot, put this in to make debugging such a case possible
+        .expireAfterAccess(30, TimeUnit.MINUTES) // we clean up unused parsers after 30 minutes
+        .build(grammar -> generateParser(grammar));
     private final IEvaluatorContext ctx;
 
     /** 
@@ -66,6 +89,33 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
     public RascalFunctionValueFactory(IEvaluatorContext ctx) {
         super();
         this.ctx = ctx;
+    }
+    
+    private ParserGenerator getParserGenerator() {
+        if (this.generator == null) {
+            this.generator = ctx.getEvaluator().getParserGenerator();
+        }
+        
+        return generator;
+    }
+
+    private Class<IGTD<IConstructor, ITree, ISourceLocation>> generateParser(IMap grammar) {
+        try {
+            return getParserGenerator().getNewParser(new NullRascalMonitor(), URIUtil.rootLocation("parser-generator"), "$GENERATED_PARSER$" + Math.abs(grammar.hashCode()), grammar);
+        } 
+        catch (ExceptionInInitializerError e) {
+            throw new ImplementationError(e.getMessage(), e);
+        }
+    }
+
+    private IGTD<IConstructor, ITree, ISourceLocation> getObjectParser(IMap iMap) {
+        Class<IGTD<IConstructor, ITree, ISourceLocation>> parser = parserCache.get(iMap);
+        try {
+            return parser.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException e) {
+            throw new ImplementationError("could not instantiate generated parser", e);
+        } 
     }
     
     @Override
@@ -163,7 +213,14 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
             tf.tupleType(tf.valueType(), tf.sourceLocationType()), 
             tf.tupleEmpty());
         
-        return function(functionType, new ParseFunction(ctx, reifiedGrammar, allowAmbiguity, hasSideEffects, firstAmbiguity, filters));
+        IGTD<IConstructor, ITree, ISourceLocation> parser = getObjectParser((IMap) ((IConstructor) reifiedGrammar).get("definitions"));
+        IConstructor startSort = (IConstructor) ((IConstructor) reifiedGrammar).get("symbol");
+
+        checkPreconditions(startSort, reifiedGrammar.getType());
+
+        String name = getParserGenerator().getParserMethodName(startSort);
+
+        return function(functionType, new ParseFunction(ctx.getValueFactory(), ctx.getCurrentAST().getLocation(), parser, name, allowAmbiguity, hasSideEffects, firstAmbiguity, filters));
     }
     
     @Override
@@ -173,34 +230,54 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
         
         // here the return type is parametrized and instantiated when the parser function is called with the
         // given start non-terminal:
-        
         Type parameterType = tf.parameterType("U", RascalValueFactory.Tree);
         
         Type functionType = tf.functionType(parameterType,
             tf.tupleType(rtf.reifiedType(parameterType), tf.valueType(), tf.sourceLocationType()), 
             tf.tupleEmpty());
+
+        IGTD<IConstructor, ITree, ISourceLocation> parser = getObjectParser((IMap) ((IConstructor) reifiedGrammar).get("definitions"));
+        IConstructor startSort = (IConstructor) ((IConstructor) reifiedGrammar).get("symbol");
+
+        checkPreconditions(startSort, reifiedGrammar.getType());    
         
-        return function(functionType, new ParametrizedParseFunction(ctx, reifiedGrammar, allowAmbiguity, hasSideEffects, firstAmbiguity, filters));
+        return function(functionType, new ParametrizedParseFunction(() -> getParserGenerator(), this, ctx.getCurrentAST().getLocation(), parser, allowAmbiguity, hasSideEffects, firstAmbiguity, filters));
+    }
+
+    private static IConstructor checkPreconditions(IValue start, Type reified) {
+        if (!(reified instanceof ReifiedType)) {
+           throw RuntimeExceptionFactory.illegalArgument(start, "A reified type is required instead of " + reified);
+        }
+        
+        Type nt = reified.getTypeParameters().getFieldType(0);
+        
+        if (!(nt instanceof NonTerminalType)) {
+            throw RuntimeExceptionFactory.illegalArgument(start, "A non-terminal type is required instead of  " + nt);
+        }
+        
+        return (IConstructor) start;
     }
     
     /**
-     * This class wraps the parseObject methods of the Evaluator by presenting it as an implementation of IFunction.
+     * This class wraps generated parser classes by presenting them as implementations of IFunction.
      * In this way library builtins can use the parser generator functionality of the Evaluator without knowing about
      * the internals of parser generation and parser caching.
      */
     static private class ParseFunction implements BiFunction<IValue[], Map<String, IValue>, IValue> {
-        protected final IEvaluatorContext ctx;
-        protected final IValue grammar;
         protected final ISet filters;
         protected final IValueFactory vf;
         protected final boolean allowAmbiguity;
         protected final boolean hasSideEffects;
         protected final boolean firstAmbiguity;
+        protected final IGTD<IConstructor, ITree, ISourceLocation> parser;
+        protected final String methodName;
+        protected final ISourceLocation caller;
         
-        public ParseFunction(IEvaluatorContext ctx, IValue grammar, IBool allowAmbiguity, IBool hasSideEffects, IBool firstAmbiguity, ISet filters) {
-            this.ctx = ctx;
-            this.vf = ctx.getValueFactory();
-            this.grammar = grammar;
+        public ParseFunction(IValueFactory vf, ISourceLocation caller, IGTD<IConstructor, ITree, ISourceLocation> parser, String methodName, IBool allowAmbiguity, IBool hasSideEffects, IBool firstAmbiguity, ISet filters) {
+            this.vf = vf;
+            this.caller = caller;
+            this.parser = parser;
+            this.methodName = methodName;
             this.filters = filters;
             this.allowAmbiguity = allowAmbiguity.getValue() || firstAmbiguity.getValue();
             this.hasSideEffects = hasSideEffects.getValue();
@@ -215,10 +292,10 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
 
             if (firstAmbiguity) {
                 if (parameters[0].getType().isString()) {
-                    return firstAmbiguity(grammar, (IString) parameters[0], ctx);
+                    return firstAmbiguity(methodName, (IString) parameters[0]);
                 }
                 else if (parameters[0].getType().isSourceLocation()) {
-                    return firstAmbiguity(grammar, (ISourceLocation) parameters[0], ctx);
+                    return firstAmbiguity(methodName, (ISourceLocation) parameters[0]);
                 }
             }
             else {
@@ -227,10 +304,10 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
                 }
 
                 if (parameters[0].getType().isString()) {
-                    return parse(grammar, filters, (IString) parameters[0], (ISourceLocation) parameters[1], allowAmbiguity, hasSideEffects, ctx);
+                    return parse(methodName, filters, (IString) parameters[0], (ISourceLocation) parameters[1], allowAmbiguity, hasSideEffects);
                 }
                 else if (parameters[0].getType().isSourceLocation()) {
-                    return parse(grammar, filters, (ISourceLocation) parameters[0], (ISourceLocation) parameters[1], allowAmbiguity, hasSideEffects, ctx);
+                    return parse(methodName, filters, (ISourceLocation) parameters[0], (ISourceLocation) parameters[1], allowAmbiguity, hasSideEffects);
                 }
             }
 
@@ -238,18 +315,16 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
         }
 
         protected Throw fail(IValue... parameters) {
-            return RuntimeExceptionFactory.callFailed(URIUtil.rootLocation("unknown"), Arrays.stream(parameters).collect(ctx.getValueFactory().listWriter()));
+            return RuntimeExceptionFactory.callFailed(caller, Arrays.stream(parameters).collect(vf.listWriter()));
         }
         
-        protected IValue parse(IValue start, ISet filters, IString input,  ISourceLocation origin, boolean allowAmbiguity, boolean hasSideEffects, IEvaluatorContext ctx) {
+        protected IValue parse(String methodName, ISet filters, IString input,  ISourceLocation origin, boolean allowAmbiguity, boolean hasSideEffects) {
             try {
-                Type reified = start.getType();
                 if (origin == null) {
                     origin = URIUtil.rootLocation("unknown");
                 }
                 
-                IConstructor grammar = checkPreconditions(start, reified);
-                return ctx.getEvaluator().parseObject(grammar, filters, origin, input.getValue().toCharArray(), allowAmbiguity, hasSideEffects);
+                return parseObject(methodName, origin, input.getValue().toCharArray(), allowAmbiguity, hasSideEffects, filters);
             }
             catch (ParseError pe) {
                 ISourceLocation errorLoc = pe.getLocation();
@@ -260,39 +335,33 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
                 throw RuntimeExceptionFactory.ambiguity(e.getLocation(), printSymbol(TreeAdapter.getType(tree)), vf.string(TreeAdapter.yield(tree)));
             }
             catch (UndeclaredNonTerminalException e){
-                throw new UndeclaredNonTerminal(e.getName(), e.getClassName(), ctx.getCurrentAST());
+                throw new UndeclaredNonTerminal(e.getName(), e.getClassName(), caller);
             }
         }
         
-        protected IValue firstAmbiguity(IValue start, IString input, IEvaluatorContext ctx) {
-            Type reified = start.getType();
-            IConstructor grammar = checkPreconditions(start, reified);
-            
+        protected IValue firstAmbiguity(String methodName, IString input) {
             try {
-                return ctx.getEvaluator().parseObject(grammar, vf.set(), URIUtil.invalidLocation(), input.getValue().toCharArray(), false, false);
+                return parseObject(methodName, URIUtil.invalidLocation(), input.getValue().toCharArray(), false, false, vf.set());
             }
             catch (ParseError pe) {
                 ISourceLocation errorLoc = pe.getLocation();
-                throw RuntimeExceptionFactory.parseError(errorLoc, ctx.getCurrentAST(), ctx.getStackTrace());
+                throw RuntimeExceptionFactory.parseError(errorLoc);
             }
             catch (Ambiguous e) {
                 return e.getTree();
             }
             catch (UndeclaredNonTerminalException e){
-                throw new UndeclaredNonTerminal(e.getName(), e.getClassName(), ctx.getCurrentAST());
+                throw new UndeclaredNonTerminal(e.getName(), e.getClassName(), caller);
             }
         }
         
-        protected IValue firstAmbiguity(IValue start, ISourceLocation input, IEvaluatorContext ctx) {
-            Type reified = start.getType();
-            IConstructor grammar = checkPreconditions(start, reified);
-            
+        protected IValue firstAmbiguity(String methodName, ISourceLocation input) {
             try {
-                return ctx.getEvaluator().parseObject(grammar, vf.set(), input, readAll(input), false, false);
+                return parseObject(methodName, input, readAll(input), false, false, vf.set());
             }
             catch (ParseError pe) {
                 ISourceLocation errorLoc = pe.getLocation();
-                throw RuntimeExceptionFactory.parseError(errorLoc, ctx.getCurrentAST(), ctx.getStackTrace());
+                throw RuntimeExceptionFactory.parseError(errorLoc);
             }
             catch (IOException e) {
                 throw RuntimeExceptionFactory.io("IO error: " + e);
@@ -301,7 +370,7 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
                 return e.getTree();
             }
             catch (UndeclaredNonTerminalException e){
-                throw new UndeclaredNonTerminal(e.getName(), e.getClassName(), ctx.getCurrentAST());
+                throw new UndeclaredNonTerminal(e.getName(), e.getClassName(), caller);
             }
         }
 
@@ -315,20 +384,17 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
             return vf.string(SymbolAdapter.toString(symbol, false));
         }
 
-        protected IValue parse(IValue start, ISet filters, ISourceLocation input, ISourceLocation origin, boolean allowAmbiguity, boolean hasSideEffects, IEvaluatorContext ctx) {
-            Type reified = start.getType();
-            IConstructor grammar = checkPreconditions(start, reified);
-            
+        protected IValue parse(String methodName, ISet filters, ISourceLocation input, ISourceLocation origin, boolean allowAmbiguity, boolean hasSideEffects) {
             if (origin == null) {
                 origin = input;
             }
             
             try {
-                return ctx.getEvaluator().parseObject(grammar, vf.set(), input, readAll(input), allowAmbiguity, hasSideEffects);
+                return parseObject(methodName, input, readAll(input), allowAmbiguity, hasSideEffects, filters);
             }
             catch (ParseError pe) {
                 ISourceLocation errorLoc = pe.getLocation();
-                throw RuntimeExceptionFactory.parseError(errorLoc, ctx.getCurrentAST(), ctx.getStackTrace());
+                throw RuntimeExceptionFactory.parseError(errorLoc);
             }
             catch (IOException e) {
                 throw RuntimeExceptionFactory.io("IO error: " + e);
@@ -338,23 +404,33 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
                 throw RuntimeExceptionFactory.ambiguity(e.getLocation(), printSymbol(TreeAdapter.getType(tree)), vf.string(TreeAdapter.yield(tree)));
             }
             catch (UndeclaredNonTerminalException e){
-                throw new UndeclaredNonTerminal(e.getName(), e.getClassName(), ctx.getCurrentAST());
+                throw new UndeclaredNonTerminal(e.getName(), e.getClassName(), caller);
             }
         }
 
-        private static IConstructor checkPreconditions(IValue start, Type reified) {
-            if (!(reified instanceof ReifiedType)) {
-               throw RuntimeExceptionFactory.illegalArgument(start, "A reified type is required instead of " + reified);
-            }
-            
-            Type nt = reified.getTypeParameters().getFieldType(0);
-            
-            if (!(nt instanceof NonTerminalType)) {
-                throw RuntimeExceptionFactory.illegalArgument(start, "A non-terminal type is required instead of  " + nt);
-            }
-            
-            return (IConstructor) start;
+        private ITree parseObject(String methodName, ISourceLocation location, char[] input,  boolean allowAmbiguity, boolean hasSideEffects,  ISet filters) {
+            IActionExecutor<ITree> exec = filters.isEmpty() ?  new NoActionExecutor() : new RascalFunctionActionExecutor(filters, !hasSideEffects);
+
+            return (ITree) parser.parse(methodName, location.getURI(), input, exec, new DefaultNodeFlattener<IConstructor, ITree, ISourceLocation>(), new UPTRNodeFactory(allowAmbiguity), (IRecoverer<IConstructor>) null);
         }
+
+        // private IConstructor parseObject(ISet filters, ISourceLocation location,  boolean allowAmbiguity, boolean hasSideEffects) {
+        //     try {
+        //         char[] input = getResourceContent(location);
+        //         return parseObject(location, input, allowAmbiguity, hasSideEffects, filters);
+        //     }
+        //     catch (IOException e) {
+        //         throw RuntimeExceptionFactory.io(vf.string(e.getMessage()));
+        //     }
+        // }
+
+        // private char[] getResourceContent(ISourceLocation location) throws IOException{
+        //     try (Reader textStream = URIResolverRegistry.getInstance().getCharacterReader(location)) {
+        //         return InputConverter.toChar(textStream);
+        //     }
+        // }
+
+        
     }
     
     /**
@@ -366,9 +442,11 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
      * parameter for the start-nonterminal.
      */
     static private class ParametrizedParseFunction extends ParseFunction {
-        
-        public ParametrizedParseFunction(IEvaluatorContext ctx, IValue grammar, IBool allowAmbiguity, IBool hasSideEffects, IBool firstAmbiguity, ISet filters) {
-            super(ctx, grammar, allowAmbiguity, hasSideEffects, firstAmbiguity, filters);
+        private Supplier<ParserGenerator> generator;
+
+        public ParametrizedParseFunction(Supplier<ParserGenerator> generator, IValueFactory vf, ISourceLocation caller, IGTD<IConstructor, ITree, ISourceLocation> parser, IBool allowAmbiguity, IBool hasSideEffects, IBool firstAmbiguity, ISet filters) {
+            super(vf, caller, parser, null, allowAmbiguity, hasSideEffects, firstAmbiguity, filters);
+            this.generator = generator;
         }
         
         @Override
@@ -377,28 +455,32 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
                 throw fail(parameters);
             }
 
+            IConstructor startSort = (IConstructor) ((IConstructor) parameters[0]).get("symbol");
+
+            if (!(parameters[0].getType() instanceof ReifiedType)) {
+                throw fail(parameters);
+            }
+
+            String name = generator.get().getParserMethodName(startSort);
+
             if (firstAmbiguity) {
                 if (parameters[1].getType().isString()) {
-                    return firstAmbiguity(parameters[0], (IString) parameters[1], ctx);
+                    return firstAmbiguity(name, (IString) parameters[1]);
                 }
                 else if (parameters[1].getType().isSourceLocation()) {
-                    return firstAmbiguity(parameters[0], (ISourceLocation) parameters[1], ctx);
+                    return firstAmbiguity(name, (ISourceLocation) parameters[1]);
                 }
             }
             else {
-                if (!(parameters[0].getType() instanceof ReifiedType)) {
-                    throw fail(parameters);
-                }
-
                 if (!parameters[2].getType().isSourceLocation()) {
                     throw fail(parameters); 
                 }
 
                 if (parameters[1].getType().isString()) {
-                    return parse(parameters[0], filters, (IString) parameters[1], (ISourceLocation) parameters[2], allowAmbiguity, hasSideEffects, ctx);
+                    return parse(name, filters, (IString) parameters[1], (ISourceLocation) parameters[2], allowAmbiguity, hasSideEffects);
                 }
                 else if (parameters[1].getType().isSourceLocation()) {
-                    return parse(parameters[0], filters, (ISourceLocation) parameters[1], (ISourceLocation) parameters[2], allowAmbiguity, hasSideEffects, ctx);
+                    return parse(name, filters, (ISourceLocation) parameters[1], (ISourceLocation) parameters[2], allowAmbiguity, hasSideEffects);
                 }
             }
 


### PR DESCRIPTION
This makes the parser/parsers function generator more like the compiled
setting. The caching is done completely inside the implementation of the
IRascalValueFactory. The parser closures capture the generated parser
classes directly. This means that right now `parsers` can only be called
with a non-terminal that was a part of the original grammar that the
parser was generated with. A side-effect of this refactoring is that
there are now two parser caches in the current interpreter. Have to
see what this means for memory efficiency before deciding to rewrite
the implementation of the `Import` class and parse concrete fragments
with the new parser methods instead of the old implementation.

This commit also removes all locking around the execution of a
generated parser, if this parser is called from outside of the
interpreter context (such as in the LSP). When the parser function
is called from another Rascal function, then normal interpreter locking
applies.
