### PR TITLE
Made java version of unsetRec

### DIFF
--- a/src/org/rascalmpl/library/Node.rsc
+++ b/src/org/rascalmpl/library/Node.rsc
@@ -148,9 +148,8 @@ public &T <: node delAnnotations(&T <: node x) = unset(x);
 .Synopsis
 Recursively reset all keyword parameters of the node and its children back to their default.
 }
-public &T unsetRec(&T x) = visit(x) { 
-  case node n => unset(n) 
-};
+@javaClass{org.rascalmpl.library.Prelude}
+public java &T unsetRec(&T x);
 
 @Deprecated{Use `unsetRec(x)`}
 public &T delAnnotationsRec(&T x) = unsetRec(x);

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -101,6 +101,7 @@ import org.rascalmpl.values.parsetrees.visitors.TreeVisitor;
 import io.usethesource.vallang.IBool;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IDateTime;
+import io.usethesource.vallang.IExternalValue;
 import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.IListWriter;
@@ -125,6 +126,9 @@ import io.usethesource.vallang.io.binary.stream.IValueOutputStream.CompressionRa
 import io.usethesource.vallang.type.Type;
 import io.usethesource.vallang.type.TypeFactory;
 import io.usethesource.vallang.type.TypeStore;
+import io.usethesource.vallang.visitors.BottomUpTransformer;
+import io.usethesource.vallang.visitors.IValueVisitor;
+import io.usethesource.vallang.visitors.IdentityVisitor;
 
 public class Prelude {
 	private static final int FILE_BUFFER_SIZE = 8 * 1024;
@@ -2230,6 +2234,26 @@ public class Prelude {
     public INode unset(INode node) {
         return  node.mayHaveKeywordParameters() ? node.asWithKeywordParameters().unsetAll() : node;
     }
+
+	public IValue unsetRec(IValue val) {
+		return val.accept(new BottomUpTransformer<>(new IdentityVisitor<RuntimeException>() {
+			@Override
+			public IValue visitConstructor(IConstructor o) throws RuntimeException {
+				return unset(o);
+			}
+			@Override
+			public IValue visitNode(INode o) throws RuntimeException {
+				return unset(o);
+			}
+			@Override
+			public IValue visitExternal(IExternalValue o) throws RuntimeException {
+				if (o instanceof INode) {
+					return unset((INode)o);
+				}
+				return o;
+			}
+		}, rascalValues));
+	}
     
     public INode arbNode() {
         return (INode) createRandomValue(TypeFactory.getInstance().nodeType(), 1 + random.nextInt(5), 1 + random.nextInt(5));


### PR DESCRIPTION
As discussed in #1639 the `unsetRec` function is slowing down the parser generator. This PR rewrites it as a java visitor.

On performance site: generating rascal-parser on current main: 24s (after running it a few time). This change: 9s. 

This should fix #1639 until we get rid of the interpreter ;)