### PR TITLE
Simplified temp resolver

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -515,3 +515,7 @@ test bool extensionSetRoot()
 
 test bool extensionSetSimple()
     = |file:///a/b.noot|[extension="aap"] == |file:///a/b.aap|;
+
+
+// we don't want backslashes in windows
+test bool correctTempPathResolverOnWindows() = /\\/ !:= resolveLocation(|tmp:///|).path;

--- a/src/org/rascalmpl/uri/file/TempURIResolver.java
+++ b/src/org/rascalmpl/uri/file/TempURIResolver.java
@@ -16,38 +16,28 @@ import java.net.URISyntaxException;
 import org.rascalmpl.uri.ILogicalSourceLocationResolver;
 import org.rascalmpl.uri.URIUtil;
 import io.usethesource.vallang.ISourceLocation;
-import io.usethesource.vallang.IValueFactory;
-import org.rascalmpl.values.ValueFactoryFactory;
 
 public class TempURIResolver implements ILogicalSourceLocationResolver {
     
-    private final IValueFactory VF;
     private final ISourceLocation root;
 
     public TempURIResolver() {
-        VF = ValueFactoryFactory.getValueFactory();
-        ISourceLocation rootFinalHack = null;
         try {
-            rootFinalHack = VF.sourceLocation("file", "", System.getProperty("java.io.tmpdir") + "/");
+            root = URIUtil.createFileLocation(System.getProperty("java.io.tmpdir"));
         }
         catch (URISyntaxException e) {
-            e.printStackTrace();
+            throw new RuntimeException("Error loading temporary location");
         }
-        root = rootFinalHack;
     }
-    
-	@Override
-	public String scheme() {
-		return "tmp";
-	}
+
+    @Override
+    public String scheme() {
+        return "tmp";
+    }
 
     @Override
     public ISourceLocation resolve(ISourceLocation input) {
-        String path = input.getPath();
-        if (!path.startsWith("/")) {
-            path = "/" + path;
-        }
-        return URIUtil.getChildLocation(root, path);
+        return URIUtil.getChildLocation(root, input.getPath());
     }
 
     @Override


### PR DESCRIPTION
The temp resolver was building strange paths on windows, now we use the URIUtil more correctly.

After finishing #1758, this can be most likely further simplified.

Before:
```
rascal>import IO;
ok
rascal>resolveLocation(|tmp:///|);
loc: |file:///C:%5CUsers%5CDavy%5CAppData%5CLocal%5CTemp%5C/|
rascal>
```


After:

```
rascal>resolveLocation(|tmp:///|);
loc: |file:///C:/Users/Davy/AppData/Local/Temp/|
```