### PR TITLE
Add support to retrieve the next free stack node id

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/grammar/ParserGenerator.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/grammar/ParserGenerator.rsc
@@ -232,7 +232,12 @@ public str newGenerate(str package, str name, Grammar gr) {
            '      <}>
            '    }
            '  }<}>
-           '	
+           '
+           '  private int nextFreeStackNodeId = <newItem()>;
+           '  protected int getFreeStackNodeId() {
+           '    return nextFreeStackNodeId++;
+           '  }
+           '
            '  // Parse methods    
            '  <for (Symbol nont <- (gr.rules.sort), isNonterminal(nont)) { >
            '  <generateParseMethod(newItems, gr.rules[unsetRec(nont)])><}>

--- a/src/org/rascalmpl/parser/gtd/SGTDBF.java
+++ b/src/org/rascalmpl/parser/gtd/SGTDBF.java
@@ -121,6 +121,15 @@ public abstract class SGTDBF<P, T, S> implements IGTD<P, T, S>{
 		unmatchableMidProductionNodes = new DoubleStack<DoubleArrayList<AbstractStackNode<P>, AbstractNode>, AbstractStackNode<P>>();
 		filteredNodes = new DoubleStack<AbstractStackNode<P>, AbstractNode>();
 	}
+
+	/**
+	 * Return a stack node id that is guaranteed not to be in use. 
+	 * The parser generator generates an override for this method as it knows which ids have been dispensed.
+	 * Tests that need this should override this method, probably using a common base class.
+	 */
+	protected int getFreeStackNodeId() {
+		throw new UnsupportedOperationException();
+	}
 	
 	/**
 	 * Triggers the gathering of alternatives for the given non-terminal.


### PR DESCRIPTION
When working on error-recovery the need arose to dynamically allocate new stack node ids.
This functionality might be of use in other scenario's, so this PR adds this support.

It is added in such a way that generating a new version RascalParser.java is not necessary until the `getFreeStackNodeId` method is actually used for Rascal itself.