### PR TITLE
Introduced a new resolver for the `mvn:///` scheme. 

### DIFF
--- a/src/org/rascalmpl/interpreter/Evaluator.java
+++ b/src/org/rascalmpl/interpreter/Evaluator.java
@@ -61,7 +61,6 @@ import org.rascalmpl.debug.IRascalRuntimeInspection;
 import org.rascalmpl.debug.IRascalSuspendTrigger;
 import org.rascalmpl.debug.IRascalSuspendTriggerListener;
 import org.rascalmpl.exceptions.ImplementationError;
-import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.exceptions.StackTrace;
 import org.rascalmpl.ideservices.IDEServices;
 import org.rascalmpl.interpreter.asserts.NotYetImplemented;

--- a/src/org/rascalmpl/interpreter/utils/RascalManifest.java
+++ b/src/org/rascalmpl/interpreter/utils/RascalManifest.java
@@ -5,7 +5,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,6 +21,7 @@ import java.util.zip.ZipEntry;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.uri.jar.JarURIResolver;
 
 import io.usethesource.vallang.ISourceLocation;
 
@@ -256,7 +256,7 @@ public class RascalManifest {
 
     public InputStream manifest(ISourceLocation root) {
         try {
-            return URIResolverRegistry.getInstance().getInputStream(URIUtil.getChildLocation(jarify(root), META_INF_RASCAL_MF));
+            return URIResolverRegistry.getInstance().getInputStream(URIUtil.getChildLocation(JarURIResolver.jarify(root), META_INF_RASCAL_MF));
         } catch (IOException e) {
             return null;
         }
@@ -287,22 +287,6 @@ public class RascalManifest {
         }
 
         return new PathConfig(srcs, libs, binFolder);
-    }
-
-    public static ISourceLocation jarify(ISourceLocation loc) {
-        if (!loc.getPath().endsWith(".jar")) {
-            return loc;
-        }
-        
-        try {
-            loc = URIUtil.changeScheme(loc, "jar+" + loc.getScheme());
-            loc = URIUtil.changePath(loc, loc.getPath() + "!/");
-            return loc;
-        }
-        catch (URISyntaxException e) {
-            assert false;  // this can never happen;
-            return loc;
-        }
     }
 
     public InputStream manifest(JarInputStream stream) {

--- a/src/org/rascalmpl/library/lang/java/m3/internal/JarConverter.java
+++ b/src/org/rascalmpl/library/lang/java/m3/internal/JarConverter.java
@@ -44,9 +44,9 @@ import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.ModuleNode;
 import org.objectweb.asm.tree.ModuleOpenNode;
 import org.objectweb.asm.tree.TypeInsnNode;
-import org.rascalmpl.interpreter.utils.RascalManifest;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.uri.jar.JarURIResolver;
 
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IList;
@@ -141,7 +141,7 @@ public class JarConverter extends M3Converter {
             try (JarInputStream jarStream = new JarInputStream(registry.getInputStream(loc))) {
                 JarEntry entry = jarStream.getNextJarEntry();
                 while (entry != null) {
-                    compUnitPhysical = URIUtil.getChildLocation(RascalManifest.jarify(loc), entry.getName());
+                    compUnitPhysical = URIUtil.getChildLocation(JarURIResolver.jarify(loc), entry.getName());
             
                     if (entry.getName().endsWith(".class")) {
                         String compUnit = getCompilationUnitRelativePath();
@@ -174,7 +174,7 @@ public class JarConverter extends M3Converter {
         String compUnit = className.replaceAll("\\.", "/");
         ClassReader classReader = resolver.buildClassReader(className);
 
-        this.compUnitPhysical = URIUtil.getChildLocation(RascalManifest.jarify(loc), compUnit + ".class");
+        this.compUnitPhysical = URIUtil.getChildLocation(JarURIResolver.jarify(loc), compUnit + ".class");
         setCompilationUnitRelations(compUnit);
         setPackagesRelations(compUnit);
         setClassRelations(classReader, compUnit);

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -8,6 +8,7 @@ import ListRelation;
 import IO;
 import util::Math;
 import Location;
+import util::FileSystem;
 
 int singleChar(str s) = charAt(s,0);
 
@@ -519,3 +520,24 @@ test bool extensionSetSimple()
 
 // we don't want backslashes in windows
 test bool correctTempPathResolverOnWindows() = /\\/ !:= resolveLocation(|tmp:///|).path;
+
+test bool mvnSchemeTest() {
+    jarFiles = find(|mvn:///|, "jar");
+
+    for (jar <- jarFiles) {
+        println(jar);
+        if (/[a-z\-]+-[0-9]+\.[0-9]+\.[0-9]+(-[A-Z\-0-9]+)?/ !:= jar[extension=""].file) {
+            throw "<jar.file> does not match the right regex";
+        }
+
+        groupId = replaceAll(jar.parent.parent.path[1..], "/", ".");
+
+        mvnLoc = |mvn://<groupId>-<jar[extension=""].file>|;
+
+        // this tests the internal consistency of the mvn resolution scheme, comparing
+        // the authority-less version with the decoding of the authority to a nested path.
+        assert resolveLocation(mvnLoc) == resolveLocation(jar);
+    }
+
+    return true;
+}

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -524,7 +524,7 @@ test bool correctTempPathResolverOnWindows() = /\\/ !:= resolveLocation(|tmp:///
 test bool mvnSchemeTest() {
     jarFiles = find(|mvn:///|, "jar");
 
-    for (jar <- jarFiles) {
+    for (jar <- jarFiles, /-sources.jar$/ !:= jar.file) {
         println("jar: <jar>");
 
         resolvedJar = resolveLocation(jar);
@@ -537,11 +537,13 @@ test bool mvnSchemeTest() {
         // the maven resolver does the inverse internally, and these 
         // two processes must match up for the resolver to be correct
         groupId = replaceAll(jar.parent.parent.parent.path[1..], "/", ".");
-        artifactId = jar[extension=""].file;
+        version = jar.parent.file;
+        artifactId = jar.parent.parent.file;
 
         println("groupId: <groupId>");
         println("artifactId: <artifactId>");
-        mvnLoc = |mvn://<groupId>.<artifactId>|;
+        println("version: <version>");
+        mvnLoc = |mvn://<groupId>.<artifactId>-<version>|;
 
         println("mvn: <mvnLoc>");
         

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -525,26 +525,30 @@ test bool mvnSchemeTest() {
     jarFiles = find(|mvn:///|, "jar");
 
     for (jar <- jarFiles) {
-        println(jar);
-        if (/[a-z\-]+-[0-9]+\.[0-9]+\.[0-9]+(-[A-Z\-0-9]+)?/ !:= jar[extension=""].file) {
-            throw "<jar.file> does not match the right regex";
-        }
+        println("jar: <jar>");
 
-        groupId = replaceAll(jar.parent.parent.path[1..], "/", ".");
-
-        mvnLoc = |mvn://<groupId>-<jar[extension=""].file>|;
-        println(resolveLocation(mvnLoc));
-        
-        // resolve and jarify
         resolvedJar = resolveLocation(jar);
-        resolvedJar.file="<jar.file>!";
-        resolvedJar.scheme = "jar+file";
 
-        println(resolvedJar);
-        println(resolveLocation(mvnLoc));
+        println("resolved jar: <resolvedJar>");
+
+        // reconstruct a mvn authority from the path by
+        // dropping leading slashes, mapping slashes to dots
+        // and skipping over the version folder.
+        // the maven resolver does the inverse internally, and these 
+        // two processes must match up for the resolver to be correct
+        groupId = replaceAll(jar.parent.parent.parent.path[1..], "/", ".");
+        artifactId = jar[extension=""].file;
+
+        println("groupId: <groupId>");
+        println("artifactId: <artifactId>");
+        mvnLoc = |mvn://<groupId>.<artifactId>|;
+
+        println("mvn: <mvnLoc>");
         
-        // this tests the internal consistency of the mvn resolution scheme, comparing
-        // the authority-less version with the decoding of the authority to a nested path.
+        resolvedMvn = resolveLocation(mvnLoc);
+
+        println("resolved mvn: <resolvedMvn>");
+    
         assert resolveLocation(mvnLoc) == resolvedJar;
     }
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -557,6 +557,24 @@ test bool mvnSchemeTest() {
         assert resolveLocation(mvnLoc) == resolveLocation(jar) : "<resolveLocation(mvnLoc)> != <resolveLocation(jar)>
                                                                  '  jar: <jar>
                                                                  '  mvnLoc: <mvnLoc>";
+
+        assert exists(mvnLoc) : "<mvnLoc> should exist because <jar> exists.";
+
+        assert exists(mvnLoc + "!") : "<mvnLoc + "!"> should resolve to the jarified root and exist";
+
+        // not all jars contain a META-INF folder
+        if (exists(mvnLoc + "!/META-INF")) {
+            // but if they do then this relation holds
+
+            assert exists(mvnLoc + "META-INF")
+                : "<mvnLoc + "META-INF"> should exist and resolved to the jarified location inside.";
+
+            assert resolveLocation(mvnLoc + "!/META-INF") == resolveLocation(mvnLoc + "META-INF")
+                : "Two different ways of resolving inside the jar (with and without !) should be equivalent";
+
+            assert (mvnLoc + "META-INF").ls == [e[path=e.path[2..]] | e <- (mvnLoc + "!/META-INF").ls]
+                : "listings should be equal mod ! for <mvnLoc + "META-INF">";
+        }
     }
 
     // report on all the failed attempts

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -540,24 +540,27 @@ MavenLocalRepositoryPath parseMavenLocalRepositoryPath(loc jar) {
         return error("This is not a repository release jar; filename should be ArtifactId-Version.jar: <jar.file>");
     }
 
-    if (/\./ := artifactId) {
-        return error("ArtifactId contains dots: <artifactId>");
+    if (/!/ := artifactId) {
+        return error("ArtifactId contains exclamation mark: <artifactId>");
     }
 
     return path(groupId, artifactId, version);
 }
 
 test bool mvnSchemeTest() {
+    debug = false;
     jarFiles = find(|mvn:///|, "jar");
 
     // check whether the implementation of the scheme holds the contract specified in the assert
     for (jar <- jarFiles, path(groupId, artifactId, version) := parseMavenLocalRepositoryPath(jar)) {
-        mvnLoc = |mvn://<groupId>.<artifactId>-<version>|;
-        assert resolveLocation(mvnLoc) == resolveLocation(jar);
+        mvnLoc = |mvn://<groupId>!<artifactId>!<version>|;
+        assert resolveLocation(mvnLoc) == resolveLocation(jar) : "<resolveLocation(mvnLoc)> != <resolveLocation(jar)>
+                                                                 '  jar: <jar>
+                                                                 '  mvnLoc: <mvnLoc>";
     }
 
     // report on all the failed attempts
-    for (jar <- jarFiles, error(msg) := parseMavenLocalRepositoryPath(jar)) {
+    for (debug, jar <- jarFiles, error(msg) := parseMavenLocalRepositoryPath(jar)) {
         println(msg);
     }
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -526,7 +526,7 @@ private data MavenLocalRepositoryPath
     | error(str cause)
     ;
 
-MavenLocalRepositoryPath parseMavenLocalRepositoryPath(loc jar) {
+private MavenLocalRepositoryPath parseMavenLocalRepositoryPath(loc jar) {
     if (jar.extension != "jar") {
         return error("jar should have jar extension");
     }

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -553,7 +553,9 @@ test bool mvnSchemeTest() {
 
     // check whether the implementation of the scheme holds the contract specified in the assert
     for (jar <- jarFiles, path(groupId, artifactId, version) := parseMavenLocalRepositoryPath(jar)) {
+        // this is the contract:
         mvnLoc = |mvn://<groupId>!<artifactId>!<version>|;
+
         assert resolveLocation(mvnLoc) == resolveLocation(jar) : "<resolveLocation(mvnLoc)> != <resolveLocation(jar)>
                                                                  '  jar: <jar>
                                                                  '  mvnLoc: <mvnLoc>";

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -533,10 +533,19 @@ test bool mvnSchemeTest() {
         groupId = replaceAll(jar.parent.parent.path[1..], "/", ".");
 
         mvnLoc = |mvn://<groupId>-<jar[extension=""].file>|;
+        println(resolveLocation(mvnLoc));
+        
+        // resolve and jarify
+        resolvedJar = resolveLocation(jar);
+        resolvedJar.file="<jar.file>!";
+        resolvedJar.scheme = "jar+file";
 
+        println(resolvedJar);
+        println(resolveLocation(mvnLoc));
+        
         // this tests the internal consistency of the mvn resolution scheme, comparing
         // the authority-less version with the decoding of the authority to a nested path.
-        assert resolveLocation(mvnLoc) == resolveLocation(jar);
+        assert resolveLocation(mvnLoc) == resolvedJar;
     }
 
     return true;

--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -21,6 +21,7 @@ import org.rascalmpl.interpreter.utils.RascalManifest;
 import org.rascalmpl.uri.ILogicalSourceLocationResolver;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.uri.jar.JarURIResolver;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
 
@@ -485,7 +486,7 @@ public class PathConfig {
             String libProjectName = manifest.getManifestProjectName(manifest.manifest(dep));
             
             if (libProjectName != null) {
-                mavenLibs.put(libProjectName, RascalManifest.jarify(dep));
+                mavenLibs.put(libProjectName, JarURIResolver.jarify(dep));
             }
         }
 

--- a/src/org/rascalmpl/uri/file/AliasedFileResolver.java
+++ b/src/org/rascalmpl/uri/file/AliasedFileResolver.java
@@ -22,7 +22,7 @@ import io.usethesource.vallang.ISourceLocation;
 public abstract class AliasedFileResolver implements ILogicalSourceLocationResolver {
 
     private final String scheme;
-    private final ISourceLocation root;
+    protected final ISourceLocation root;
 
     AliasedFileResolver(String scheme, String rootPath) {
         this.scheme = scheme;

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -79,7 +79,7 @@ public class MavenRepositoryURIResolver extends AliasedFileResolver {
             
             // if the above fails we default to the home folder anyway.
             // note that since it does not exist this will make all downstream resolutions fail
-            // to to "file does not exist"
+            // to "file does not exist"
         }
         
         return m2HomeFolder;

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -15,7 +15,10 @@ import io.usethesource.vallang.ISourceLocation;
 /**
  * Finds jar files (and what's inside) relative to the root of the LOCAL Maven repository.
  * 
- * We use `mvn://<groupid>.<name>-<version>/<path-inside-jar>` as the general scheme.
+ * We use `mvn://<groupid>!<name>!<version>/<path-inside-jar>` as the general scheme;
+ * also `mvn://<groupid>!<name>!<version>/!/<path-inside-jar>` is allowed to make sure the
+ * root `mvn://<groupid>!<name>!<version>/` remains a jar file unambiguously.
+ * 
  * So the authority encodes the identity of the maven project and the path encodes
  * what's inside the respective jar file.
  * 

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -48,7 +48,7 @@ import io.usethesource.vallang.ISourceLocation;
  */
 public class MavenRepositoryURIResolver extends AliasedFileResolver {
     private final Pattern authorityRegEx 
-        = Pattern.compile("^([a-zA-Z0-9.]+)\\.([a-zA-Z0-9]+)-([0-9]+\\.[0-9]+\\.[0-9]+)(-[A-Z0-9-]+)?$");
+        = Pattern.compile("^([a-zA-Z0-9.]+)\\.([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+\\.[0-9]+)(-[A-Z0-9-]+)?$");
     //                               groupId       .  artifactId  - major .  minor .  patch   -OptionalReleaseTag
 
     public MavenRepositoryURIResolver() throws IOException {
@@ -176,7 +176,7 @@ public class MavenRepositoryURIResolver extends AliasedFileResolver {
                 return jarLocation;
             }
             else {
-                throw new IOException("Could not parse authority into Maven Project group, name and version: " + authority);
+                return null; // signal resolution has failed.
             }
         }    
     }

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -48,7 +48,7 @@ import io.usethesource.vallang.ISourceLocation;
  */
 public class MavenRepositoryURIResolver extends AliasedFileResolver {
     private final Pattern authorityRegEx 
-        = Pattern.compile("^([a-zA-Z0-9-.]+)\\.([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+(\\.[0-9]+)?)(-[A-Z0-9-]+)?$");
+        = Pattern.compile("^([a-zA-Z0-9-.]+)\\.([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+(\\.[0-9]+)?)(-[a-zA-Z0-9-]+)?$");
     //                               groupId       .  artifactId  - major .  minor .  patch   -OptionalReleaseTag
 
     public MavenRepositoryURIResolver() throws IOException {

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -32,8 +32,8 @@ import io.usethesource.vallang.ISourceLocation;
  * the version from the artifactId.
  * 
  * Locations with the `mvn` scheme are typically produced by configuration code that uses 
- * Maven to resolve dependencies. Once the group id, name and version are known, any
- * `mvn:///` location is easily constructed and uses. It can be seen as a transparent
+ * a Maven pom.xml to resolve dependencies. Once the group id, name and version are known, any
+ * `mvn:///` location is easily constructed and used. It can be seen as a transparent
  * short-hand for an absolute `file:///` location that points into the (deeply nested)
  * .m2 local repository. The prime benefits are:
  *    1. much shorter location than `file:///`
@@ -42,7 +42,7 @@ import io.usethesource.vallang.ISourceLocation;
  * 
  * It is a logical resolver in order to allow for short names for frequently
  * occurring paths, without loss of transparancy. We always know which jar file is meant,
- * and the encoding is one-to-one. 
+ * and the encoding is (almost) one-to-one. 
  * 
  * This resolver does NOT find the "latest" version or any version of a package without an explicit
  * version reference in the authority pattern, by design. Any automated resolution here would
@@ -51,7 +51,7 @@ import io.usethesource.vallang.ISourceLocation;
  * to implement dependency resolution.
  * 
  * This resolver also does not implement any download or installation procedure, by design.
- * It does not access and REMOTE repositories although it easily could be implemented.
+ * It does not access any REMOTE repositories although it easily could be implemented.
  * This scheme should simply reflect what _has been downloaded and installed_ into the LOCAL maven
  * repository. This is for the sake of transparancy and predictability, but also for _legal_ reasons:
  * Any automated implicit downloading by the `mvn://` scheme could easily result in late/lazy downloading 
@@ -65,12 +65,16 @@ import io.usethesource.vallang.ISourceLocation;
  * for dependencies on open-source packages, with for example GPL licenses, must have the 
  * opportunity to scrutinize every instance of incorporating such as dependency. Therefore
  * it must not be automated here. Note that these are not necessarily people from the usethesource or
- * Rascal-contributing organizations; but our users (Rascal language engineers) that we protect
- * here.
+ * Rascal-contributing organizations; but our industrial, educational and academic users 
+ * (Rascal language engineers) that we protect here.
  * 
  * This resolver is to replace for the large part the use of the deprecate `lib` scheme
- * from {@see RascalLibraryURIResolver} which leaves too much implicit and automates too 
+ * from {@see RascalLibraryURIResolver} which left too much implicit and automated too 
  * much to obtain any transparancy in dependency resolution. 
+ * 
+ * Another pitfall of this scheme is that since it transparantely resolves to file:/// and jar+file:///
+ * schemes, it could be used to _write_ to `mvn` jars as well. Of course this is very much not a good 
+ * idea; but there is currently no way to register read-only logical schemes.
  */
 public class MavenRepositoryURIResolver extends AliasedFileResolver {
     private final Pattern authorityRegEx 

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -48,7 +48,7 @@ import io.usethesource.vallang.ISourceLocation;
  */
 public class MavenRepositoryURIResolver extends AliasedFileResolver {
     private final Pattern authorityRegEx 
-        = Pattern.compile("^([a-zA-Z0-9.]+)\\.([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+\\.[0-9]+)(-[A-Z0-9-]+)?$");
+        = Pattern.compile("^([a-zA-Z0-9.]+)\\.([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+(\\.[0-9]+)?)(-[A-Z0-9-]+)?$");
     //                               groupId       .  artifactId  - major .  minor .  patch   -OptionalReleaseTag
 
     public MavenRepositoryURIResolver() throws IOException {
@@ -146,7 +146,8 @@ public class MavenRepositoryURIResolver extends AliasedFileResolver {
                 String group = m.group(1);
                 String name = m.group(2);
                 String version = m.group(3);
-                String tag = m.group(4);
+                // String patch = m.group(4);
+                String tag = m.group(5);
 
                 // tags are optional
                 tag = tag == null ? "" : tag;
@@ -160,7 +161,7 @@ public class MavenRepositoryURIResolver extends AliasedFileResolver {
                     + "/"
                     + name
                     + "-"
-                    + version
+                    + version 
                     + tag
                     + ".jar"
                     ;

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -48,8 +48,8 @@ import io.usethesource.vallang.ISourceLocation;
  */
 public class MavenRepositoryURIResolver extends AliasedFileResolver {
     private final Pattern authorityRegEx 
-        = Pattern.compile("^([a-zA-Z0-9-.]+)\\.([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+(\\.[0-9]+)?)(-[a-zA-Z0-9-]+)?$");
-    //                               groupId       .  artifactId  - major .  minor .  patch   -OptionalReleaseTag
+        = Pattern.compile("^([a-zA-Z0-9-.]+)[.]([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+(\\.[0-9]+)?)([-][a-zA-Z0-9\\-_]+|[.]v[0-9]+)?$");
+    //                               groupId       .  artifactId    - major .  minor .  patch         -OptionalReleaseTag
 
     public MavenRepositoryURIResolver() throws IOException {
         super("mvn", inferMavenRepositoryLocation());
@@ -158,6 +158,7 @@ public class MavenRepositoryURIResolver extends AliasedFileResolver {
                     + name
                     + "/"
                     + version
+                    + tag
                     + "/"
                     + name
                     + "-"

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -167,7 +167,17 @@ public class MavenRepositoryURIResolver extends AliasedFileResolver {
 
                 var jarLocation = URIUtil.getChildLocation(root, jarPath);
 
-                if (!path.isEmpty()) {
+                // convenience feature: `/!` path switches to jarified version (helps with auto-completion)
+                var pathIsJarRoot = "/!".equals(path);
+
+                // compensate for additional !'s produced by the previous
+                if (!pathIsJarRoot && path.startsWith("/!")) {
+                    path = path.substring(2);
+                }
+
+                // if the path is non-empty we mean to look inside of the jar
+                    if ((!path.isEmpty() && !path.equals("/")) || pathIsJarRoot) {
+                    path = pathIsJarRoot ? "" : path;
                     // go make a location that points _inside_ of the jar
                     jarLocation = JarURIResolver.jarify(jarLocation);
                     jarLocation = URIUtil.getChildLocation(jarLocation, path);

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -48,8 +48,8 @@ import io.usethesource.vallang.ISourceLocation;
  */
 public class MavenRepositoryURIResolver extends AliasedFileResolver {
     private final Pattern authorityRegEx 
-        = Pattern.compile("^([a-zA-Z0-9-.]+)[.]([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+(\\.[0-9]+)?)([-][a-zA-Z0-9\\-_]+|[.]v[0-9]+)?$");
-    //                               groupId       .  artifactId    - major .  minor .  patch         -OptionalReleaseTag
+        = Pattern.compile("^([a-zA-Z0-9-_.]+?)[!]([a-zA-Z0-9-_.]+)([!][a-zA-Z0-9\\-_.]+)$");
+    //                               groupId         !  artifactId      ! optionAlComplexVersionString
 
     public MavenRepositoryURIResolver() throws IOException {
         super("mvn", inferMavenRepositoryLocation());
@@ -146,24 +146,19 @@ public class MavenRepositoryURIResolver extends AliasedFileResolver {
                 String group = m.group(1);
                 String name = m.group(2);
                 String version = m.group(3);
-                // String patch = m.group(4);
-                String tag = m.group(5);
 
-                // tags are optional
-                tag = tag == null ? "" : tag;
-
+                version = version == null ? "" : version.substring(1);
+              
                 String jarPath 
                     = group.replaceAll("\\.", "/")
                     + "/"
                     + name
                     + "/"
                     + version
-                    + tag
                     + "/"
                     + name
                     + "-"
-                    + version 
-                    + tag
+                    + version
                     + ".jar"
                     ;
 

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -22,7 +22,9 @@ import io.usethesource.vallang.ISourceLocation;
  * So the authority encodes the identity of the maven project and the path encodes
  * what's inside the respective jar file.
  * 
- * Here version is [0-9]+ major . [0-9]+ minor .[0-9]+ path -[A-Za-z\-]* optionalTag
+ * Here version is an arbitrary string with lots of numbers, dots, dashed and underscores.
+ * Typically we'd expect the semantic versioning scheme here with some release tag, but
+ * real maven projects frequently do not adhere to that standard. 
  * 
  * Locations with the `mvn` scheme are typically produced by configuration code that uses 
  * Maven to resolve dependencies. Once the group id, name and version are known, any

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -1,0 +1,108 @@
+package org.rascalmpl.uri.file;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.uri.jar.JarURIResolver;
+
+import io.usethesource.vallang.ISourceLocation;
+
+/**
+ * Finds jar files (and what's inside) relative to the root of the LOCAL Maven repository.
+ * 
+ * We use `mvn://<groupid>.<name>-<version>/<path-inside-jar>` as the general scheme.
+ * So the authority encodes the identity of the maven project and the path encodes
+ * what's inside the respective jar file.
+ * 
+ * Here version is [0-9]+ major . [0-9]+ minor .[0-9]+ path -[A-Za-z\-]* optionalTag
+ * 
+ * Locations with the `mvn` scheme are typically produced by configuration code that uses 
+ * Maven to resolve dependencies. Once the group id, name and version are known, any
+ * `mvn:///` location is easily constructed and uses. It can be seen as a transparent
+ * short-hand for an absolute `file:///` location that points into the (deeply nested)
+ * .m2 local repository. The prime benefits are:
+ *    1. much shorter location than `file:///`
+ *    2. full transparency, more so than `lib:///`
+ *    3. unique identification, modulo the (configured) location of the local repository.
+ * 
+ * It is a logical resolver in order to allow for short names for frequently
+ * occurring paths, without loss of transparancy. We always know which jar file is meant,
+ * and the encoding is one-to-one. 
+ * 
+ * This resolver does NOT find the "latest" version or any version of a package without an explicit
+ * version reference in the authority pattern, by design. Any automated resolution here would
+ * make the dependency management downstream less transparant and possibly error-prone. 
+ * 
+ * This resolver also does not implement any download or installation procedure, by design.
+ * It should simply reflect what has been downloaded and installed into the LOCAL maven
+ * repository.
+ * 
+ * This resolver is to replace for the large part the use of the deprecate `lib` scheme
+ * from {@see RascalLibraryURIResolver} which leaves too much implicit and automates too 
+ * much to obtain any transparancy in dependency resolution. 
+ */
+public class MavenRepositoryURIResolver extends AliasedFileResolver {
+    private final Pattern namePattern 
+        = Pattern.compile("([a-z0-9\\-\\.]+)\\.([a-z0-9\\-]+)\\-([0-9]+\\.[0-9]+\\.[0-9]+(-[A-Za-z0-9\\-)?)");
+
+    public MavenRepositoryURIResolver() throws IOException {
+        super("mvn", inferMavenRepositoryLocation());
+    }
+
+    private static String inferMavenRepositoryLocation() {
+        // TODO add -D and maven home settings resolution
+        return System.getProperty("user.home") + "/.m2";
+    }
+
+    @Override
+    public ISourceLocation resolve(ISourceLocation input) throws IOException {
+        String authority = input.getAuthority();
+        String path = input.getPath();
+
+        if (authority.isEmpty()) {
+            // we simply see this as a path relative to the root of the .m2 folder
+            return URIUtil.getChildLocation(root, path);
+        }
+        else {
+            // the authority encodes the group, name and version of a maven dependency
+            // org.rascalmpl.rascal-34.2.0-RC2
+            var m = namePattern.matcher(authority);
+
+            if (m.matches()) {
+                String group = m.group(0);
+                String name = m.group(1);
+                String version = m.group(3);
+
+                System.err.println("group: " + group);
+                System.err.println("name: " + group);
+                System.err.println("version: " + group);
+
+                String jarPath 
+                    = group.replaceAll("\\.", "/")
+                    + "/"
+                    + name
+                    + "/"
+                    + name
+                    + "-"
+                    + version
+                    + ".jar"
+                    ;
+
+                var jarLocation = URIUtil.getChildLocation(root, jarPath);
+
+                if (!path.isEmpty() && !path.equals("/")) {
+                    // go make a location that points _inside_ of the jar
+                    jarLocation = JarURIResolver.jarify(jarLocation);
+                    jarLocation = URIUtil.getChildLocation(jarLocation, path);
+                }
+
+                return jarLocation;
+            }
+            else {
+                throw new IOException("Could not parse authority into Maven Project group, name and version: " + authority);
+            }
+        }
+        
+    }
+}

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -48,7 +48,7 @@ import io.usethesource.vallang.ISourceLocation;
  */
 public class MavenRepositoryURIResolver extends AliasedFileResolver {
     private final Pattern authorityRegEx 
-        = Pattern.compile("^([a-zA-Z0-9.]+)\\.([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+(\\.[0-9]+)?)(-[A-Z0-9-]+)?$");
+        = Pattern.compile("^([a-zA-Z0-9-.]+)\\.([a-zA-Z0-9-]+)-([0-9]+\\.[0-9]+(\\.[0-9]+)?)(-[A-Z0-9-]+)?$");
     //                               groupId       .  artifactId  - major .  minor .  patch   -OptionalReleaseTag
 
     public MavenRepositoryURIResolver() throws IOException {

--- a/src/org/rascalmpl/uri/jar/JarURIResolver.java
+++ b/src/org/rascalmpl/uri/jar/JarURIResolver.java
@@ -7,6 +7,7 @@ import java.nio.charset.Charset;
 
 import org.rascalmpl.uri.ISourceLocationInput;
 import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.uri.classloaders.IClassloaderLocationResolver;
 
 import io.usethesource.vallang.ISourceLocation;
@@ -154,4 +155,30 @@ public class JarURIResolver implements ISourceLocationInput, IClassloaderLocatio
     public ClassLoader getClassLoader(ISourceLocation loc, ClassLoader parent) throws IOException {
         return registry.getClassLoader(getResolvedJarPath(loc), parent);
     }
+
+    /**
+     * Turns the any location of a jar file, as long as it has the extension `.jar`
+     * to a location inside of that jarfile (the root).
+     * 
+     * For example: file:///myJar.jar  becomes jar+file:///myJar.jar!/
+     * 
+     * After this transformation you can search inside the jar using listEntries
+     * or getChildLocation.
+     */
+    public static ISourceLocation jarify(ISourceLocation loc) {
+        if (!loc.getPath().endsWith(".jar")) {
+            return loc;
+        }
+        
+        try {
+            loc = URIUtil.changeScheme(loc, "jar+" + loc.getScheme());
+            loc = URIUtil.changePath(loc, loc.getPath() + "!/");
+            return loc;
+        }
+        catch (URISyntaxException e) {
+            assert false;  // this can never happen;
+            return loc;
+        }
+    }
+
 }

--- a/src/org/rascalmpl/uri/resolvers.config
+++ b/src/org/rascalmpl/uri/resolvers.config
@@ -8,6 +8,7 @@ org.rascalmpl.uri.classloaders.SystemClassloaderResolver
 org.rascalmpl.uri.jar.JarURIResolver
 org.rascalmpl.uri.zip.ZipURIResolver
 org.rascalmpl.uri.file.HomeURIResolver
+org.rascalmpl.uri.file.MavenRepositoryURIResolver
 org.rascalmpl.uri.file.CWDURIResolver
 org.rascalmpl.uri.file.CurrentWorkingDriveResolver
 org.rascalmpl.uri.file.UNCResolver


### PR DESCRIPTION
If this `mvn://<groupId>!<artifactId>!<versionWithoptionalReleaseTag>` scheme works properly, it can transparantly replace all the `lib://<artifactId/` usages.

* this is a logical resolve that produces `file:///` URIs. This important for efficiency as the `mvn://` paths end up in classloader situations where they are short-circuited into highly optimized URLclassloaders.
* in fact this is a short-hand notation for file:/// URLs that is based only on the folder structure of the maven local repository: `<path>/<to>/<groupId>/<artifactId>/<version>/<artifactId>-<version>.jar` and nothing more and nothing less.
* `mvn:///` the authority-less root resolves to the root of the local maven repository for exploration purposes.
* the actual root of  the maven repository is:
   * if `-Dmaven.repo.local=<whatever>` is set, the root is `whatever`
   * otherwise if `~/.m2` exists, the root is `~/.m2/repository`
   * otherwise if `<localRepository>something</localRepository>` is set in `settings.xml` in the maven installation folder, then the root is `something`
   * otherwise the root defaults to `~/.m2/repository`
* The two `!` separators are essential; we first tried with `.` because of style, but while testing on real local repositories (big ones) we found many projects to have `.` in their artifact names. That led to ambigous parsing of the authority which is not stable. 

For Eclipse projects we were already using `plugin://` and `bundle://` for dependencies transparantly. The `lib:///` scheme did not add anything much there anyway. 

A new PR will make the necessary adjustments to the PathConfig and RascalManifest configuration algorithms for the interpreter and the compiler. This one focuses only on adding the resolution capability for the `mvn` scheme. It is quite possible that after these changes the `Required-Libraries` configuration option is no longer use{d,ful} and we can get rid of it. 