### PR TITLE
Refactoring eval to allow for full path configuration via a PathConfig parameter.

### DIFF
--- a/src/org/rascalmpl/library/util/Eval.java
+++ b/src/org/rascalmpl/library/util/Eval.java
@@ -23,7 +23,6 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.rascalmpl.ast.Expression.ReifiedType;
 import org.rascalmpl.debug.IRascalMonitor;
 import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.ideservices.IDEServices;

--- a/src/org/rascalmpl/library/util/Eval.java
+++ b/src/org/rascalmpl/library/util/Eval.java
@@ -323,14 +323,14 @@ public class Eval {
 	public static class EvaluatorInterruptTimer extends Thread {
 		private final Evaluator eval;
 		private final int timeout;
-		private int elapsed;
 		private final int sample;
 		private volatile boolean running;
 		
 		public EvaluatorInterruptTimer(Evaluator eval, int timeout) {
 			super();
+			setDaemon(true);
 			this.eval = eval;
-			this.elapsed = 0;
+			// this.elapsed = 0;
 			this.timeout = timeout;
 			this.sample = java.lang.Math.max(timeout / 10, 1);
 			running = true;
@@ -338,7 +338,7 @@ public class Eval {
 
 		public void run() {
 			running = true;
-			elapsed = 0;
+			var elapsed = 0;
 			while (running) {
 				try {
 					sleep(sample);

--- a/src/org/rascalmpl/library/util/Eval.java
+++ b/src/org/rascalmpl/library/util/Eval.java
@@ -271,7 +271,7 @@ public class Eval {
 			this.eval = eval;
 			this.elapsed = 0;
 			this.timeout = timeout;
-			this.sample = timeout / 10;
+			this.sample = java.lang.Math.max(timeout / 10, 1);
 			running = true;
 		}
 

--- a/src/org/rascalmpl/library/util/Eval.java
+++ b/src/org/rascalmpl/library/util/Eval.java
@@ -14,27 +14,39 @@
 *******************************************************************************/
 package org.rascalmpl.library.util;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.rascalmpl.ast.Expression.ReifiedType;
 import org.rascalmpl.debug.IRascalMonitor;
 import org.rascalmpl.exceptions.RuntimeExceptionFactory;
-import org.rascalmpl.exceptions.Throw;
+import org.rascalmpl.ideservices.IDEServices;
 import org.rascalmpl.interpreter.Evaluator;
-import org.rascalmpl.interpreter.IEvaluator;
-import org.rascalmpl.interpreter.env.Environment;
+import org.rascalmpl.interpreter.control_exceptions.InterruptException;
+import org.rascalmpl.interpreter.control_exceptions.MatchFailed;
 import org.rascalmpl.interpreter.env.GlobalEnvironment;
 import org.rascalmpl.interpreter.env.ModuleEnvironment;
+import org.rascalmpl.interpreter.load.StandardLibraryContributor;
 import org.rascalmpl.interpreter.result.Result;
-import org.rascalmpl.interpreter.staticErrors.StaticError;
 import org.rascalmpl.interpreter.staticErrors.UnexpectedType;
-import org.rascalmpl.parser.gtd.exception.ParseError;
+import org.rascalmpl.interpreter.utils.RascalManifest;
+import org.rascalmpl.shell.ShellEvaluatorFactory;
+import org.rascalmpl.types.RascalTypeFactory;
 import org.rascalmpl.types.TypeReifier;
+import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.uri.classloaders.SourceLocationClassLoader;
+import org.rascalmpl.uri.project.ProjectURIResolver;
+import org.rascalmpl.uri.project.TargetURIResolver;
+import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
+import org.rascalmpl.values.functions.IFunction;
 
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IInteger;
@@ -48,166 +60,215 @@ import io.usethesource.vallang.type.TypeFactory;
 import io.usethesource.vallang.type.TypeStore;
 
 public class Eval {
-	private final IValueFactory values;
-		
-	private final IInteger duration;
-	private final Evaluator eval;
-	private int evalCount = 0;
+	private final IRascalValueFactory values;
 
 	private final TypeReifier tr;
 	private final TypeFactory tf = TypeFactory.getInstance();
 	private final TypeStore store = new TypeStore();
 	private final Type param = tf.parameterType("T");
 	public final Type Result = tf.abstractDataType(store, "Result", param);
+	public final Type TypeTyp = RascalTypeFactory.getInstance().reifiedType(param);
 	public final Type Result_void = tf.constructor(store, Result, "ok");
 	public final Type Result_value = tf.constructor(store, Result, "result", param, "val");
 	public final Type Exception = tf.abstractDataType(store, "Exception");
 	public final Type Exception_StaticError = tf.constructor(store, Exception, "StaticError", tf.stringType(), "messages", tf.sourceLocationType(), "location");
- 
+	private final Type resetType = tf.functionType(tf.voidType(), tf.tupleEmpty(), tf.tupleEmpty());
+	private final Type evalType = tf.functionType(Result_value, tf.tupleType(TypeTyp, tf.stringType()), tf.tupleEmpty());
+	private final Type execConstructor;
 
+	/* the following four fields are inherited by the configuration of nested evaluators */
+	private final OutputStream stderr;
+	private final OutputStream stdout;
+	private final InputStream input;
+	private final IDEServices services;
 			
-	public Eval(IValueFactory values, OutputStream out, OutputStream err, InputStream in, ClassLoader loader, IRascalMonitor monitor) {
+	public Eval(IRascalValueFactory values, OutputStream out, OutputStream err, InputStream in, ClassLoader loader, IDEServices services, TypeStore ts) {
 		super();
 		this.values = values;
 		this.tr = new TypeReifier(values);
-		this.duration = values.integer(1000*100); // default duration for eval
-		
-		GlobalEnvironment heap = new GlobalEnvironment();
-        ModuleEnvironment root = new ModuleEnvironment("$eval$", heap);
-        this.eval = new Evaluator(values, in, err, out, root, heap, monitor);
-        
-        // TODO: this is to fix the course Question compiler with a workaround.
-        // it would be better to parameterize eval with a PathConfig.
-        this.eval.addRascalSearchPath(URIUtil.rootLocation("std"));
-        //          this.eval.getConfiguration().setRascalJavaClassPathProperty(ctx.getConfiguration().getRascalJavaClassPathProperty());
-	}
-
-	private ModuleEnvironment getUniqueModuleEnvironment() {
-		return new ModuleEnvironment("$evalinstance$" + evalCount++ , eval.getHeap());
-	}
-
-	public IValue eval (IValue typ, IString input, IInteger duration) {
-		Result<IValue> result = doEval(typ, ValueFactoryFactory.getValueFactory().list(input), duration, true);
-		
-		if(result.getStaticType().isBottom()){
-		  return values.constructor(Result_void);
-		}
-		else {
-			Map<Type,Type> bindings = new HashMap<Type,Type>();
-			bindings.put(param, result.getStaticType());
-			return values.constructor(Result_value.instantiate(bindings), result.getValue());
-		}
+		this.stderr = err;
+		this.stdout = out;
+		this.input = in;
+		this.services = services;
+		execConstructor = ts.lookupConstructor(ts.lookupAbstractDataType("RascalRuntime"), "evaluator").iterator().next();
 	}
 	
-	public IValue eval (IValue typ, IString input) {
-		return eval(typ, input, duration);
-	}
-
-	public IValue eval (IValue typ, IList commands, IInteger duration) {
-		Result<IValue> result = doEval(typ, commands, duration, true);
-		
-		if(result.getStaticType().isBottom()){
-		//if (result.getType().isSubtypeOf(TypeFactory.getInstance().voidType())) {
-			return values.constructor(Result_void);
-		}
-		else {
-			Map<Type,Type> bindings = new HashMap<Type,Type>();
-			bindings.put(param, result.getStaticType());
-			return values.constructor(Result_value.instantiate(bindings), result.getValue());
-		}
-	}
-	
-	public IValue eval (IValue typ, IList commands) {
-		return eval(typ, commands, duration);
-	}
-	
-	public IValue evalType (IString input, IInteger duration) {
-		Result<IValue> result =  doEval(null, values.list(input), duration, true);
-		// Make sure redundant spaces are removed from the type.
-		return values.string(result.getStaticType().toString().replaceAll(" ", ""));
-	}
-	
-	public IValue evalType (IString input) {
-		return evalType(input, duration);
-	}
-	
-	public IValue evalType (IList commands, IInteger duration) {
-		Result<IValue> result = doEval(null, commands, duration, true);
-		return values.string(result.getStaticType().toString().replaceAll(" ", ""));
-	}
-	
-	public IValue evalType (IList commands) {
-		return evalType(commands, duration);
-	}
-	
-	public Result<IValue> doEval (IValue expected, IList commands, IInteger duration, boolean forRascal) {
-		IEvaluator<Result<IValue>> evaluator = eval;
-		EvalTimer timer = new EvalTimer(evaluator, duration.intValue());
-
-		Result<IValue> result = null;
-		Environment old = evaluator.getCurrentEnvt();
-		ModuleEnvironment env = getUniqueModuleEnvironment();
-		
+	public IConstructor createRascalRuntime(IConstructor pathConfigCons) {
 		try {
-			timer.start();
-			
-			evaluator.setCurrentEnvt(env);
-			if(!timer.hasExpired() && commands.length() > 0){
-				for(IValue command : commands){
-					ISourceLocation commandLocation = eval.getValueFactory().sourceLocation("eval", "", "/","command=" + ((IString)command).getValue(), null);
-					result = evaluator.evalMore(null, ((IString) command).getValue(), commandLocation);
+			PathConfig pcfg = new PathConfig(pathConfigCons);
+			RascalRuntime runtime = new RascalRuntime(pcfg, input, stderr, stdout, services);
+
+			return values.constructor(execConstructor,
+				pathConfigCons,
+				buildResetFunction(runtime),
+				buildEvalFunction(runtime)
+			);
+		}
+		catch (IOException | URISyntaxException e) {
+			throw RuntimeExceptionFactory.io(values.string(e.getMessage()));
+		}
+	}
+
+	private IFunction buildResetFunction(RascalRuntime exec) {
+		return values.function(resetType, (args, kwargs) -> {
+			exec.reset();
+			return null;
+		});
+	}
+
+	private IFunction buildEvalFunction(RascalRuntime exec) {
+		return values.function(evalType, (args, kwargs) -> {    
+			var durInt = (IInteger) (kwargs.containsKey("duration") ? kwargs.get("duration") : values.integer(-1));
+
+			EvaluatorInterruptTimer timer = new EvaluatorInterruptTimer(exec.eval, durInt.intValue());
+
+			try {	
+				IConstructor expected = (IConstructor) args[0];
+				if (!(expected.getType().getName().equals("type"))) {
+					throw new MatchFailed();
 				}
+
+				IString command = (IString) args[1];
+				if (!command.getType().isString()) {
+					throw new MatchFailed();
+				}
+
+				if (durInt.intValue() > 0) {
+					timer.start();
+				}
+				Result<?> result = exec.eval(services, command.getValue());
+
+				Type typ = tr.valueToType(expected);
+				if (!result.getStaticType().isSubtypeOf(typ)) {
+					throw new UnexpectedType(typ, result.getStaticType(), URIUtil.rootLocation("eval"));
+				}
+
+				if (result.getStaticType().isBottom()) {
+					return values.constructor(Result_void);
+				}
+				else {
+					Map<Type,Type> bindings = new HashMap<Type,Type>();
+					bindings.put(param, result.getStaticType());
+					return values.constructor(Result_value.instantiate(bindings), result.getValue());
+				}
+			}
+			catch (InterruptException | InterruptedException e) {
+				throw RuntimeExceptionFactory.timeout(null, null);
+			}
+			catch (IOException e) {
+				throw RuntimeExceptionFactory.io(values.string(e.getMessage()));
+			}
+			finally {
+				// very necessary to clean up the timer thread
 				timer.cancel();
-				if (timer.hasExpired()) {
-					throw RuntimeExceptionFactory.timeout(null, null);
+			}
+		});
+	}
+
+	/**
+	 * A RascalRuntime is an evaluator that configures itself from a PathConfig instance,
+	 * and then offers the `eval` method, and the `reset` method to interact it.
+	 */
+	private static class RascalRuntime {
+		private final Evaluator eval;
+		
+		public RascalRuntime(PathConfig pcfg, InputStream input, OutputStream stderr, OutputStream stdout, IDEServices services) throws IOException, URISyntaxException{
+			GlobalEnvironment heap = new GlobalEnvironment();
+			ModuleEnvironment root = heap.addModule(new ModuleEnvironment(ModuleEnvironment.SHELL_MODULE, heap));
+			IValueFactory vf = ValueFactoryFactory.getValueFactory();
+			this.eval = new Evaluator(vf, input, stderr, stdout, root, heap, services);
+
+			eval.addRascalSearchPathContributor(StandardLibraryContributor.getInstance());
+			eval.setMonitor(services);        
+			eval.getConfiguration().setRascalJavaClassPathProperty(javaCompilerPathAsString(pcfg.getJavaCompilerPath()));
+			eval.setMonitor(services);
+
+			if (!pcfg.getSrcs().isEmpty()) {
+				ISourceLocation projectRoot = inferProjectRoot((ISourceLocation) pcfg.getSrcs().get(0));
+				String projectName = new RascalManifest().getProjectName(projectRoot);
+				URIResolverRegistry reg = URIResolverRegistry.getInstance();
+				reg.registerLogical(new ProjectURIResolver(projectRoot, projectName));
+				reg.registerLogical(new TargetURIResolver(projectRoot, projectName));
+			}
+
+			for (IValue path : pcfg.getSrcs()) {
+				eval.addRascalSearchPath((ISourceLocation) path); 
+			}
+
+			for (IValue path : pcfg.getLibs()) {
+				eval.addRascalSearchPath((ISourceLocation) path);
+			}
+
+			ClassLoader cl = new SourceLocationClassLoader(pcfg.getClassloaders(), ShellEvaluatorFactory.class.getClassLoader());
+			eval.addClassLoader(cl);
+		}
+
+		private static ISourceLocation inferProjectRoot(ISourceLocation member) {
+			ISourceLocation current = member;
+			URIResolverRegistry reg = URIResolverRegistry.getInstance();
+			while (current != null && reg.exists(current) && reg.isDirectory(current)) {
+				if (reg.exists(URIUtil.getChildLocation(current, "META-INF/RASCAL.MF"))) {
+					return current;
+				}
+
+				if (URIUtil.getParentLocation(current).equals(current)) {
+					// we went all the way up to the root
+					return reg.isDirectory(member) ? member : URIUtil.getParentLocation(member);
 				}
 				
-				if (expected != null) {
-					Type typ = tr.valueToType((IConstructor) expected);
-					if (!result.getStaticType().isSubtypeOf(typ)) {
-						throw new UnexpectedType(typ, result.getStaticType(), URIUtil.rootLocation("eval"));
-					}
-				}
-				return result;
+				current = URIUtil.getParentLocation(current);
 			}
-		}
-		catch (ParseError e) {
-			if (forRascal) 
-				throw RuntimeExceptionFactory.parseError(e.getLocation(), null, null);
-			throw e;
-		}
-		catch (StaticError e) {
-			if (forRascal) {
-			  throw new Throw(values.constructor(Exception_StaticError, values.string(e.getMessage()), e.getLocation()), (ISourceLocation) null, null);
-			}
-			throw e;
-		} 
-		catch (URISyntaxException e) {
-			// this should never happen
-			if (forRascal)
-				throw RuntimeExceptionFactory.illegalArgument(commands, null, null);
-			throw new RuntimeException(e.getMessage(), e);
-		}
-		finally {
-			evaluator.getHeap().removeModule(env);
-			evaluator.setCurrentEnvt(old);
-		}
-		
-		if (forRascal) 
-			throw RuntimeExceptionFactory.illegalArgument(commands, null, null);
-		
-		throw new IllegalArgumentException();
-	}
-	
 
-	public static class Timer extends Thread {
+			return current;
+		}
+		
+		private String javaCompilerPathAsString(IList javaCompilerPath) {
+			StringBuilder b = new StringBuilder();
+
+			for (IValue elem : javaCompilerPath) {
+				ISourceLocation loc = (ISourceLocation) elem;
+
+				if (b.length() != 0) {
+					b.append(File.pathSeparatorChar);
+				}
+
+				// this is the precondition
+				assert loc.getScheme().equals("file");
+
+				// this is robustness in case of experimentation in pom.xml
+				if ("file".equals(loc.getScheme())) {
+					b.append(Paths.get(loc.getURI()).toAbsolutePath().toString());
+				}
+			}
+
+			return b.toString();
+		}
+	
+		public void reset() {
+			eval.getCurrentModuleEnvironment().reset();
+			eval.getHeap().clear();
+		}
+
+		public Result<IValue> eval(IRascalMonitor monitor, String line) throws InterruptedException, IOException {
+			return eval.eval(monitor, line, IRascalValueFactory.getInstance().sourceLocation(URIUtil.assumeCorrect("eval", "", "", "command=" + line)));
+		}
+	}
+
+	/**
+	 * This Thread class counts 10 steps towards overflowing the timeout,
+	 * and then stops while informing the given Evaluator object to interrupt
+	 * its running program.
+	 */
+	public static class EvaluatorInterruptTimer extends Thread {
+		private final Evaluator eval;
 		private final int timeout;
 		private int elapsed;
 		private final int sample;
 		private volatile boolean running;
-
-		public Timer(int timeout) {
+		
+		public EvaluatorInterruptTimer(Evaluator eval, int timeout) {
 			super();
+			this.eval = eval;
 			this.elapsed = 0;
 			this.timeout = timeout;
 			this.sample = timeout / 10;
@@ -227,34 +288,13 @@ public class Eval {
 				elapsed += sample;
 				if (elapsed > timeout && running) {
 					running = false;
-					timeout();
+					eval.interrupt();
 				}
 			}
 		}
 
 		public void cancel() {
 			running = false;
-		}
-
-		public boolean hasExpired() {
-			return elapsed > timeout;
-		}
-
-		public void timeout(){
-			System.err.println("Timeout!");
-		}
-	}
-
-	public static class EvalTimer extends Timer {
-		private IEvaluator<Result<IValue>> eval;
-
-		public EvalTimer(IEvaluator<Result<IValue>> eval, int timeout) {
-			super(timeout);
-			this.eval = eval;
-		}
-		
-		public void timeout(){
-			eval.interrupt();
 		}
 	}
 }

--- a/src/org/rascalmpl/library/util/Eval.rsc
+++ b/src/org/rascalmpl/library/util/Eval.rsc
@@ -8,100 +8,110 @@
 @contributor{Jurgen J. Vinju - Jurgen.Vinju@cwi.nl - CWI}
 @contributor{Atze van der Ploeg - Atze.van.der.Ploeg@cwi.nl (CWI)}
 @contributor{Paul Klint - Paul.Klint@cwi.nl - CWI}
-
-
 module util::Eval
 
 extend Exception;
+extend util::Reflective;
 
-public data Result[&T] = ok() | result(&T val);
+@synopsis{Results encode the output of a call to `eval`}
+@description{
+* `ok` reflects the execution was succesful while there was no output. For example a call to `println` would produce `ok()`.
+* `result` captures a value of a certain type, which is parameterized as `&T`.
+}
+data Result[&T] = ok() | result(&T val);
 
-public data Exception 
+@synsopsis{Normally static errors are not run-time exceptions, but `eval` wraps them due to its dynamic nature.}
+@description{
+`eval` will throw the first static error that is blocking the execution of a command.
+}
+data Exception 
   = StaticError(str message, loc location)
   ; 
- 
 
-@synopsis{Evaluate a (list of) Rascal commands and return the value of the last command.}
+@synopsis{A reusable instance of the Rascal runtime system configured by a specific PathConfig.}
 @description{
-Evaluate a command or a list of commands and return the value of the last command that is executed.
+* `pcfg` documents the configuration parameters for this specific Rascal run-time
+* `reset()` when called clears the heap of imported modules and all the local declarations in the top-level module instance.
+* `eval(typ, command, duration=1000)` evaluates the command, expecting a result of type `typ`. 
+   * The optional `duration` keyword parameterized will limit execution time to the given amount of milliseconds.
+   * The `typ` parameter must be a supertype of any output expected from the `eval` command. If this is not the case, then a run-time exception will be thrown. It is always safe to put `#value` there.
 
-Note that a command can be one of:
-
+For `eval` note that a command can be one of:
 *  Statement
 *  Declaration
 *  Import
 *  Extend
-*  SyntaxDefinition
-   
+*  SyntaxDefinition 
 
-The notable exclusion are exprssions. An expression is not allowed as a command to the eval function. You can easily make a Statement from an Expression by adding a semi-colon.
- 
-An optional `duration` argument may be present to limit the time
-(in milliseconds) the execution may take. By default, the duration is set to 1000 ms.
+For evaluating an Expression simply add a semicolon to the end: `1 + 1;`
 }
 @examples{
 ```rascal-shell
 import util::Eval;
-eval("2 * 3;");
-eval(["X = 2 * 3;", "X + 5;"]);
+e = createRascalRuntime()
+e.eval(#int, "2 * 3;");
 ```
+
+A run-time can keep state between calls of `eval`:
+```rascal-shell
+import util::Eval;
+e = createRascalRuntime()
+e.eval(#void, "import IO");
+e.eval(#int, "int a = 1;");
+e.eval(#void, "println(a)");
+```
+
 }
-// --- eval with default duration (1000 ms)
+data RascalRuntime
+  = evaluator(
+      PathConfig pcfg,
+      void () reset,
+      Result[&T] (type[&T] typ, str command /* int duration=-1 */) eval
+  );
 
-// -- Give input string to the Rascal evaluator and return its value
+@synopsis{Workhorse to instantiate a working ((RascalRuntime))/}
 @javaClass{org.rascalmpl.library.util.Eval}
-public java Result[&T] eval(type[&T] typ, str command) throws Timeout, StaticError, ParseError;
-public Result[value] eval(str command)  = eval(#value, command);
+java RascalRuntime createRascalRuntime(PathConfig pcfg=pathConfig());
 
-// -- Give list of commands to the Rascal evaluator and return value of the last one.
-@javaClass{org.rascalmpl.library.util.Eval}
-public java Result[&T] eval(type[&T] typ, list[str] commands) throws Timeout, StaticError, ParseError;
-public Result[value] eval(list[str] commands)  = eval(#value, commands);
- 
-// --- eval with given duration (in milliseconds)
-
-// -- Give input string to the Rascal evaluator and return its value within duration ms.
-@javaClass{org.rascalmpl.library.util.Eval}
-public java Result[&T] eval(type[&T] typ, str command, int duration) throws Timeout, StaticError, ParseError;
-public Result[value] eval(str command, int duration)  = eval(#value, command, duration);
-
-// -- Give list of commands to the Rascal evaluator and return value of the last one within duration ms.
-@javaClass{org.rascalmpl.library.util.Eval}
-public java Result[&T] eval(type[&T] typ, list[str] commands, int duration) throws Timeout, StaticError, ParseError;
-public Result[value] eval(list[str] commands, int duration) = eval(#value, commands, duration);
-
-
-
-@synopsis{Evaluate a (list of) Rascal commands and return the type of the last command.}
+@synopsis{Evaluate a single command and return its return value.}
 @description{
-Evaluate a command or a list of commands and return the type of the value of the last command that is executed.
-An optional `duration` argument may be present to limit the time
-(in milliseconds) the execution may take. By default, the duration is set to 1000 ms.
+This creates a ((RascalRuntime)), uses it to evaluate one command, and then discards the runtime again.
+
+For efficiency's sake it may be better to use ((createRascalRuntime)), and call it's `eval` closure
+as often as you need it. 
 }
-@examples{
-```rascal-shell
-import util::Eval;
-evalType("2 * 3;");
-evalType("[1, 2, 3];");
-```
+public Result[&T] eval(type[&T] typ, str command, int duration=-1, PathConfig pcfg=pathConfig()) 
+  throws Timeout, StaticError, ParseError
+  = eval(typ, [command], pcfg=pcfg, duration=duration);
+
+@synopsis{Evaluate a list of command and return the value of the last command.}
+@description{
+This creates a ((RascalRuntime)), uses it to evaluate some commands, and then discards the runtime again.
+
+For efficiency's sake it may be better to use ((createRascalRuntime)), and call it's `eval` closure
+as often as you need it. 
 }
-// --- evalType with default duration (1000 ms)
+Result[&T] eval(type[&T] typ, list[str] commands, int duration=-1, PathConfig pcfg=pathConfig()) 
+  throws Timeout, StaticError, ParseError {
+    e = createRascalRuntime(pcfg=pcfg);
 
-// -- Give input string to the Rascal evaluator and return its type as string.
-@javaClass{org.rascalmpl.library.util.Eval}
-public java str evalType(str command) throws Timeout, StaticError, ParseError;
+    for (command <- commands[..-1]) {
+      e.eval(#value, command, duration=duration);
+    }
 
-// -- Give list of commands to the Rascal evaluator and return the type of the last one.
-@javaClass{org.rascalmpl.library.util.Eval}
-public java str evalType(list[str] commands) throws Timeout, StaticError, ParseError;
+    return e.eval(typ, commands[-1], duration=duration);
+}
 
-// --- evalType with given duration (in milliseconds)
+@synopsis{Evaluate a list of command and return the value of the last command.}
+@description{
+This creates a ((RascalRuntime)), uses it to evaluate some commands, and then discards the runtime again.
 
-//-- Give input string to the Rascal evaluator and return its type as string within duration ms.
-@javaClass{org.rascalmpl.library.util.Eval}
-public java str evalType(str command, int duration) throws Timeout, StaticError, ParseError;
+For efficiency's sake it may be better to use ((createRascalRuntime)), and call it's `eval` closure
+as often as you need it. 
+}
+Result[value] eval(list[str] commands, int duration=-1, PathConfig pcfg=pathConfig())  
+  throws Timeout, StaticError, ParseError
+  = eval(#value, commands, duration=duration, pcfg=pcfg);
+ 
 
-// -- Give list of commands to the Rascal evaluator and return the type of the last one within duration ms.
-@javaClass{org.rascalmpl.library.util.Eval}
-public java str evalType(list[str] commands, int duration) throws Timeout, StaticError, ParseError;
 

--- a/src/org/rascalmpl/library/util/Eval.rsc
+++ b/src/org/rascalmpl/library/util/Eval.rsc
@@ -225,6 +225,9 @@ test bool evalWithOwnPathConfig() {
   return e.eval(#int, "a") == result(42);
 }
 
-// Here are some deprecated functions for backward compatibility's sake
+test bool testStaticTypeOf() {
+  e = createRascalRuntime();
+  return e.staticTypeOf("1") == #int;
+}
 
 

--- a/src/org/rascalmpl/library/util/Eval.rsc
+++ b/src/org/rascalmpl/library/util/Eval.rsc
@@ -8,6 +8,7 @@
 @contributor{Jurgen J. Vinju - Jurgen.Vinju@cwi.nl - CWI}
 @contributor{Atze van der Ploeg - Atze.van.der.Ploeg@cwi.nl (CWI)}
 @contributor{Paul Klint - Paul.Klint@cwi.nl - CWI}
+@synopsis{Provides string-based programmatic access to a fully functional Rascal execution engine.}
 module util::Eval
 
 extend Exception;
@@ -60,7 +61,18 @@ e.eval(#void, "import IO");
 e.eval(#int, "int a = 1;");
 e.eval(#void, "println(a)");
 ```
-
+}
+@benefits{
+* Creating a single run-time engine is an expensive operation. By reusing it you
+can safe a lot of time and space. Use `.reset()` to reuse the configuration while dropping
+all other state and returning to an initial runtime.
+* The PathConfig parameter completelu defines the configuration of the ((RascalRuntime)).
+}
+@pitfalls{
+* To turn a value string into an actual value, it's better and faster to use ((readTextValueString)) or ((readTextValueFile)).
+* Parsing file paths is better done using ((locFromUnixPath)) and ((locFromWindowsPath)).
+* A ((RascalRuntime)) is neither thread-safe nor thread-friendly. 
+* `staticTypeOf` is an abstract interpreter which can take as much time as running the program. 
 }
 data RascalRuntime
   = evaluator(

--- a/src/org/rascalmpl/library/util/Eval.rsc
+++ b/src/org/rascalmpl/library/util/Eval.rsc
@@ -46,16 +46,16 @@ data RuntimeException
 negative number disables the timeout feature. By default the timeout is off.
 }
 @examples{
-```rascal-shell
+```rascal-shell,error // while bootstrapping
 import util::Eval;
-e = createRascalRuntime()
+e = createRascalRuntime();
 e.eval(#int, "2 * 3;");
 ```
 
 A run-time can keep state between calls of `eval`:
-```rascal-shell
+```rascal-shell,error // while bootstrapping
 import util::Eval;
-e = createRascalRuntime()
+e = createRascalRuntime();
 e.eval(#void, "import IO");
 e.eval(#int, "int a = 1;");
 e.eval(#void, "println(a)");

--- a/src/org/rascalmpl/library/util/Eval.rsc
+++ b/src/org/rascalmpl/library/util/Eval.rsc
@@ -73,14 +73,15 @@ data RascalRuntime
 
 @synopsis{Workhorse to instantiate a working ((RascalRuntime))/}
 @javaClass{org.rascalmpl.library.util.Eval}
+@description{
+See ((RascalRuntime)) on how to use a configured and stateful runtime
+to evaluate Rascal commands or the static type checker.
+}
 java RascalRuntime createRascalRuntime(PathConfig pcfg=pathConfig());
 
 @synopsis{Evaluate a single command and return its return value.}
 @description{
 This creates a ((RascalRuntime)), uses it to evaluate one command, and then discards the runtime again.
-
-For efficiency's sake it may be better to use ((createRascalRuntime)), and call it's `eval` closure
-as often as you need it. 
 }
 @deprecated{Use ((createRascalRuntime)) instead for better efficiency and configurability.}
 Result[&T] eval(type[&T] typ, str command, int duration=-1, PathConfig pcfg=pathConfig()) 
@@ -90,9 +91,6 @@ Result[&T] eval(type[&T] typ, str command, int duration=-1, PathConfig pcfg=path
 @synopsis{Evaluate a list of command and return the value of the last command.}
 @description{
 This creates a ((RascalRuntime)), uses it to evaluate some commands, and then discards the runtime again.
-
-For efficiency's sake it may be better to use ((createRascalRuntime)), and call it's `eval` closure
-as often as you need it. 
 }
 @deprecated{Use ((createRascalRuntime)) instead for better efficiency and configurability.}
 Result[&T] eval(type[&T] typ, list[str] commands, int duration=-1, PathConfig pcfg=pathConfig()) 
@@ -119,14 +117,17 @@ Result[value] eval(list[str] commands, int duration=-1, PathConfig pcfg=pathConf
   = eval(#value, commands, duration=duration, pcfg=pcfg);
 
 @deprecated{Use ((createRascalRuntime)) instead for better efficiency and configurability.} 
+@synopsis{Evaluate a command and return the value, unless the `duration` amount of milliseconds has passed first.}
 Result[&T] eval(type[&T] typ, str command, int duration) throws Timeout, StaticError, ParseError
   = eval(typ, command, duration=duration);
 
 @deprecated{Use ((createRascalRuntime)) instead for better efficiency and configurability.} 
+@synopsis{Evaluate a list of commands and return the value of the last command, unless the `duration` amount of milliseconds has passed first.}
 Result[&T] eval(type[&T] typ, list[str] commands, int duration) throws Timeout, StaticError, ParseError
   = eval(typ, commands, duration=duration);
 
 @deprecated{Use ((createRascalRuntime)) instead for better efficiency and configurability.} 
+
 Result[value] eval(list[str] commands, int duration) 
   = eval(#value, commands, duration=duration);
 

--- a/src/org/rascalmpl/library/util/Eval.rsc
+++ b/src/org/rascalmpl/library/util/Eval.rsc
@@ -25,7 +25,7 @@ data Result[&T] = ok() | result(&T val);
 @description{
 `eval` will throw the first static error that is blocking the execution of a command.
 }
-data Exception 
+data RuntimeException 
   = StaticError(str message, loc location)
   | Timeout()
   ; 

--- a/src/org/rascalmpl/library/util/Validator.rsc
+++ b/src/org/rascalmpl/library/util/Validator.rsc
@@ -43,7 +43,7 @@ private data RuntimeException = none();
 	    name = getName(v);
 	    children = getChildren(v);
         params = getKeywordParameters(v);
-        arity = size(children);
+        int arity = size(children);
 
         candidates // first the constructors with the right name
             = [<name, symbols, kwTypes> | /\cons(label(name, def), symbols, kwTypes, _) := grammar[def]?{}, size(symbols) == arity]

--- a/test/org/rascalmpl/test/util/LibraryUtilModules.java
+++ b/test/org/rascalmpl/test/util/LibraryUtilModules.java
@@ -1,0 +1,11 @@
+package org.rascalmpl.test.util;
+
+import org.junit.runner.RunWith;
+import org.rascalmpl.test.infrastructure.RascalJUnitTestPrefix;
+import org.rascalmpl.test.infrastructure.RascalJUnitTestRunner;
+
+@RunWith(RascalJUnitTestRunner.class)
+@RascalJUnitTestPrefix("util")
+public class LibraryUtilModules {
+    
+}


### PR DESCRIPTION
* this introduces one createRascalRuntime function which configures and captures an Evaluator instance.
* all the other java methods are now pure Rascal

This also prepares for eval not being implemented by an interpreter anymore but by a compiled run-time.
However the `duration` parameter for timeouts leans on the interruptability of the interpreter 
for which there is no known dual in the compiled runtime.

This implementation/design avoids an internal map or cache for run-time configured for specific PathConfig instances. Not keeping a configured evaluator around can severely harm performance when repeatedly calling `eval`. Before "configurability" we had only one Evaluator instance to cache, but with the PathConfig parameter there are potentially many. By using closures to capture the Evaluator instance, the control for keeping the reference is with the programmer that wants to call `eval`, on the Rascal call stack by any chance. If the reference is lost the JVM can quickly GC the footprint of the Evaluator, and if they keep the reference they can keep calling into it as often as required. 

This fixes #1445 
