### PR TITLE
shader renames jansi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,13 @@
                                 <relocation>
                                     <pattern>org.fusesource.jansi</pattern>
                                     <shadedPattern>org.rascampl.fusesource.jansi</shadedPattern>
+                                    <excludes>
+                                        <exclude>org.fusesource.jansi.internal.*</exclude>
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>jline</pattern>
+                                    <shadedPattern>org.rascampl.jline</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>

--- a/pom.xml
+++ b/pom.xml
@@ -296,14 +296,14 @@
                             <relocations>
                                 <relocation>
                                     <pattern>org.fusesource.jansi</pattern>
-                                    <shadedPattern>org.rascampl.fusesource.jansi</shadedPattern>
+                                    <shadedPattern>org.rascalmpl.fusesource.jansi</shadedPattern>
                                     <excludes>
                                         <exclude>org.fusesource.jansi.internal.*</exclude>
                                     </excludes>
                                 </relocation>
                                 <relocation>
                                     <pattern>jline</pattern>
-                                    <shadedPattern>org.rascampl.jline</shadedPattern>
+                                    <shadedPattern>org.rascalmpl.jline</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>

--- a/pom.xml
+++ b/pom.xml
@@ -293,9 +293,12 @@
                                     <resource>io/usethesource/vallang/type/types.config </resource>
                                 </transformer>
                             </transformers>
-                            <!--
-                                    http://zhentao-li.blogspot.nl/2012/06/maven-shade-plugin-invalid-signature.html
-                                -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.fusesource.jansi</pattern>
+                                    <shadedPattern>org.rascampl.fusesource.jansi</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/src/org/rascalmpl/interpreter/ConsoleRascalMonitor.java
+++ b/src/org/rascalmpl/interpreter/ConsoleRascalMonitor.java
@@ -38,8 +38,8 @@ public class ConsoleRascalMonitor implements IRascalMonitor {
 
 	@Override
 	public void jobStep(String name, String msg, int inc) {
-		//out.println(name);
-		//out.flush();
+		out.println(name);
+		out.flush();
 	}
 
 	@Override

--- a/src/org/rascalmpl/library/lang/rascal/vis/ImportGraph.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/vis/ImportGraph.rsc
@@ -87,8 +87,8 @@ ProjectModel getProjectModel(loc file) {
 
         return projectModel(
             modules = {name},
-            imports = {<name, i> | i <- imps},
-            extends = {<name, e> | e <- exts}
+            imports = {name} * imps,
+            extends = {name} * exts
         );
     }
     catch ParseError(_) : 


### PR DESCRIPTION
This PR uses the shader to move the `org.fusesource.jansi` package to `org.rascalmpl.fusesource.jansi`. Doing this prevents a later collision between jansi versions inside of the mvn runtime.

Some collatoral fix: For `-B` mvn batch mode the monitor did not print intermediate steps anymore. Fixed that too.