### PR TITLE
Make a canonical file path if we are asked to build a new file path

### DIFF
--- a/src/org/rascalmpl/interpreter/load/StandardLibraryContributor.java
+++ b/src/org/rascalmpl/interpreter/load/StandardLibraryContributor.java
@@ -18,6 +18,8 @@ import java.net.URISyntaxException;
 import java.util.List;
 
 import org.rascalmpl.interpreter.utils.RascalManifest;
+import org.rascalmpl.uri.URIUtil;
+
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IValueFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
@@ -54,7 +56,7 @@ public class StandardLibraryContributor implements
 						}
 					}
 					else {
-						l.add(vf.sourceLocation("file","", path));
+						l.add(URIUtil.createFileLocation(path));
 					}
 				} catch (URISyntaxException e) {
 				}

--- a/src/org/rascalmpl/uri/URIUtil.java
+++ b/src/org/rascalmpl/uri/URIUtil.java
@@ -11,6 +11,7 @@
 package org.rascalmpl.uri;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -55,8 +56,14 @@ public class URIUtil {
 	 * @throws URISyntaxException
 	 */
 	public static URI createFile(String path) throws URISyntaxException {
-		path = fixWindowsPath(path);
-		return fixUnicode(new File(path).toURI());
+		File file = new File(fixWindowsPath(path));
+		try {
+			file = file.getCanonicalFile();
+		}
+		catch (IOException e) {
+			// swallow, let's keep the old file
+		}
+		return fixUnicode(file.toURI());
 	}
 	
 	/**


### PR DESCRIPTION
This fixes #1809 


I could not come up with a good test case for it, as there is no way to trigger `URIUtil.fileLocation` from rascal that I could find.