### PR TITLE
a little compile for generating cached module parsers

### DIFF
--- a/src/org/rascalmpl/interpreter/result/SourceLocationResult.java
+++ b/src/org/rascalmpl/interpreter/result/SourceLocationResult.java
@@ -509,31 +509,8 @@ public class SourceLocationResult extends ElementResult<ISourceLocation> {
 				if (!replType.isString()) {
 					throw new UnexpectedType(getTypeFactory().stringType(), replType, ctx.getCurrentAST());
 				}
-				String ext = newStringValue;
 				
-				boolean endsWithSlash = path.endsWith(URIUtil.URI_PATH_SEPARATOR);
-				if (endsWithSlash) {
-					path = path.substring(0, path.length() - 1);
-				}
-
-				if (path.length() > 1) {
-					int slashIndex = path.lastIndexOf(URIUtil.URI_PATH_SEPARATOR);
-					int index = path.substring(slashIndex).lastIndexOf('.');
-
-					if (index == -1 && !ext.isEmpty()) {
-						path = path + (!ext.startsWith(".") ? "." : "") + ext;
-					}
-					else if (!ext.isEmpty()) {
-						path = path.substring(0, slashIndex + index) + (!ext.startsWith(".") ? "." : "") + ext;
-					}
-					else if (index != -1) {
-						path = path.substring(0, slashIndex + index);
-					}
-
-					if (endsWithSlash) {
-						path = path + URIUtil.URI_PATH_SEPARATOR;
-					}
-				}
+				path = URIUtil.changeExtension(loc, newStringValue).getPath();
 				uriPartChanged = true;
 			}
 			else if (name.equals("top")) {

--- a/src/org/rascalmpl/library/lang/rascal/grammar/storage/ModuleParserStorage.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/grammar/storage/ModuleParserStorage.rsc
@@ -1,0 +1,46 @@
+@synopsis{Functionality for caching module parsers}
+@description{
+The Rascal interpreter can take a lot of time while loading modules.
+In particular in deployed situations (Eclipse and VScode plugins), the 
+time it takes to load the parser generator for generating the parsers
+which are required for analyzing concrete syntax fragments is prohibitive (20s).
+This means that the first syntax highlighting sometimes can only appear
+after more than 20s after loading an extension (VScode) or plugin (Eclipse).
+
+This "compiler" takes any number of Rascal modules and extracts a grammar
+for each of them, in order to use the ((Library::ParseTree)) module's
+functions ((saveParsers)) on them respectively to store each parser
+in a `.parsers` file. 
+
+After that the Rascal interpreter has a special mode for using ((loadParsers))
+while importing a new module if a cache `.parsers` file is present next to 
+the `.rsc` respective file.
+}
+@benefits{
+* loading modules without having to first load and use a parser generator can be up 1000 times faster.
+}
+@pitfalls{
+:::warning
+This caching feature is _static_. There is no automated cache clearance.
+If your grammars change, any saved `.parsers` files do not change with it. 
+It is advised that you programmatically execute this compiler at deployment time
+to store the `.parsers` file _only_ in deployed `jar` files. That way, you can not
+be bitten by a concrete syntax parser that is out of date at development time.
+:::
+}
+@license{
+  Copyright (c) 2009-2023 NWO-I CWI
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+}
+@contributor{Jurgen J. Vinju - Jurgen.Vinju@cwi.nl - CWI}
+@bootstrapParser
+module lang::rascal::grammar::storage::ModuleParserStorage
+
+import lang::rascal::grammar::definition::Modules;
+import lang::rascal::\syntax::Rascal;
+import util::Reflective;
+
+

--- a/src/org/rascalmpl/library/lang/rascal/grammar/storage/ModuleParserStorage.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/grammar/storage/ModuleParserStorage.rsc
@@ -64,6 +64,43 @@ Rascal interpreter will use this instead of spinning up its own parser generator
 * this compiler may have slight differences in semantics with the way the interpreter composes grammars for modules, since
 it is implemented differently. However, no such issues are currently known.
 }
+@examples{
+Typically you would call the generate-sources MOJO from the rascal-maven-plugin, in `pom.xml`, like so:
+
+```xml
+<plugin>
+    <groupId>org.rascalmpl</groupId>
+    <artifactId>rascal-maven-plugin</artifactId>
+    <version>0.14.6</version>
+    <configuration>
+        <mainModule>YourMainModule</mainModule>
+    </configuration>
+    <executions>
+        <execution>
+            <id>it-compile</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+                <goal>generate-sources</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
+And you'd write this module to make it work:
+
+```rascal
+module YourMainModule
+
+import util::Reflective;
+import lang::rascal::grammar::storage::ModuleParserStorage;
+
+int main(list[str] args) {
+    pcfg = getProjectPathConfig(|project://yourProject|);
+    storeParsersForModules(pcfg);
+}
+```
+}
 void storeParsersForModules(PathConfig pcfg) {
     storeParsersForModules({*find(src, "rsc") | src <- pcfg.srcs, bprintln("Crawling <src>")}, pcfg);
 }

--- a/src/org/rascalmpl/uri/URIUtil.java
+++ b/src/org/rascalmpl/uri/URIUtil.java
@@ -433,4 +433,32 @@ public class URIUtil {
     public static ISourceLocation createFromURI(String value) throws URISyntaxException {
         return vf.sourceLocation(createFromEncoded(value));
     }
+    public static ISourceLocation changeExtension(ISourceLocation location, String ext) throws URISyntaxException {
+        String path = location.getPath();
+		boolean endsWithSlash = path.endsWith(URIUtil.URI_PATH_SEPARATOR);
+		if (endsWithSlash) {
+			path = path.substring(0, path.length() - 1);
+		}
+
+		if (path.length() > 1) {
+			int slashIndex = path.lastIndexOf(URIUtil.URI_PATH_SEPARATOR);
+			int index = path.substring(slashIndex).lastIndexOf('.');
+
+			if (index == -1 && !ext.isEmpty()) {
+				path = path + (!ext.startsWith(".") ? "." : "") + ext;
+			}
+			else if (!ext.isEmpty()) {
+				path = path.substring(0, slashIndex + index) + (!ext.startsWith(".") ? "." : "") + ext;
+			}
+			else if (index != -1) {
+				path = path.substring(0, slashIndex + index);
+			}
+
+			if (endsWithSlash) {
+				path = path + URIUtil.URI_PATH_SEPARATOR;
+			}
+		}
+
+		return URIUtil.changePath(location, path);
+    }
 }


### PR DESCRIPTION
* for every module file `M.rsc` that requires a concrete syntax parser, this PR checks if `M.parsers` is right there next to it. If so then it uses `ParseTree::loadParsers` instead of generating a parser (and loading a parser generator!). 
* to generate a bunch of `.parsers` file, this PR contains `lang::rascal::grammars::storage::ModuleParserStorage` which provides `void storeParsersForModules(PathConfig pcfg)`. This will produce the required `.parser` file in the `bin` parameter location of the pathConfig, based on the relative file path of the `rsc` file in the `srcs` parameter of the pathConfig.
* so to use this: 
   * call `storeParsersForModules` _once_, i.e. during `mvn package` or just before
   * make sure the `.rsc` files that are loaded from the jar are copied right **next to** the .parsers file
   * wait and see
* success is visible in the **absence** of log messages that are "loading the parser generator" modules. Also the first module loads 1000x faster and subsequent modules 20 to 30 times faster than before.
* please give it a spin. I'm curious if this is enough to solve https://github.com/usethesource/rascal-language-servers/issues/267