### PR TITLE
Augmented the entry "Program"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.28.3-SNAPSHOT</version>
+    <version>0.28.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/org/rascalmpl/courses/Rascal/Declarations/Program/Program.md
+++ b/src/org/rascalmpl/courses/Rascal/Declarations/Program/Program.md
@@ -16,25 +16,18 @@ A Rascal program consists of a number of ((Declarations-Module))s.
 
 A Rascal program consists of a number of ((Module Declarations)), each stored in a separate file with the extension `.rsc`.
 
-Throughout a Rascal program, comments are prefixed by `//` and the language also provides more meaningful code comments, 
-described in ((Doc Annotations)). 
+A Rascal program can have `main()` functions declared as its entry point. The execution context decides which main function will run, by selecting  main ((Module)) from which the `main` function is chosen.
 
-A Rascal program can have *one* `main()` function declared as its entry point.
-
-Just like any other Rascal function, `main()` has typed arguments and a return type, but unlike other functions, the 
-keyword arguments of `main()` can be automatically translated from same name parameters passed at the command line.
+Just like any other Rascal function, `main()` has typed arguments and a return type, but unlike other functions, the keyword arguments of `main()` can be automatically translated from same name parameters passed at the command line.
 
 There are two variants of `main()`:
 
-1. Accepting just one argument of type `list[str]`
-2. Accepting keyword arguments of varying types
+1. Accepting just one positional argument of type `list[str]`: `int main(list[str] arguments) { ... }`
+2. Accepting keyword arguments of varying types: `int main(str name="", int age=-1) { ... }`
 
-In the first case, the declaration of `main()`, its arguments and  their effect are similar to the way ``main()`` is declared 
-and used in languages such as C and Java. That is, any command-line arguments are passed to the program without any further 
-processing as an array of strings. 
+In the first case, the declaration of `main()`, its arguments and  their effect are similar to the way ``main()`` is declared and used in languages such as C and Java. That is, any command-line arguments are passed to the program without any further processing as an array of strings. 
 
-But in the second case, any arguments to `main()` are automatically [marshalled](https://en.wikipedia.org/wiki/Marshalling_(computer_science)) 
-to their named keyword counterparts and get validated according to their declared type.
+But in the second case, any arguments to `main()` are automatically [marshalled](https://en.wikipedia.org/wiki/Marshalling_(computer_science)) to their named keyword counterparts and get validated according to their declared type.
 
 #### Examples
 
@@ -43,7 +36,7 @@ describing each of the example programs below are placed in the same directory a
 
 1. Command line arguments as a list of string values
 
-   ```
+   ```rascal
    module main_args_as_list
 
    import IO;
@@ -56,7 +49,7 @@ describing each of the example programs below are placed in the same directory a
 
    Calling this program with:
 
-   ```
+   ```bash
    > java -jar rascal-shell-stable.jar main_args_as_list.rsc -p1 1 -p2 2 -p3 3
    ```
 
@@ -68,7 +61,7 @@ describing each of the example programs below are placed in the same directory a
 
 2. Command line arguments as named keywords of varying types.
 
-   ```
+   ```rascal
    module main_args_as_kwd
    
    import IO;
@@ -88,12 +81,11 @@ describing each of the example programs below are placed in the same directory a
    }
    ```
 
-   Notice here, as Rascal is a *value-oriented language*, all keyword arguments must have a default value 
-   (for more information see ((Immutable Values))).
+   Notice here, as Rascal is a *value-oriented language*, with no concept of `null`, all keyword arguments must have a default value.
 
    Calling this program with:
 
-   ```
+   ```bash
    > java -jar rascal-shell-stable.jar main_args_as_kwd.rsc
    ```
 
@@ -110,7 +102,7 @@ describing each of the example programs below are placed in the same directory a
    Now, every keyword argument to ``main()`` can be set at the comand line with its 
    "name". For example, calling the same program with:
 
-   ```
+   ```bash
    > java -jar rascal-shell-stable.jar main_args_as_kwd.rsc -b Blue
    ```
 
@@ -126,7 +118,7 @@ describing each of the example programs below are placed in the same directory a
 
    And calling it with:
 
-   ```
+   ```bash
    > java -jar rascal-shell-stable.jar main_args_as_kwd.rsc -c -d 1 2 3 4 5 -e \|file:///blue.tst\|
    ```
 
@@ -151,7 +143,7 @@ describing each of the example programs below are placed in the same directory a
    in the command line in the same order they are defined in `main()`. Therefore, 
    the following call *will produce an error*:
 
-   ```
+   ```bash
    > java -jar rascal-shell-stable.jar main_args_as_kwd.rsc SomeString
    ```
 
@@ -160,9 +152,11 @@ describing each of the example programs below are placed in the same directory a
 * Keyword arguments offer automatic data marshalling and validation from 
   their command line format to valid values according to a keyword's defined
   data type. No extra libraries are required.
-
+* With keyword arguments the definition of optional parameters is easy.
+* With keyword arguments the user of a main function can get basic instructions using `-help` or `-?`
 
 #### Pitfalls
 
+* If keyword parameters are not optional but required, the programmer must check this explicity.
 * Mandatory positional arguments require special handling.
 

--- a/src/org/rascalmpl/courses/Rascal/Declarations/Program/Program.md
+++ b/src/org/rascalmpl/courses/Rascal/Declarations/Program/Program.md
@@ -16,10 +16,141 @@ A Rascal program consists of a number of ((Declarations-Module))s.
 
 A Rascal program consists of a number of ((Module Declarations)), each stored in a separate file with extension `.rsc`.
 
+Rascal code comments are prefixed with `//`.
+
+A Rascal program can have a `main()` function declared as its entry point.
+
+Just like any other Rascal function, `main()` has arguments and a return type, 
+but unlike other functions, the arguments of `main()` have a special interpreation.
+
+There are two forms of `main()`:
+
+1. Accepting just one argument of type `list[str]`.
+2. Accepting keyword arguments of varying types
+
+In the first case, the declaration of `main()`, its arguments and 
+their effect is similar to languages such as C and Java, any command-line 
+arguments are passed to the program without any further processing as a 
+list of strings.
+
+In the second case, any arguments to `main()` are [marshalled](https://en.wikipedia.org/wiki/Marshalling_(computer_science)) to and from their named keyword 
+counterparts as well as validated.
 
 #### Examples
 
+1. Command line arguments as a list of string values
+
+   ```
+   module main_args_as_list
+
+   import IO;
+
+   int main(list[str] args){
+       println(args);
+       return 0;
+   }
+   ```
+
+   Calling this program with:
+
+   ```
+   > java -jar rascal.jar main_args_as_list.rsc -p1 1 -p2 2 -p3 3
+   ```
+
+   Would produce:
+
+   ```
+   ["-p1","1","-p2","2","-p3","3"]
+   ```
+
+2. Command line arguments as named keywords of varying types.
+
+   ```
+   module main_args_as_kwd
+   
+   import IO;
+
+   int main(int a=0, 
+   	    str b="", 
+	    bool c=false, 
+	    list[int] d=[],
+	    loc e=|file:///|){
+
+       println(a);
+       println(b);
+       println(c);
+       println(d);
+       println(e);
+       return 0;
+   }
+   ```
+
+   Notice here, all keyword arguments require a default value as per Rascal's
+   paradigm.
+
+   Calling this program with:
+
+   ```
+   > java -jar rascal.jar main_args_as_kwd.rsc
+   ```
+
+   Would produce:
+
+   ```
+   0
+
+   false
+   []
+   |file:///|
+   ```
+
+   Now, every keyword argument can be set at the comand line with its 
+   "name". For example, calling the same program with:
+
+   ```
+   > java -jar rascal.jar main_args_as_kwd.rsc -b Blue
+   ```
+
+   Would produce:
+
+   ```
+   0
+   blue
+   false
+   []
+   |file:///|
+   ```
+
+   And calling it with:
+
+   ```
+   > java -jar rascal.jar main_args_as_kwd.rsc -c -d 1 2 3 4 5 -e \|file:///blue.tst\|
+   ```
+
+   Would produce:
+
+   ```
+   0
+
+   true
+   [1,2,3,4,5]
+   |file:///blue.txt|
+   ```
+
+   Notice here that `-c`, being of type Bool, was simply specified in the 
+   command line and that was enough to toggle its value to `true`.
+   Notice also that `-d` has already been transformed to a list of integers 
+   as well as location.
+   
+
+
 #### Benefits
 
+* Keyword arguments offer automatic data marshalling and validation from 
+  their command line format to valid values according to a keyword's defined
+  data type.
+
 #### Pitfalls
+
+* Mandatory arguments require special handling
 

--- a/src/org/rascalmpl/courses/Rascal/Declarations/Program/Program.md
+++ b/src/org/rascalmpl/courses/Rascal/Declarations/Program/Program.md
@@ -14,29 +14,32 @@ A Rascal program consists of a number of ((Declarations-Module))s.
 
 #### Description
 
-A Rascal program consists of a number of ((Module Declarations)), each stored in a separate file with extension `.rsc`.
+A Rascal program consists of a number of ((Module Declarations)), each stored in a separate file with the extension `.rsc`.
 
-Rascal code comments are prefixed with `//`.
+Throughout a Rascal program, comments are prefixed by `//` and the language also provides more meaningful code comments, 
+described in ((Doc Annotations)). 
 
-A Rascal program can have a `main()` function declared as its entry point.
+A Rascal program can have *one* `main()` function declared as its entry point.
 
-Just like any other Rascal function, `main()` has arguments and a return type, 
-but unlike other functions, the arguments of `main()` have a special interpreation.
+Just like any other Rascal function, `main()` has typed arguments and a return type, but unlike other functions, the 
+keyword arguments of `main()` can be automatically translated from same name parameters passed at the command line.
 
-There are two forms of `main()`:
+There are two variants of `main()`:
 
-1. Accepting just one argument of type `list[str]`.
+1. Accepting just one argument of type `list[str]`
 2. Accepting keyword arguments of varying types
 
-In the first case, the declaration of `main()`, its arguments and 
-their effect is similar to languages such as C and Java, any command-line 
-arguments are passed to the program without any further processing as a 
-list of strings.
+In the first case, the declaration of `main()`, its arguments and  their effect are similar to the way ``main()`` is declared 
+and used in languages such as C and Java. That is, any command-line arguments are passed to the program without any further 
+processing as an array of strings. 
 
-In the second case, any arguments to `main()` are [marshalled](https://en.wikipedia.org/wiki/Marshalling_(computer_science)) to and from their named keyword 
-counterparts as well as validated.
+But in the second case, any arguments to `main()` are automatically [marshalled](https://en.wikipedia.org/wiki/Marshalling_(computer_science)) 
+to their named keyword counterparts and get validated according to their declared type.
 
 #### Examples
+
+In the following examples, it is assumed that the user has access to the ``rascal.jar`` file and that the files with the code
+describing each of the example programs below are placed in the same directory as the ``rascal.jar`` file.
 
 1. Command line arguments as a list of string values
 
@@ -85,8 +88,8 @@ counterparts as well as validated.
    }
    ```
 
-   Notice here, all keyword arguments require a default value as per Rascal's
-   paradigm.
+   Notice here, as Rascal is a *value-oriented language*, all keyword arguments must have a default value 
+   (for more information see ((Immutable Values))).
 
    Calling this program with:
 
@@ -104,7 +107,7 @@ counterparts as well as validated.
    |file:///|
    ```
 
-   Now, every keyword argument can be set at the comand line with its 
+   Now, every keyword argument to ``main()`` can be set at the comand line with its 
    "name". For example, calling the same program with:
 
    ```
@@ -137,20 +140,29 @@ counterparts as well as validated.
    |file:///blue.txt|
    ```
 
-   Notice here that `-c`, being of type Bool, was simply specified in the 
-   command line and that was enough to toggle its value to `true`.
-   Notice also that `-d` has already been transformed to a list of integers 
-   as well as location.
-   
+   Notice here that `-c`, being of type `bool`, was simply specified in the 
+   command line as a flag and that was enough to set its value to `true`.
+   Notice also that `-d` has already been transformed to a list of integers
+   as per its specification. The same applies for `e`, which is of type 
+   location, although the "pipe" characters might require escaping.
 
+   Finally, if no keyword parameters are passed on the command line (i.e. no command line 
+   argument is prefixed by a `-` character), the arguments are assumed to be given 
+   in the command line in the same order they are defined in `main()`. Therefore, 
+   the following call *will produce an error*:
+
+   ```
+   > java -jar rascal.jar main_args_as_kwd.rsc SomeString
+   ```
 
 #### Benefits
 
 * Keyword arguments offer automatic data marshalling and validation from 
   their command line format to valid values according to a keyword's defined
-  data type.
+  data type. No extra libraries are required.
+
 
 #### Pitfalls
 
-* Mandatory arguments require special handling
+* Mandatory positional arguments require special handling.
 

--- a/src/org/rascalmpl/courses/Rascal/Declarations/Program/Program.md
+++ b/src/org/rascalmpl/courses/Rascal/Declarations/Program/Program.md
@@ -38,8 +38,8 @@ to their named keyword counterparts and get validated according to their declare
 
 #### Examples
 
-In the following examples, it is assumed that the user has access to the ``rascal.jar`` file and that the files with the code
-describing each of the example programs below are placed in the same directory as the ``rascal.jar`` file.
+In the following examples, it is assumed that the user has access to the ``rascal-shell-stable.jar`` file and that the files with the code
+describing each of the example programs below are placed in the same directory as the ``.jar`` file for simplicity.
 
 1. Command line arguments as a list of string values
 
@@ -57,7 +57,7 @@ describing each of the example programs below are placed in the same directory a
    Calling this program with:
 
    ```
-   > java -jar rascal.jar main_args_as_list.rsc -p1 1 -p2 2 -p3 3
+   > java -jar rascal-shell-stable.jar main_args_as_list.rsc -p1 1 -p2 2 -p3 3
    ```
 
    Would produce:
@@ -94,7 +94,7 @@ describing each of the example programs below are placed in the same directory a
    Calling this program with:
 
    ```
-   > java -jar rascal.jar main_args_as_kwd.rsc
+   > java -jar rascal-shell-stable.jar main_args_as_kwd.rsc
    ```
 
    Would produce:
@@ -111,7 +111,7 @@ describing each of the example programs below are placed in the same directory a
    "name". For example, calling the same program with:
 
    ```
-   > java -jar rascal.jar main_args_as_kwd.rsc -b Blue
+   > java -jar rascal-shell-stable.jar main_args_as_kwd.rsc -b Blue
    ```
 
    Would produce:
@@ -127,7 +127,7 @@ describing each of the example programs below are placed in the same directory a
    And calling it with:
 
    ```
-   > java -jar rascal.jar main_args_as_kwd.rsc -c -d 1 2 3 4 5 -e \|file:///blue.tst\|
+   > java -jar rascal-shell-stable.jar main_args_as_kwd.rsc -c -d 1 2 3 4 5 -e \|file:///blue.tst\|
    ```
 
    Would produce:
@@ -152,7 +152,7 @@ describing each of the example programs below are placed in the same directory a
    the following call *will produce an error*:
 
    ```
-   > java -jar rascal.jar main_args_as_kwd.rsc SomeString
+   > java -jar rascal-shell-stable.jar main_args_as_kwd.rsc SomeString
    ```
 
 #### Benefits


### PR DESCRIPTION
Hello

I have made an attempt to augment the "Rascal Language Reference"/Declarations/Program entry by adding 2 more elements: How to document code and what is a program's entry point (`main()`) and its variants.

For the code documentation part, it might sound simplistic but this was one of the things I had to actively search the documentation on how to do it. The code examples (beginning with "Hello World") do not contain comments all the way until we hit "Colored Trees".  They do contain annotations but when I was starting out, I was not exactly sure what they meant and I was focusing on understanding the code.

As far as documenting `main()` and its variants, again, it was born out of a personal need to create kind-of-usable programs as I am familiarising with Rascal . By the time I needed it though, I had already picked on the similarities between Rascal and Java and for one of the programs I tried to write, I entered `int main(list[int] nums){}` and the ensuing error told me everything I needed to know :D Needless to say, I really liked the automatic marshalling between values passed on the command line and main's arguments. It is a really simple and useful feature.

I am spelling these two points out in detail because, the way the documentation is structured right now is probably good as a reference manual, but if someone is just starting out, they will probably have to shift through many different pages. I was wondering if I should modify "Hello World" with some additional comments and links to the rest of the documentation but I did not want to mess around with the documentation system you may be establishing. Happy to hear any guidelines on this. For example, I was not even sure about adding "comments" to the concept of "Program"...To me it seemed very relevant. But if every lemma has to describe one thing and one thing only, including the two lines about code comments might not be correct.

Finally, you might notice that the examples in "Program" are using the long-hand way of calling `rascal-shell-stable.jar`. I am actually using:

```
#!/bin/bash

java -jar rascal-shell-stable.jar $@
```

as an executable `rsc.sh` and simply do `rsc.sh path_to_program.rsc`. This would result in much shorter command line examples here but it is also linux/bash specific. If it would be useful to mention something like this I can add it to "Getting Started"...or maybe there is a more suitable section (?).

All the best