### PR TITLE
Rewrote isSameFile and other common functions used in rascal-core

### DIFF
--- a/src/org/rascalmpl/library/Location.rsc
+++ b/src/org/rascalmpl/library/Location.rsc
@@ -69,12 +69,8 @@ This conversion supports generic Unix path syntax, including:
 loc locFromUnixPath(str path) = parseUnixPath(path);
 
 @synopsis{Check that two locations refer to the same file.}    
-bool isSameFile(loc l, loc r) 
-    = l.scheme == r.scheme 
-    && l.authority == r.authority
-    && l.path == r.path
-    && l.query == r.query
-    ;
+@javaClass{org.rascalmpl.library.Prelude}
+java bool isSameFile(loc l, loc r);
 
 @synopsis{Compare two location values lexicographically.}
 @description{
@@ -105,23 +101,8 @@ Strict containment between two locations `inner` and `outer` holds when
 - both.
 }
 
-bool isStrictlyContainedIn(loc inner, loc outer){
-    // inlined inverse of isSameFile, as this function gets called very often in rascal-core
-    if (inner.scheme != outer.scheme 
-        || inner.authority != outer.authority
-        || inner.path != outer.path
-        || inner.query != outer.query) {
-        return false;
-    }
-    if(inner.offset?){
-        if(outer.offset?){
-            return inner.offset == outer.offset && inner.offset + inner.length <  outer.offset + outer.length
-                || inner.offset >  outer.offset && inner.offset + inner.length <= outer.offset + outer.length;
-        } 
-        return inner.offset > 0;
-    }
-    return false;
-}
+@javaClass{org.rascalmpl.library.Prelude}
+java bool isStrictlyContainedIn(loc inner, loc outer);
 
 
 @synopsis{Is a location textually contained in another location?}
@@ -133,22 +114,8 @@ Containment between two locations `inner` and `outer` holds when
 - `inner` is strictly contained in `outer`.
 }
 
-bool isContainedIn(loc inner, loc outer){
-    // inlined inverse of isSameFile, as this function gets called very often in rascal-core
-    if (inner.scheme != outer.scheme 
-        || inner.authority != outer.authority
-        || inner.path != outer.path
-        || inner.query != outer.query) {
-        return false;
-    }
-    if(inner.offset?){
-        if(outer.offset?){
-            return (inner.offset >= outer.offset && inner.offset + inner.length <= outer.offset + outer.length);
-        } 
-        return true;
-    }
-    return !outer.offset?;
-}
+@javaClass{org.rascalmpl.library.Prelude}
+java bool isContainedIn(loc inner, loc outer);
 
 
 @synopsis{Begins a location's text before (but may overlap with) another location's text?}
@@ -192,10 +159,8 @@ bool isImmediatelyAfter(loc l, loc r)
 
 
 @synopsis{Refer two locations to text that overlaps?}
-bool isOverlapping(loc l, loc r)
-    = isSameFile(l, r) && (  (l.offset <= r.offset && l.offset + l.length > r.offset) 
-                          || (r.offset <= l.offset && r.offset + r.length > l.offset)
-                          );
+@javaClass{org.rascalmpl.library.Prelude}
+java bool isOverlapping(loc l, loc r);
 
 
 @synopsis{Compute a location that textually covers the text of a list of locations.}

--- a/src/org/rascalmpl/library/Location.rsc
+++ b/src/org/rascalmpl/library/Location.rsc
@@ -69,7 +69,12 @@ This conversion supports generic Unix path syntax, including:
 loc locFromUnixPath(str path) = parseUnixPath(path);
 
 @synopsis{Check that two locations refer to the same file.}    
-bool isSameFile(loc l, loc r) = l.top[fragment=""] == r.top[fragment=""];
+bool isSameFile(loc l, loc r) 
+    = l.scheme == r.scheme 
+    && l.authority == r.authority
+    && l.path == r.path
+    && l.query == r.query
+    ;
 
 @synopsis{Compare two location values lexicographically.}
 @description{
@@ -101,18 +106,19 @@ Strict containment between two locations `inner` and `outer` holds when
 }
 
 bool isStrictlyContainedIn(loc inner, loc outer){
-    if(inner == outer){
+    // inlined inverse of isSameFile, as this function gets called very often in rascal-core
+    if (inner.scheme != outer.scheme 
+        || inner.authority != outer.authority
+        || inner.path != outer.path
+        || inner.query != outer.query) {
         return false;
     }
-    if(isSameFile(inner, outer)){
-       if(inner.offset?){
-          if(outer.offset?){
-            return    inner.offset == outer.offset && inner.offset + inner.length <  outer.offset + outer.length
-                   || inner.offset >  outer.offset && inner.offset + inner.length <= outer.offset + outer.length;
-          } else {
-            return inner.offset > 0;
-          }
-       }
+    if(inner.offset?){
+        if(outer.offset?){
+            return inner.offset == outer.offset && inner.offset + inner.length <  outer.offset + outer.length
+                || inner.offset >  outer.offset && inner.offset + inner.length <= outer.offset + outer.length;
+        } 
+        return inner.offset > 0;
     }
     return false;
 }
@@ -128,18 +134,20 @@ Containment between two locations `inner` and `outer` holds when
 }
 
 bool isContainedIn(loc inner, loc outer){
-    if(isSameFile(inner, outer)){
-       if(inner.offset?){
-          if(outer.offset?){
-            return (inner.offset >= outer.offset && inner.offset + inner.length <= outer.offset + outer.length);
-          } else {
-            return true;
-          }
-       } else {
-         return !outer.offset?;
-       }
+    // inlined inverse of isSameFile, as this function gets called very often in rascal-core
+    if (inner.scheme != outer.scheme 
+        || inner.authority != outer.authority
+        || inner.path != outer.path
+        || inner.query != outer.query) {
+        return false;
     }
-    return false;
+    if(inner.offset?){
+        if(outer.offset?){
+            return (inner.offset >= outer.offset && inner.offset + inner.length <= outer.offset + outer.length);
+        } 
+        return true;
+    }
+    return !outer.offset?;
 }
 
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Locations.rsc
@@ -351,6 +351,30 @@ test bool isContainedIn2(int f, int len){
     return report(l1, l2, !isContainedIn(l2, l1));
 }
 
+// isStrictlyContainedIn
+
+test bool isStrictlyContainedIn1(int f, int len) {
+    f1 = restrict(f); t1 = restrict(f1 + len);
+    len1 = t1 - f1;
+    delta = (t1-f1)/2;
+    l1 = getLoc(f1, t1); l2 = getLoc(f1 + delta, t1 - delta);
+    return report(l1, l2, delta > 0 ==> isStrictlyContainedIn(l2, l1));
+}
+
+test bool isStrictlyContainedIn2(int f, int len) {
+    f1 = restrict(f); t1 = restrict(f1 + len);
+    len1 = t1 - f1;
+    delta = (t1-f1)/2;
+    l1 = getLoc(f1, t1); l2 = getLoc(f1, t1 - delta);
+    return report(l1, l2, delta > 0 ==> isStrictlyContainedIn(l2, l1));
+}
+
+test bool isStrictlyContainedIn3(int f, int len) {
+    f1 = restrict(f); t1 = restrict(f1 + len);
+    l1 = getLoc(f1, t1); 
+    return report(l1, l1, !isStrictlyContainedIn(l1, l1));
+}
+
 // beginsBefore
 
 @ignore{unknown}


### PR DESCRIPTION
These functions were in the hotpath of rascal-core.

While for one of them we opted to use a custom java implementation (which was 10x faster than this library function), we still discovered a version of these functions thats 2x as fast.