### PR TITLE
Made commons compress dependency explicit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,16 @@
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
         </dependency>
+        <dependency> <!-- used by the compression uri feature-->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.26.0</version>
+        </dependency>
+        <dependency> <!-- needed by commons-compress for compressed+...://...zst -->
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <version>1.5.5-11</version>
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/src/org/rascalmpl/uri/CompressedStreamResolver.java
+++ b/src/org/rascalmpl/uri/CompressedStreamResolver.java
@@ -10,13 +10,9 @@ import java.nio.charset.Charset;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 
-import com.github.luben.zstd.ZstdInputStream;
-import com.github.luben.zstd.ZstdOutputStream;
-
 import io.usethesource.vallang.ISourceLocation;
 
 public class CompressedStreamResolver implements ISourceLocationInputOutput {
-    private static final String ZSTD_COMPRESSION = "ZSTD";
     private final URIResolverRegistry registry;
     
     public CompressedStreamResolver(URIResolverRegistry registry) {
@@ -42,9 +38,6 @@ public class CompressedStreamResolver implements ISourceLocationInputOutput {
 	}
 
 	private static final InputStream getInputStream(String compressionMethod, InputStream original) throws IOException, CompressorException {
-	    if (compressionMethod == ZSTD_COMPRESSION) {
-	        return new ZstdInputStream(original);
-	    }
 	    return new CompressorStreamFactory().createCompressorInputStream(compressionMethod, original);
 	}
 	
@@ -68,9 +61,6 @@ public class CompressedStreamResolver implements ISourceLocationInputOutput {
 	}
 	
 	private static final OutputStream getOutputStream(String compressionMethod, OutputStream original) throws IOException, CompressorException {
-	    if (compressionMethod == ZSTD_COMPRESSION) {
-	        return new ZstdOutputStream(original);
-	    }
 	    return new CompressorStreamFactory().createCompressorOutputStream(compressionMethod, original);
 	}
 	
@@ -120,7 +110,7 @@ public class CompressedStreamResolver implements ISourceLocationInputOutput {
 			case "lzma" : return CompressorStreamFactory.LZMA;
 			case "Z" : return CompressorStreamFactory.Z;
 			case "xz": return CompressorStreamFactory.XZ;
-			case "zst": return ZSTD_COMPRESSION;
+			case "zst": return CompressorStreamFactory.ZSTANDARD;
 			case "7z":
 			case "zip":
 			case "rar":


### PR DESCRIPTION
We were using commons-compress from vallang, so I made it explicit, and also took the opportunity to use zstd support inside common compress to simplify the code a bit.