### PR TITLE
added a buffer for unfinished lines during progress bar printing. the lines will be completed by the next print, or way at the end when all progress bars are done. 

### DIFF
--- a/src/org/rascalmpl/library/util/Monitor.rsc
+++ b/src/org/rascalmpl/library/util/Monitor.rsc
@@ -206,6 +206,9 @@ test bool unfinishedInputTest() {
   for (/<l:[a-z]>/ := "abcdefghijklmnopqrstuwvxyz") {
     print(l); // no newline!
     jobStep("job", "letter <l>", work=1);
+    if (arbInt(10) == 0) {
+      println(); // break it
+    }
   }
   println(); // flush it
   jobEnd("job");

--- a/src/org/rascalmpl/library/util/Monitor.rsc
+++ b/src/org/rascalmpl/library/util/Monitor.rsc
@@ -200,3 +200,14 @@ test bool simpleAsyncPrintTest() {
   jobEnd("job");
   return true;
 }
+
+test bool unfinishedInputTest() {
+  jobStart("job", totalWork=26);
+  for (/<l:[a-z]>/ := "abcdefghijklmnopqrstuwvxyz") {
+    print(l); // no newline!
+    jobStep("job", "letter <l>", work=1);
+  }
+  println(); // flush it
+  jobEnd("job");
+  return true;
+}

--- a/src/org/rascalmpl/library/util/Monitor.rsc
+++ b/src/org/rascalmpl/library/util/Monitor.rsc
@@ -210,7 +210,7 @@ test bool unfinishedInputTest() {
       println(); // break it
     }
   }
-  println(); // flush it
+  // println(); // flush it
   jobEnd("job");
   return true;
 }

--- a/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
+++ b/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
@@ -332,7 +332,7 @@ public class TerminalProgressBarMonitor extends FilterOutputStream implements IR
                 + " "
                 ;
 
-            writer.println("\r" + line); // note this puts us one line down
+            writer.println(line); // note this puts us one line down
         }
 
         private String threadLabel() {

--- a/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
+++ b/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
@@ -489,18 +489,14 @@ public class TerminalProgressBarMonitor extends FilterOutputStream implements IR
     }
 
     private UnfinishedLine findUnfinishedLine() {
-        UnfinishedLine before = unfinishedLines.stream()
+        return unfinishedLines.stream()
             .filter(l -> l.threadId == Thread.currentThread().getId())
             .findAny()
-            .orElse(null);
-
-        if (before == null) {
-            UnfinishedLine l = new UnfinishedLine();
-            unfinishedLines.add(l);
-            before = l;
-        }
-
-        return before;
+            .orElseGet(() -> {
+                UnfinishedLine l = new UnfinishedLine();
+                unfinishedLines.add(l);
+                return l;    
+            });
     }
     
     @Override

--- a/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
+++ b/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
@@ -171,10 +171,17 @@ public class TerminalProgressBarMonitor extends FilterOutputStream implements IR
                 // write everything out (except the last unfinished line), but including the last newline
                 out.write(buffer, 0, lastNewLine + 1);
                 
-                // rewind buffer to throw everything away that has been written already
-                curEnd -= lastNewLine;
-                System.arraycopy(buffer, lastNewLine + 1, buffer, 0, curEnd);
-                lastNewLine = -1; // no newline anymore
+                if (lastNewLine + 1 == curEnd) {
+                    // nothing left
+                    curEnd = 0;
+                    lastNewLine = -1;
+                }
+                else {
+                    // copy the last line that does not end with a newline
+                    curEnd -= lastNewLine;
+                    System.arraycopy(buffer, lastNewLine + 1, buffer, 0, curEnd);
+                    lastNewLine = -1; // no newline anymore
+                }
             }
 
             // otherwise we wait until the next input comes to be able to complete a line.
@@ -190,7 +197,7 @@ public class TerminalProgressBarMonitor extends FilterOutputStream implements IR
         }
     
         private int startOfLastLine() {
-            for (int i = curEnd; i >= 0; i--) {
+            for (int i = curEnd - 1; i >= 0; i--) {
                 if (buffer[i] == '\n') {
                     return i;
                 }

--- a/src/org/rascalmpl/test/infrastructure/TestFramework.java
+++ b/src/org/rascalmpl/test/infrastructure/TestFramework.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.After;
-import org.rascalmpl.debug.IRascalMonitor;
 import org.rascalmpl.interpreter.Evaluator;
 import org.rascalmpl.interpreter.env.GlobalEnvironment;
 import org.rascalmpl.interpreter.env.ModuleEnvironment;

--- a/src/org/rascalmpl/uri/file/UNCResolver.java
+++ b/src/org/rascalmpl/uri/file/UNCResolver.java
@@ -2,8 +2,6 @@ package org.rascalmpl.uri.file;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.regex.Pattern;
-
 import io.usethesource.vallang.ISourceLocation;
 
 /**

--- a/test/org/rascalmpl/MatchFingerprintTest.java
+++ b/test/org/rascalmpl/MatchFingerprintTest.java
@@ -21,8 +21,6 @@ import org.rascalmpl.interpreter.Evaluator;
 import org.rascalmpl.interpreter.env.GlobalEnvironment;
 import org.rascalmpl.interpreter.env.ModuleEnvironment;
 import org.rascalmpl.test.infrastructure.RascalJUnitTestRunner;
-import org.rascalmpl.test.infrastructure.TestFramework;
-
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.ISourceLocation;


### PR DESCRIPTION
Fixes #1948 and #1946 by considering all different situations that can arise when output is printed during progress bar visualizations:
* the new output does not end with a newline
* previously output did not end with a newline
* both combined, and
* neither

The new implementation satisfies the **invariant** that the cursor position will always be on **column 0** when a new version of a progress bar is printed. This is necesary for the progress bar to fit one exactly one line and fill it; and also to prevent flickering (a bar that moves would flicker).

Furthermore this implementation is thread-safe, because it maintains unfinished sentences for every different thread, and completes them incrementally as new output is printed from each thread. In this manner another invariant is satisfied: never is output printed one the same line from different threads. The lines of different threads may interleave; but not the columns.

The printing is now incremental _per line_ such that output still appears as the program is running, but it is _synchronized_ on newline characters, in order to be able to satisfy the "column=0" invariant at all times.