### PR TITLE
This fixes #1920 but it has a backward compatibility problem.

### DIFF
--- a/src/org/rascalmpl/exceptions/RascalStackOverflowError.java
+++ b/src/org/rascalmpl/exceptions/RascalStackOverflowError.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2024 CWI
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+
+ *   * Jurgen J. Vinju - Jurgen.Vinju@cwi.nl - CWI
+*******************************************************************************/
+package org.rascalmpl.exceptions;
+
+import org.rascalmpl.ast.AbstractAST;
+import org.rascalmpl.interpreter.IEvaluatorContext;
+import org.rascalmpl.interpreter.env.Environment;
+
+/**
+ * This class captures the runtime state of the interpreter at the moment
+ * we detect a java StackOverflowError. Since we can not use any stack depth
+ * at that moment to create a real Throw exception, we only copy the deepest
+ * environment and wrap it in here. Later on the level of the REPL, when the
+ * stack is completely unrolled, we can convert the stack trace to a Rascal trace.
+ */
+public class RascalStackOverflowError extends RuntimeException {
+    private static final long serialVersionUID = -3947588548271683963L;
+    private final Environment deepestEnvironment;
+    private final AbstractAST currentAST;
+ 
+    public RascalStackOverflowError(AbstractAST current, Environment deepest) {
+        this.deepestEnvironment = deepest;
+        this.currentAST = current;
+    }
+
+    public Throw makeThrow() {
+        StackTrace trace = new StackTrace();
+        Environment env = deepestEnvironment;
+
+        while (env != null) {
+            trace.add(env.getLocation(), env.getName());
+            env = env.getCallerScope();
+        }
+
+        return RuntimeExceptionFactory.stackOverflow(currentAST, trace);
+    }
+}

--- a/src/org/rascalmpl/interpreter/result/RascalFunction.java
+++ b/src/org/rascalmpl/interpreter/result/RascalFunction.java
@@ -40,6 +40,7 @@ import org.rascalmpl.ast.Parameters;
 import org.rascalmpl.ast.Statement;
 import org.rascalmpl.ast.Type.Structured;
 import org.rascalmpl.exceptions.ImplementationError;
+import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.interpreter.Accumulator;
 import org.rascalmpl.interpreter.IEvaluator;
 import org.rascalmpl.interpreter.IEvaluatorContext;
@@ -302,6 +303,18 @@ public class RascalFunction extends NamedFunction {
                     result = computeReturn(e, renamings, dynamicRenamings);
                     storeMemoizedResult(actuals,keyArgValues, result);
                     return result;
+                }
+                catch (StackOverflowError e) {
+                    // get a shallow stack trace because we don't have any stack room at the moment.
+                    // StackTrace trace = new StackTrace();
+                    // Environment env = eval.getCurrentEnvt();
+                    // int max = 10;
+                    // while (env != null && max-- > 0) {
+                    // 	trace.add(env.getLocation(), env.getName());
+                    // 	env = env.getCallerScope();
+                    // }
+    
+                    throw new RuntimeException("hello");
                 }
             }
 

--- a/src/org/rascalmpl/repl/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/RascalInterpreterREPL.java
@@ -19,6 +19,7 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.rascalmpl.exceptions.RascalStackOverflowError;
 import org.rascalmpl.exceptions.StackTrace;
 import org.rascalmpl.exceptions.Throw;
 import org.rascalmpl.ideservices.IDEServices;
@@ -148,6 +149,10 @@ public abstract class RascalInterpreterREPL extends BaseRascalREPL {
         }
         catch (ParseError pe) {
             parseErrorMessage(eval.getErrorPrinter(), lastLine, "prompt", pe, indentedPrettyPrinter);
+            return null;
+        }
+        catch (RascalStackOverflowError e) {
+            throwMessage(eval.getErrorPrinter(), e.makeThrow(), indentedPrettyPrinter);
             return null;
         }
         catch (StaticError e) {

--- a/src/org/rascalmpl/semantics/dynamic/Expression.java
+++ b/src/org/rascalmpl/semantics/dynamic/Expression.java
@@ -32,7 +32,9 @@ import org.rascalmpl.ast.Name;
 import org.rascalmpl.ast.Parameters;
 import org.rascalmpl.ast.Statement;
 import org.rascalmpl.exceptions.ImplementationError;
+import org.rascalmpl.exceptions.RascalStackOverflowError;
 import org.rascalmpl.exceptions.RuntimeExceptionFactory;
+import org.rascalmpl.exceptions.StackTrace;
 import org.rascalmpl.exceptions.Throw;
 import org.rascalmpl.interpreter.IEvaluator;
 import org.rascalmpl.interpreter.IEvaluatorContext;
@@ -542,12 +544,14 @@ public abstract class Expression extends org.rascalmpl.ast.Expression {
 				catch (Failure | MatchFailed e) {
 				    throw RuntimeExceptionFactory.callFailed(eval.getValueFactory().list(actuals), eval.getCurrentAST(), eval.getStackTrace());
 				}
+				catch (StackOverflowError e) {
+					// this should not use so much stack as to trigger another StackOverflowError
+					throw new RascalStackOverflowError(this, eval.getCurrentEnvt());
+				}
 				return res;
 			}
-			catch (StackOverflowError e) {
-				e.printStackTrace();
-				throw RuntimeExceptionFactory.stackOverflow(this, eval.getStackTrace());
-			}
+			finally {}
+			
 		}
 
 		@Override


### PR DESCRIPTION
* stackoverflow errors were not reported properly. Instead the
  interpreter triggered many more stackoverflow errors while trying to
  report on them.
* fixed this by capturing the deepest overflow exception and wrapping
  the current runtime stack in a cheap exception object. This object is
  then thrown an caught by the REPL loop which prints the proper
  exception stack trace.
* We lost the ability to catch a stackOverflow() exception in Rascal
  code with this. This is problematic since there are tools that use
  that (drAmbiguity) in case of expected eternal recursions. So for now
  this is PR and I would like to hear if anybody has ideas on how to fix
  this properly without loss of this important feature.
