### PR TITLE
Reduced duplicate code of cwd/home/tmp resolvers

### DIFF
--- a/src/org/rascalmpl/uri/file/AliasedFileResolver.java
+++ b/src/org/rascalmpl/uri/file/AliasedFileResolver.java
@@ -1,0 +1,35 @@
+package org.rascalmpl.uri.file;
+
+import java.io.IOException;
+
+import org.rascalmpl.uri.ILogicalSourceLocationResolver;
+import org.rascalmpl.uri.URIUtil;
+
+import io.usethesource.vallang.ISourceLocation;
+
+public abstract class AliasedFileResolver implements ILogicalSourceLocationResolver {
+
+    private final String scheme;
+
+    AliasedFileResolver(String scheme) {
+        this.scheme = scheme;
+    }
+
+    abstract ISourceLocation getRoot();
+
+    @Override
+    public ISourceLocation resolve(ISourceLocation input) throws IOException {
+        return URIUtil.getChildLocation(getRoot(), input.getPath());
+    }
+
+    @Override
+    public String scheme() {
+        return scheme;
+    }
+
+    @Override
+    public String authority() {
+        return "";
+    }
+    
+}

--- a/src/org/rascalmpl/uri/file/AliasedFileResolver.java
+++ b/src/org/rascalmpl/uri/file/AliasedFileResolver.java
@@ -1,3 +1,15 @@
+/**************************************************
+ * Copyright (c) 2022, NWO-I Centrum Wiskunde & Informatica (CWI) 
+ * All rights reserved. 
+ *   
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+ *   
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+ *   
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+ *   
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ ****************************************************/
 package org.rascalmpl.uri.file;
 
 import java.io.IOException;
@@ -10,16 +22,16 @@ import io.usethesource.vallang.ISourceLocation;
 public abstract class AliasedFileResolver implements ILogicalSourceLocationResolver {
 
     private final String scheme;
+    private final ISourceLocation root;
 
-    AliasedFileResolver(String scheme) {
+    AliasedFileResolver(String scheme, String rootPath) {
         this.scheme = scheme;
+        this.root = FileURIResolver.constructFileURI(rootPath);
     }
-
-    abstract ISourceLocation getRoot();
 
     @Override
     public ISourceLocation resolve(ISourceLocation input) throws IOException {
-        return URIUtil.getChildLocation(getRoot(), input.getPath());
+        return URIUtil.getChildLocation(root, input.getPath());
     }
 
     @Override

--- a/src/org/rascalmpl/uri/file/CWDURIResolver.java
+++ b/src/org/rascalmpl/uri/file/CWDURIResolver.java
@@ -13,19 +13,13 @@
 *******************************************************************************/
 package org.rascalmpl.uri.file;
 
-import io.usethesource.vallang.ISourceLocation;
-
 /**
  * For reading and writing files relative to the current working directory.
  */
 public class CWDURIResolver extends AliasedFileResolver {
 
 	public CWDURIResolver() {
-		super("cwd");
+		super("cwd", System.getProperty("user.dir"));
 	}
 	
-	@Override
-	ISourceLocation getRoot() {
-		return FileURIResolver.constructFileURI(System.getProperty("user.dir"));
-	}
 }

--- a/src/org/rascalmpl/uri/file/CWDURIResolver.java
+++ b/src/org/rascalmpl/uri/file/CWDURIResolver.java
@@ -13,27 +13,19 @@
 *******************************************************************************/
 package org.rascalmpl.uri.file;
 
-import org.rascalmpl.uri.ILogicalSourceLocationResolver;
-import org.rascalmpl.uri.URIUtil;
 import io.usethesource.vallang.ISourceLocation;
 
 /**
  * For reading and writing files relative to the current working directory.
  */
-public class CWDURIResolver implements ILogicalSourceLocationResolver {
+public class CWDURIResolver extends AliasedFileResolver {
 
-	@Override
-	public String scheme() {
-		return "cwd";
+	public CWDURIResolver() {
+		super("cwd");
 	}
 	
 	@Override
-	public ISourceLocation resolve(ISourceLocation input) {
-		return URIUtil.getChildLocation(FileURIResolver.constructFileURI(System.getProperty("user.dir")), input.getPath());
-	}
-
-	@Override
-	public String authority() {
-		return "";
+	ISourceLocation getRoot() {
+		return FileURIResolver.constructFileURI(System.getProperty("user.dir"));
 	}
 }

--- a/src/org/rascalmpl/uri/file/HomeURIResolver.java
+++ b/src/org/rascalmpl/uri/file/HomeURIResolver.java
@@ -11,17 +11,9 @@
 *******************************************************************************/
 package org.rascalmpl.uri.file;
 
-import io.usethesource.vallang.ISourceLocation;
-
 public class HomeURIResolver extends AliasedFileResolver {
 
-
 	public HomeURIResolver() {
-		super("home");
-	}
-
-	@Override
-	ISourceLocation getRoot() {
-		return FileURIResolver.constructFileURI(System.getProperty("user.home"));
+		super("home", System.getProperty("user.home"));
 	}
 }

--- a/src/org/rascalmpl/uri/file/HomeURIResolver.java
+++ b/src/org/rascalmpl/uri/file/HomeURIResolver.java
@@ -11,24 +11,17 @@
 *******************************************************************************/
 package org.rascalmpl.uri.file;
 
-import org.rascalmpl.uri.ILogicalSourceLocationResolver;
-import org.rascalmpl.uri.URIUtil;
 import io.usethesource.vallang.ISourceLocation;
 
-public class HomeURIResolver implements ILogicalSourceLocationResolver {
+public class HomeURIResolver extends AliasedFileResolver {
 
-	@Override
-	public String scheme() {
-		return "home";
-	}
-	
-	@Override
-	public ISourceLocation resolve(ISourceLocation input) {
-		return URIUtil.getChildLocation(FileURIResolver.constructFileURI(System.getProperty("user.home")), input.getPath());
+
+	public HomeURIResolver() {
+		super("home");
 	}
 
 	@Override
-	public String authority() {
-		return "";
+	ISourceLocation getRoot() {
+		return FileURIResolver.constructFileURI(System.getProperty("user.home"));
 	}
 }

--- a/src/org/rascalmpl/uri/file/TempURIResolver.java
+++ b/src/org/rascalmpl/uri/file/TempURIResolver.java
@@ -11,16 +11,9 @@
 *******************************************************************************/
 package org.rascalmpl.uri.file;
 
-import io.usethesource.vallang.ISourceLocation;
-
 public class TempURIResolver extends AliasedFileResolver {
     
     public TempURIResolver() {
-        super("tmp");
-    }
-
-    @Override
-    ISourceLocation getRoot() {
-        return FileURIResolver.constructFileURI(System.getProperty("java.io.tmpdir"));
+        super("tmp", System.getProperty("java.io.tmpdir"));
     }
 }

--- a/src/org/rascalmpl/uri/file/TempURIResolver.java
+++ b/src/org/rascalmpl/uri/file/TempURIResolver.java
@@ -11,37 +11,16 @@
 *******************************************************************************/
 package org.rascalmpl.uri.file;
 
-import java.net.URISyntaxException;
-
-import org.rascalmpl.uri.ILogicalSourceLocationResolver;
-import org.rascalmpl.uri.URIUtil;
 import io.usethesource.vallang.ISourceLocation;
 
-public class TempURIResolver implements ILogicalSourceLocationResolver {
+public class TempURIResolver extends AliasedFileResolver {
     
-    private final ISourceLocation root;
-
     public TempURIResolver() {
-        try {
-            root = URIUtil.createFileLocation(System.getProperty("java.io.tmpdir"));
-        }
-        catch (URISyntaxException e) {
-            throw new RuntimeException("Error loading temporary location");
-        }
+        super("tmp");
     }
 
     @Override
-    public String scheme() {
-        return "tmp";
-    }
-
-    @Override
-    public ISourceLocation resolve(ISourceLocation input) {
-        return URIUtil.getChildLocation(root, input.getPath());
-    }
-
-    @Override
-    public String authority() {
-        return "";
+    ISourceLocation getRoot() {
+        return FileURIResolver.constructFileURI(System.getProperty("java.io.tmpdir"));
     }
 }


### PR DESCRIPTION
These class were all just copies of each other (but with slightly different strategies). So I factored out their common code.

It's a pity that java allows for users to change env variables, else we could just resolve the root location one time, at the start.