### PR TITLE
Allow type transformations with mapper for Map

### DIFF
--- a/src/org/rascalmpl/library/Map.rsc
+++ b/src/org/rascalmpl/library/Map.rsc
@@ -157,7 +157,7 @@ int incr(int x) { return x + 1; }
 mapper(("apple": 1, "pear": 2, "orange": 3), prefix, incr);
 ```
 }
-public map[&K, &V] mapper(map[&K, &V] M, &L (&K) F, &W (&V) G)
+public map[&L, &W] mapper(map[&K, &V] M, &L (&K) F, &W (&V) G)
  = (F(key) : G(M[key]) | &K key <- M);
 
 


### PR DESCRIPTION
Hi, while aggregating results using Map's mapper I noticed that it does not allow the key and value types to change. Its return type matches the input types of the map functions F and G, rather than their return types. This restricts the map functions to only transform the values within the same type. 

The proposed change updates the return type of `mapper` to match that of the given map functions. Existing usage should not be impacted by this change as the current return types of F and G are inferred.

The mapper functions for [Set](https://github.com/usethesource/rascal/blob/main/src/org/rascalmpl/library/Set.rsc#L131) and [List](https://github.com/usethesource/rascal/blob/main/src/org/rascalmpl/library/List.rsc#L335) already use matching return types. As far as I could see those are the only other instances of mapper.

<summary> Running `mvn test` yields the same result before and after the change.
<details>
<pre>
[ERROR] Tests run: 5898, Failures: 0, Errors: 3, Skipped: 201, Time elapsed: 73.458 s <<< FAILURE! - in org.rascalmpl.test.AllSuiteParallel
[ERROR] hamcrestJarM3RemainedTheSame: <4276,168>(org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester)  Time elapsed: 0.005 s  <<< ERROR!
org.rascalmpl.exceptions.Throw: /Users/arjobruijnes/Documents/Projects/rascal/src/org/rascalmpl/library/lang/rascal/tests/library/lang/java/m3/BasicM3Tests.rsc:172,13: "typeDependency has different value"
	at org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.runTests(RascalJUnitParallelRecursiveTestRunner.java:226)
	at org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.run(RascalJUnitParallelRecursiveTestRunner.java:207)

[ERROR] junitM3RemainedTheSame: <2582,183>(org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester)  Time elapsed: 0.001 s  <<< ERROR!
org.rascalmpl.exceptions.Throw: /Users/arjobruijnes/Documents/Projects/rascal/src/org/rascalmpl/library/lang/rascal/tests/library/lang/java/m3/BasicM3Tests.rsc:172,13: "messages has different value"
	at org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.runTests(RascalJUnitParallelRecursiveTestRunner.java:226)
	at org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester.run(RascalJUnitParallelRecursiveTestRunner.java:207)

[ERROR] junitASTsRemainedTheSame: <3250,189>(org.rascalmpl.test.infrastructure.RascalJUnitParallelRecursiveTestRunner$ModuleTester)  Time elapsed: 0 s  <<< ERROR!
java.lang.Exception:
Test lang::rascal::tests::library::lang::java::m3::BasicM3Tests::junitASTsRemainedTheSame failed due to
	test returned false




[INFO] Running org.rascalmpl.TypeReificationTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.rascalmpl.TypeReificationTest
[INFO] Running org.rascalmpl.MatchFingerprintTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.rascalmpl.MatchFingerprintTest
[INFO]
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   RascalJUnitParallelRecursiveTestRunner$ModuleTester.run:207->runTests:226 » Throw
[ERROR]   RascalJUnitParallelRecursiveTestRunner$ModuleTester.junitASTsRemainedTheSame: <3250,189> »
[ERROR]   RascalJUnitParallelRecursiveTestRunner$ModuleTester.run:207->runTests:226 » Throw
[INFO]
[ERROR] Tests run: 5911, Failures: 0, Errors: 3, Skipped: 201
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10:14 min
[INFO] Finished at: 2023-12-29T00:56:01+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project rascal: There are test failures.
[ERROR]
[ERROR] Please refer to /Users/arjobruijnes/Documents/Projects/rascal/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
</pre>
</details>
<summary>