### PR TITLE
Add documentation to some methods in util::FileSystem

### DIFF
--- a/src/org/rascalmpl/library/analysis/grammars/LOC.rsc
+++ b/src/org/rascalmpl/library/analysis/grammars/LOC.rsc
@@ -5,7 +5,7 @@
   which accompanies this distribution, and is available at
   http://www.eclipse.org/legal/epl-v10.html
 }
-@synopis{Generic utilities to compute (S)LOC metrics based on grammars}
+@synopsis{Generic utilities to compute (S)LOC metrics based on grammars}
 @description{
 We use this definition to separate lines from: <http://en.wikipedia.org/wiki/Newline>:
  

--- a/src/org/rascalmpl/library/util/FileSystem.rsc
+++ b/src/org/rascalmpl/library/util/FileSystem.rsc
@@ -16,14 +16,25 @@ data FileSystem
   
 FileSystem crawl(loc l) = isDirectory(l) ? directory(l, {crawl(e) | e <- l.ls}) : file(l);
 
+@synopis{
+  Recursively lists locations of all files from the supplied directory.
+  If input is a file, its location is returned instead.
+}
 set[loc] files(loc l) = isDirectory(l) ? { *files(e) | e <- l.ls } : {l};
 
+@synopis{
+  Recursively lists locations of all files that satisfy the filter criterion `filt`.
+  For a file to be included, `filt` must return `true` for it.
+}
 set[loc] find(loc f, bool (loc) filt) 
   = isDirectory(f) 
       ? {*find(c, filt) | c <- f.ls} + (filt(f) ? {f} : { }) 
       : (filt(f) ? {f} : { })
       ;
 
+@synopis{
+  Recursively lists locations of all files that end in `ext`.
+}
 set[loc] find(loc f, str ext) = find(f, bool (loc l) { return l.extension == ext; });
 
 @synopis{Lists all files recursively ignored files and directories starting with a dot.}

--- a/src/org/rascalmpl/library/util/FileSystem.rsc
+++ b/src/org/rascalmpl/library/util/FileSystem.rsc
@@ -16,13 +16,13 @@ data FileSystem
   
 FileSystem crawl(loc l) = isDirectory(l) ? directory(l, {crawl(e) | e <- l.ls}) : file(l);
 
-@synopis{
+@synopsis{
   Recursively lists locations of all files from the supplied directory.
   If input is a file, its location is returned instead.
 }
 set[loc] files(loc l) = isDirectory(l) ? { *files(e) | e <- l.ls } : {l};
 
-@synopis{
+@synopsis{
   Recursively lists locations of all files that satisfy the filter criterion `filt`.
   For a file to be included, `filt` must return `true` for it.
 }
@@ -32,12 +32,12 @@ set[loc] find(loc f, bool (loc) filt)
       : (filt(f) ? {f} : { })
       ;
 
-@synopis{
+@synopsis{
   Recursively lists locations of all files that end in `ext`.
 }
 set[loc] find(loc f, str ext) = find(f, bool (loc l) { return l.extension == ext; });
 
-@synopis{Lists all files recursively ignored files and directories starting with a dot.}
+@synopsis{Lists all files recursively ignored files and directories starting with a dot.}
 set[loc] visibleFiles(loc l) {
   if (/^\./ := l.file) 
     return {};

--- a/src/org/rascalmpl/library/util/ShellExec.rsc
+++ b/src/org/rascalmpl/library/util/ShellExec.rsc
@@ -31,7 +31,7 @@ For environment variables in `envVars` the same treatment is given to convert va
 @javaClass{org.rascalmpl.library.util.ShellExec}
 java PID createProcess(loc processCommand, loc workingDir=|cwd:///|, list[value] args = [], map[str, value] envVars = ());
 
-@synopis{start, run and kill an external process returning its output as a string.}
+@synopsis{start, run and kill an external process returning its output as a string.}
 @deprecrated{Use the `exec`` function that takes `loc` for processCommand for better portability behavior between operating systems.}
 str exec(str processCommand, loc workingDir=|cwd:///|, list[str] args = [], map[str, str] env = ()) {
    pid = createProcess(processCommand, workingDir=workingDir, args=args, envVars=env);
@@ -40,7 +40,7 @@ str exec(str processCommand, loc workingDir=|cwd:///|, list[str] args = [], map[
    return result;
 }
 
-@synopis{start, run and kill an external process returning its output as a string.}
+@synopsis{start, run and kill an external process returning its output as a string.}
 str exec(loc processCommand, loc workingDir=|cwd:///|, list[value] args = [], map[str, value] env = ()) {
    pid = createProcess(processCommand, workingDir=workingDir, args=args, envVars=env);
    result = readEntireStream(pid);
@@ -58,7 +58,7 @@ tuple[str output, int exitCode] execWithCode(str processCommand, loc workingDir=
     return <result, exitCode(pid)>;
 }
 
-@synopis{start, run and kill an external process returning its output as a string with an exit code.}
+@synopsis{start, run and kill an external process returning its output as a string with an exit code.}
 tuple[str output, int exitCode] execWithCode(loc processCommand, loc workingDir=|cwd:///|, list[value] args = [], map[str, value] env = ()) {
     pid = createProcess(processCommand, workingDir=workingDir, args=args, envVars=env);
     result = readEntireStream(pid);


### PR DESCRIPTION
Same as #1785 , but with `@synopsis`.
Also changes two other files, where `synopsis` was missing the second `s`.