### PR TITLE
Type.match and Type.instantiate for NonTerminalType

### DIFF
--- a/src/org/rascalmpl/types/NonTerminalType.java
+++ b/src/org/rascalmpl/types/NonTerminalType.java
@@ -541,15 +541,18 @@ public class NonTerminalType extends RascalType {
 
 	@Override
 	public boolean match(Type matched, Map<Type, Type> bindings) throws FactTypeUseException {
-		matched.isSubtypeOf(this);
-		return isSubtypeOf(matched);
-		// if (matched instanceof NonTerminalType) {
-		// 	return SymbolAdapter.match(symbol, ((NonTerminalType) matched).symbol, bindings);
-		// }
-		// else {
-		// 	IRascalValueFactory vf = IRascalValueFactory.getInstance();
+		// return matched.isSubtypeOf(this);
+		if (matched.isSubtypeOf(TypeFactory.getInstance().voidType())) {
+			return true;
+
+		}
+		else if (matched instanceof NonTerminalType) {
+			return SymbolAdapter.match(symbol, ((NonTerminalType) matched).symbol, bindings);
+		}
+		else {
+			IRascalValueFactory vf = IRascalValueFactory.getInstance();
 			
-		// 	return SymbolAdapter.match(symbol, matched.asSymbol(vf, new TypeStore(), vf.setWriter(), new HashSet<>()), bindings);
-		// }
+			return SymbolAdapter.match(symbol, matched.asSymbol(vf, new TypeStore(), vf.setWriter(), new HashSet<>()), bindings);
+		}
 	}
 }

--- a/src/org/rascalmpl/types/NonTerminalType.java
+++ b/src/org/rascalmpl/types/NonTerminalType.java
@@ -543,16 +543,27 @@ public class NonTerminalType extends RascalType {
 	public boolean match(Type matched, Map<Type, Type> bindings) throws FactTypeUseException {
 		// return matched.isSubtypeOf(this);
 		if (matched.isSubtypeOf(TypeFactory.getInstance().voidType())) {
+			// this is a common fast path otherwise handled by the else case down here
 			return true;
 
 		}
 		else if (matched instanceof NonTerminalType) {
+			// we have to implement this on the symbol level since we do not have separate types
+			// for every different kind of non-terminal (regular symbols, literals, etc)
 			return SymbolAdapter.match(symbol, ((NonTerminalType) matched).symbol, bindings);
 		}
 		else {
 			IRascalValueFactory vf = IRascalValueFactory.getInstance();
+			// here we lift the other types to symbols, such that they can be compared.
+			// this is mainly necessary for the different kinds of parametrized sorts and
+			// how they match against the ADT names and parameters.
 			
 			return SymbolAdapter.match(symbol, matched.asSymbol(vf, new TypeStore(), vf.setWriter(), new HashSet<>()), bindings);
 		}
+	}
+
+	@Override
+	public boolean isOpen() {
+		return SymbolAdapter.isOpen(symbol);
 	}
 }

--- a/src/org/rascalmpl/types/NonTerminalType.java
+++ b/src/org/rascalmpl/types/NonTerminalType.java
@@ -39,6 +39,7 @@ import io.usethesource.vallang.ISet;
 import io.usethesource.vallang.ISetWriter;
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.IValueFactory;
+import io.usethesource.vallang.exceptions.FactTypeUseException;
 import io.usethesource.vallang.type.Type;
 import io.usethesource.vallang.type.TypeFactory;
 import io.usethesource.vallang.type.TypeFactory.RandomTypesConfig;
@@ -315,7 +316,6 @@ public class NonTerminalType extends RascalType {
 	protected Type glbWithConstructor(Type type) {
 	  return TF.voidType();
 	}
-
 	
 	@Override
 	protected boolean isSupertypeOf(Type type) {
@@ -325,6 +325,7 @@ public class NonTerminalType extends RascalType {
 	  
 	  return super.isSupertypeOf(type);
 	}
+
 	
 	@Override
 	protected boolean isSupertypeOf(RascalType type) {
@@ -531,5 +532,24 @@ public class NonTerminalType extends RascalType {
 	    
 	    // TODO: this generates an on-the-fly nullable production and returns a tree for that rule
 	    return rvf.appl(vf.constructor(RascalValueFactory.Production_Default, symbol, vf.list(), vf.set()), vf.list());
+	}
+
+	@Override
+	public Type instantiate(Map<Type, Type> bindings) {
+		return RTF.nonTerminalType(SymbolAdapter.instantiate(symbol, bindings));
+	}
+
+	@Override
+	public boolean match(Type matched, Map<Type, Type> bindings) throws FactTypeUseException {
+		matched.isSubtypeOf(this);
+		return isSubtypeOf(matched);
+		// if (matched instanceof NonTerminalType) {
+		// 	return SymbolAdapter.match(symbol, ((NonTerminalType) matched).symbol, bindings);
+		// }
+		// else {
+		// 	IRascalValueFactory vf = IRascalValueFactory.getInstance();
+			
+		// 	return SymbolAdapter.match(symbol, matched.asSymbol(vf, new TypeStore(), vf.setWriter(), new HashSet<>()), bindings);
+		// }
 	}
 }

--- a/src/org/rascalmpl/types/RascalType.java
+++ b/src/org/rascalmpl/types/RascalType.java
@@ -1,5 +1,8 @@
 package org.rascalmpl.types;
 
+import java.util.Map;
+
+import io.usethesource.vallang.exceptions.FactTypeUseException;
 import io.usethesource.vallang.type.ExternalType;
 import io.usethesource.vallang.type.Type;
 

--- a/src/org/rascalmpl/values/parsetrees/SymbolAdapter.java
+++ b/src/org/rascalmpl/values/parsetrees/SymbolAdapter.java
@@ -1190,6 +1190,10 @@ public class SymbolAdapter {
 		symbol = stripLabelsAndConditions(symbol);
 		subject = stripLabelsAndConditions(subject);
 		
+		if (isVoid(symbol)) {
+			return true;
+		}
+		
 		// fast path equality is fine, but no more binding can be learned from that either
 		// this happens a lot because types are not accidentally constructed from each other.
 		if (isEqual(symbol, subject)) {
@@ -1228,23 +1232,11 @@ public class SymbolAdapter {
 		}
 		
 		if (isIterPlus(symbol) || isIterStar(symbol)) {
-			if (isIterPlusSeps(subject) || isIterStarSeps(subject)) {
-				// the subject is separated but the patter not (yet)
-				// TODO check if the subject only has layout
-				IConstructor elem1 = getSymbol(symbol);
-				IConstructor elem2 = getSymbol(subject);
+			// don't care if the other has separators or not.
+			IConstructor elem1 = getSymbol(symbol);
+			IConstructor elem2 = getSymbol(subject);
 				
-				return match(elem1, elem2, bindings);
-			}
-			else if (isIterPlus(subject) || isIterStar(subject)) {
-				// both are not separated
-				IConstructor elem1 = getSymbol(symbol);
-				IConstructor elem2 = getSymbol(subject);
-				return match(elem1, elem2, bindings);
-			}
-			else {
-				return false;
-			}
+			return match(elem1, elem2, bindings);
 		}
 
 		// this happens when we match against abstract patterns with concrete trees
@@ -1366,6 +1358,6 @@ public class SymbolAdapter {
 		// all the other symbols are not composed of other symbols
 		// sort, lex, keyword, empty, char-class, layout, literal, ci-lit, int, str, real, node, value, num, datetime and loc
 
-		return symbol.equals(subject);        
+		return isEqual(symbol, subject);
     }
 }


### PR DESCRIPTION
Trying to implement Type.match and Type.instantiate for NonTerminalType such that pattern matching works for types like `{&T &E}*` and `&O?` 

* If that works, then generic library functions like `sort`, `size`, `zip` and `reverse` can be written for syntax lists
* Generally some things become simpler for concrete syntax analysis which are now "given" for abstract syntax and abstract lists.
* It's a big step towards finishing the concrete syntax features.
* Most complex code written for this works both for the interpreter and the compiled run-time as it is a part of the run-time type system of Rascal parse trees.