### PR TITLE
Remove black color from Rascal prompt

### DIFF
--- a/src/org/rascalmpl/repl/BaseREPL.java
+++ b/src/org/rascalmpl/repl/BaseREPL.java
@@ -274,7 +274,7 @@ public class BaseREPL {
     }
 
     private String previousPrompt = "";
-    public static final String PRETTY_PROMPT_PREFIX = Ansi.ansi().reset().bold().fg(Color.BLACK).toString();
+    public static final String PRETTY_PROMPT_PREFIX = Ansi.ansi().reset().bold().toString();
     public static final String PRETTY_PROMPT_POSTFIX = Ansi.ansi().boldOff().reset().toString();
 
     protected void updatePrompt() {


### PR DESCRIPTION
Fixes #1806

By removing the color from the prompt, making it only bold, the shell can decide about coloring, which should allow the prompt to be always readable