### PR TITLE
added default clipboard utility (ported from Eclipse environment), which should work on any non-headless JVM environment

### DIFF
--- a/src/org/rascalmpl/library/util/Clipboard.java
+++ b/src/org/rascalmpl/library/util/Clipboard.java
@@ -1,0 +1,49 @@
+package org.rascalmpl.library.util;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.rascalmpl.debug.IRascalMonitor;
+import org.rascalmpl.values.RascalValueFactory;
+import org.rascalmpl.values.parsetrees.SymbolAdapter;
+import org.rascalmpl.values.parsetrees.TreeAdapter;
+
+import io.usethesource.vallang.IBool;
+import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.IInteger;
+import io.usethesource.vallang.IString;
+import io.usethesource.vallang.IValue;
+import io.usethesource.vallang.IValueFactory;
+import io.usethesource.vallang.io.StandardTextWriter;
+
+public class Clipboard {
+    private final IValueFactory vf;
+    private final java.awt.datatransfer.Clipboard cp;
+    private IRascalMonitor monitor;
+
+    public Clipboard(IValueFactory vf, IRascalMonitor monitor) {
+        this.vf = vf;
+        this.cp = java.awt.Toolkit.getDefaultToolkit().getSystemClipboard();
+        this.monitor = monitor;
+    }
+
+    public void copy(IString arg, IBool indent, IInteger level) {
+		cp.setContents(new StringSelection(arg.getValue()), null);
+    }
+
+    public IString paste() {
+        try {
+            if (cp.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
+                return vf.string(cp.getData(DataFlavor.stringFlavor).toString());
+            }
+        }
+        catch (UnsupportedFlavorException | IOException e) {
+           monitor.warning("Clipboard::paste failed", null);
+        }
+        
+        return vf.string("");
+    }
+}

--- a/src/org/rascalmpl/library/util/Clipboard.java
+++ b/src/org/rascalmpl/library/util/Clipboard.java
@@ -4,20 +4,9 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
-import java.io.StringWriter;
-
 import org.rascalmpl.debug.IRascalMonitor;
-import org.rascalmpl.values.RascalValueFactory;
-import org.rascalmpl.values.parsetrees.SymbolAdapter;
-import org.rascalmpl.values.parsetrees.TreeAdapter;
-
-import io.usethesource.vallang.IBool;
-import io.usethesource.vallang.IConstructor;
-import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.IString;
-import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.IValueFactory;
-import io.usethesource.vallang.io.StandardTextWriter;
 
 public class Clipboard {
     private final IValueFactory vf;

--- a/src/org/rascalmpl/library/util/Clipboard.java
+++ b/src/org/rascalmpl/library/util/Clipboard.java
@@ -30,7 +30,7 @@ public class Clipboard {
         this.monitor = monitor;
     }
 
-    public void copy(IString arg, IBool indent, IInteger level) {
+    public void copy(IString arg) {
 		cp.setContents(new StringSelection(arg.getValue()), null);
     }
 

--- a/src/org/rascalmpl/library/util/Clipboard.java
+++ b/src/org/rascalmpl/library/util/Clipboard.java
@@ -31,7 +31,8 @@ public class Clipboard {
     }
 
     public void copy(IString arg) {
-		cp.setContents(new StringSelection(arg.getValue()), null);
+        var selection = new StringSelection(arg.getValue());
+		cp.setContents(selection, selection);
     }
 
     public IString paste() {

--- a/src/org/rascalmpl/library/util/Clipboard.rsc
+++ b/src/org/rascalmpl/library/util/Clipboard.rsc
@@ -13,14 +13,13 @@ then paste always returns the empty string.
 java str paste();
 
 @javaClass{org.rascalmpl.library.util.Clipboard}
-@synopsis{Load the pretty printed value as a string into the system clipboard.}
+@synopsis{Load the contents of a string value into the system clipboard.}
 @description{
-This will pretty print a value to a string and then load it into the clipboard.
-* top-level strings are unquoted and de-escaped first
-* top-level parse trees are yielded
-* structured values are pretty-printed with each indentation level `level` spaces deep.
+This will put the contents of the string value in into the system clipboard.
+So this is not the string value with quotes and escapes, but the pure String
+data.
 
 If the system's clipboard is not accessible (say we are running in a headless environment),
 then copy always has no effect.
 }
-java void copy(str content, bool indent=true, int level=2);
+java void copy(str content);

--- a/src/org/rascalmpl/library/util/Clipboard.rsc
+++ b/src/org/rascalmpl/library/util/Clipboard.rsc
@@ -10,6 +10,13 @@ the source to a string value.
 If the system's clipboard is not accessible (say we are running in a headless environment),
 then paste always returns the empty string.
 }
+@pitfalls{
+* the first time paste or copy are called the UI toolkit must boot up; it can take a few seconds.
+}
+@benefits{
+* copy/paste allow for interesting and useful user interactions, especially while experimenting on the REPL.
+* paste encodes and escapes all kinds of wild characters automatically.
+}
 java str paste();
 
 @javaClass{org.rascalmpl.library.util.Clipboard}
@@ -21,5 +28,12 @@ data.
 
 If the system's clipboard is not accessible (say we are running in a headless environment),
 then copy always has no effect.
+}
+@pitfalls{
+* the first time paste or copy are called the UI toolkit must boot up; it can take a few seconds.
+}
+@benefits{
+* copy/paste allow for interesting and useful user interactions, especially while experimenting on the REPL. 
+* copy transfers the pure content of the string, no quotes or escapes.
 }
 java void copy(str content);

--- a/src/org/rascalmpl/library/util/Clipboard.rsc
+++ b/src/org/rascalmpl/library/util/Clipboard.rsc
@@ -23,7 +23,7 @@ java str paste();
 @synopsis{Load the contents of a string value into the system clipboard.}
 @description{
 This will put the contents of the string value in into the system clipboard.
-So this is not the string value with quotes and escapes, but the pure String
+So this is not the string value with quotes and escapes, but the pure string
 data.
 
 If the system's clipboard is not accessible (say we are running in a headless environment),

--- a/src/org/rascalmpl/library/util/Clipboard.rsc
+++ b/src/org/rascalmpl/library/util/Clipboard.rsc
@@ -1,0 +1,26 @@
+@synopsis{Programmatic access to the native system clipboard (copy and paste), with some handy (de)-escaping features.}
+module util::Clipboard
+
+@javaClass{org.rascalmpl.library.util.Clipboard}
+@synopsis{If there is textual content in the current clipboard, then return it as a string.}
+@description{
+This will transfer any plaintext content that is currently on the system clipboard, no matter
+the source to a string value.
+
+If the system's clipboard is not accessible (say we are running in a headless environment),
+then paste always returns the empty string.
+}
+java str paste();
+
+@javaClass{org.rascalmpl.library.util.Clipboard}
+@synopsis{Load the pretty printed value as a string into the system clipboard.}
+@description{
+This will pretty print a value to a string and then load it into the clipboard.
+* top-level strings are unquoted and de-escaped first
+* top-level parse trees are yielded
+* structured values are pretty-printed with each indentation level `level` spaces deep.
+
+If the system's clipboard is not accessible (say we are running in a headless environment),
+then copy always has no effect.
+}
+java void copy(str content, bool indent=true, int level=2);


### PR DESCRIPTION
This adds util::Clipboard::{paste,copy} functions that do what you think they do. 