### PR TITLE
implemented a 4-bit ANSI background color cycler for every new instance of a progress bar. Also uses the old gray colors for reference

### DIFF
--- a/src/org/rascalmpl/library/util/Monitor.rsc
+++ b/src/org/rascalmpl/library/util/Monitor.rsc
@@ -162,7 +162,7 @@ with workload `1` and the same label as the job name.
 test bool horseRaceTest() {
   distance  = 3000000;
   stride    = 50;
-  horses    = 5;
+  horses    = 28;
   handicaps = [ arbInt(stride * 15 / 100)    | _ <- [0..horses]];
   labels    = [ "Horse <h> (handicap is <handicaps[h]>)" | h <- [0..horses]];
   progress  = [ 0                            | _ <- [0..horses]];

--- a/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
+++ b/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
@@ -32,6 +32,45 @@ import jline.internal.Configuration;
  * with an object of this class.
  */
 public class TerminalProgressBarMonitor extends FilterOutputStream implements IRascalMonitor  {
+    /** 
+     * Temporary array to allow for a different color for every next bar;
+     * we use to test different colors in different terminal color schemes.
+     * We focus on the 4-bit colors because those are most likely to have been mapped by a theme.
+     * The greyscale colors are there for reference, because we started out with those.
+     */
+    public static final String[][] FOUR_BIT_BGCOLORS = {
+        {"Black", "\u001B[40m"},
+        {"Red", "\u001B[41m"},
+        {"Green", "\u001B[42m"},
+        {"Yellow", "\u001B[43m"},
+        {"Blue", "\u001B[44m"},
+        {"Magenta", "\u001B[45m"},
+        {"Cyan", "\u001B[46m"},
+        {"White", "\u001B[47m"},
+        {"Bright Black", "\u001B[100m"},
+        {"Bright Red", "\u001B[101m"},
+        {"Bright Green", "\u001B[102m"},
+        {"Bright Yellow", "\u001B[103m"},
+        {"Bright Blue", "\u001B[104m"},
+        {"Bright Magenta", "\u001B[105m"},
+        {"Bright Cyan", "\u001B[106m"},
+        {"Bright White", "\u001B[107m"},
+        // 8-bit greyscale codes (skipping every other gradient)
+        {"Grey0", "\u001B[48;5;232m"},
+        {"Grey2", "\u001B[48;5;234m"},
+        {"Grey4", "\u001B[48;5;236m"},
+        {"Grey6", "\u001B[48;5;238m"},
+        {"Grey8", "\u001B[48;5;240m"},
+        {"Grey10", "\u001B[48;5;242m"},
+        {"Grey12", "\u001B[48;5;244m"},
+        {"Grey14", "\u001B[48;5;246m"},
+        {"Grey16", "\u001B[48;5;248m"},
+        {"Grey18", "\u001B[48;5;250m"},
+        {"Grey20", "\u001B[48;5;252m"},
+        {"Grey22", "\u001B[48;5;254m"}
+    };
+    private static int colorCycler = 0;
+    
     /**
      * We administrate an ordered list of named bars, which will be printed from
      * top to bottom just above the next prompt.
@@ -213,6 +252,8 @@ public class TerminalProgressBarMonitor extends FilterOutputStream implements IR
      * Represents one currently running progress bar
      */
     private class ProgressBar {
+        private int colorPicked = colorCycler++ % FOUR_BIT_BGCOLORS.length;
+
         private final long threadId;
         private final String name;
         private int max;
@@ -311,7 +352,7 @@ public class TerminalProgressBarMonitor extends FilterOutputStream implements IR
             capName = message.length() > 0 ? (capName + ": ") : capName;
 
                 // fill up and cut off:
-            msg = capName + msg;
+            msg = capName + " " + FOUR_BIT_BGCOLORS[colorPicked][0] + ", " + msg;
             msg = (msg + " ".repeat(Math.max(0, barWidth - msg.length()))).substring(0, barWidth);
 
             // split
@@ -329,7 +370,7 @@ public class TerminalProgressBarMonitor extends FilterOutputStream implements IR
 
             var line 
                 = done 
-                + ANSI.lightBackground() 
+                + FOUR_BIT_BGCOLORS[colorPicked][1] /*ANSI.lightBackground() */
                 + ANSI.underlined()
                 + ANSI.overlined()
                 + frontPart

--- a/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
+++ b/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
@@ -371,14 +371,14 @@ public class TerminalProgressBarMonitor extends FilterOutputStream implements IR
             var line 
                 = done 
                 + FOUR_BIT_BGCOLORS[colorPicked][1] /*ANSI.lightBackground() */
-                + ANSI.underlined()
-                + ANSI.overlined()
-                // + "\u001B[30m" // black foreground
+                // + ANSI.underlined()
+                // + ANSI.overlined()
+                + "\u001B[37m" // white/black foreground 37/30
                 + frontPart
-                // + "\u001B[0m" // reset foreground
+                + "\u001B[0m" // reset foreground
                 + ANSI.noBackground()
                 + backPart
-                + ANSI.normal()
+                // + ANSI.normal()
                 + " " + clock + " "
                 + String.format("%d:%02d:%02d.%03d", duration.toHoursPart(), duration.toMinutes(), duration.toSecondsPart(), duration.toMillisPart())
                 + " "

--- a/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
+++ b/src/org/rascalmpl/repl/TerminalProgressBarMonitor.java
@@ -373,7 +373,9 @@ public class TerminalProgressBarMonitor extends FilterOutputStream implements IR
                 + FOUR_BIT_BGCOLORS[colorPicked][1] /*ANSI.lightBackground() */
                 + ANSI.underlined()
                 + ANSI.overlined()
+                // + "\u001B[30m" // black foreground
                 + frontPart
+                // + "\u001B[0m" // reset foreground
                 + ANSI.noBackground()
                 + backPart
                 + ANSI.normal()


### PR DESCRIPTION
@DavyLandman @PaulKlint this is not for merging; but for trying out all the different colors in the ANSI 4-bit pallette as possible backgrounds. Notice that the names of the colors are not necessarily what people implement in their terminals. 

For example, this is what wikipedia reports on different interpretations already: https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit:~:text=The%20chart%20below%20shows%20a%20few%20examples%20of%20how%20VGA%20standard%20and%20modern%20terminal%20emulators%20translate%20the%204%2Dbit%20color%20codes%20into%2024%2Dbit%20color%20codes.

Let's collect some screenshots here. 