### PR TITLE
Improve parser performance by removing old JDT/JIT tuning

### DIFF
--- a/src/org/rascalmpl/parser/gtd/stack/edge/EdgesSet.java
+++ b/src/org/rascalmpl/parser/gtd/stack/edge/EdgesSet.java
@@ -13,6 +13,8 @@
 *******************************************************************************/
 package org.rascalmpl.parser.gtd.stack.edge;
 
+import java.util.Arrays;
+
 import org.rascalmpl.parser.gtd.result.AbstractContainerNode;
 import org.rascalmpl.parser.gtd.stack.AbstractStackNode;
 import org.rascalmpl.parser.gtd.util.IntegerMap;
@@ -48,10 +50,9 @@ public class EdgesSet<P>{
 	}
 	
 	private void enlarge(){
-		AbstractStackNode<P>[] oldEdges = edges;
-		edges = (AbstractStackNode<P>[]) new AbstractStackNode[size << 1];
-		System.arraycopy(oldEdges, 0, edges, 0, size);
+		edges = Arrays.copyOf(edges, size << 1, edges.getClass());
 	}
+
 	
 	public void add(AbstractStackNode<P> edge){
 		while(size >= edges.length){ // While instead of if to enable the JIT to eliminate the bounds check on the edges array 


### PR DESCRIPTION
This change made the parser run between 8 and 12% faster.

Since the discussion in usethesource/rascal-language-servers#267 pointed towards the parser, I took a look at the profiler, and this method popped up. I thought, maybe 11y of changes of the JDK have caught up.

I think primarily the `Arrays.copyOf` method is implemented in native code, so that gives some benefits.

I wrote a small java program that would load all rascal files in the rascal project in memory, and would run the parser over that. 

The old code before this fix:

```
Parsing took: 10153 ms
Parsing took: 8624 ms
Parsing took: 8548 ms
Parsing took: 8518 ms
Parsing took: 8445 ms
Parsing took: 8448 ms
Parsing took: 8462 ms
Parsing took: 8458 ms
Parsing took: 8472 ms
Parsing took: 8527 ms
```

You see the first one the loop that the JIT kicked in.

After applying this change:

```
Start parsing
Parsing took: 9412 ms
Parsing took: 7633 ms
Parsing took: 7587 ms
Parsing took: 7634 ms
Parsing took: 7558 ms
Parsing took: 7608 ms
Parsing took: 7629 ms
Parsing took: 7753 ms
Parsing took: 7636 ms
Parsing took: 7631 ms
```

So depending on which values you compare, anywhere between 8 and 12% speedup. 




