### PR TITLE
Rewrote squeeze to avoid commons-lang dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,11 +413,6 @@
             <artifactId>commons-math</artifactId>
             <version>2.2</version>
         </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
-        </dependency>
         <dependency> <!-- used by the compression uri feature-->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -3040,6 +3040,34 @@ public class Prelude {
 		return values.string(s.getValue().trim());
 	}
 	
+	public IString squeeze(IString src, IString charSet) {
+		if (charSet.getValue().isBlank()) {
+			return src;
+		}
+		final Pattern isCharset = Pattern.compile("[" + charSet.getValue() + "]", Pattern.UNICODE_CHARACTER_CLASS);
+		StringBuilder result = new StringBuilder(src.length());
+		var chars = src.iterator();
+		int previousMatch = -1;
+		while (chars.hasNext()) {
+			int cp = chars.nextInt();
+			if (cp == previousMatch) {
+				// swallow
+				continue;
+			}
+
+			String c = Character.toString(cp);
+			if (isCharset.matcher(c).matches()) {
+				previousMatch = cp;
+				// swallow the next
+			}
+			else {
+				previousMatch = -1;
+			}
+			result.append(c);
+		}
+		return values.string(result.toString());
+	}
+	
 	public IString capitalize(IString src) {
 		StringBuilder result = new StringBuilder(src.length());
 		boolean lastWhitespace= true;

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -3040,31 +3040,6 @@ public class Prelude {
 		return values.string(s.getValue().trim());
 	}
 	
-	public IString squeeze(IString src, IString charSet) {
-		final Pattern isCharset = Pattern.compile("[" + charSet.getValue() + "]", Pattern.UNICODE_CHARACTER_CLASS);
-		StringBuilder result = new StringBuilder(src.length());
-		var chars = src.iterator();
-		int previousMatch = -1;
-		while (chars.hasNext()) {
-			int cp = chars.nextInt();
-			if (cp == previousMatch) {
-				// swallow
-				continue;
-			}
-
-			String c = Character.toString(cp);
-			if (isCharset.matcher(c).matches()) {
-				previousMatch = cp;
-				// swallow the next
-			}
-			else {
-				previousMatch = -1;
-			}
-			result.append(c);
-		}
-		return values.string(result.toString());
-	}
-	
 	public IString capitalize(IString src) {
 		StringBuilder result = new StringBuilder(src.length());
 		boolean lastWhitespace= true;

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -3070,7 +3070,7 @@ public class Prelude {
 	}
 	
 	public IString squeeze(IString src, IString charSet) {
-		if (charSet.getValue().isBlank()) {
+		if (charSet.getValue().isEmpty()) {
 			return src;
 		}
 		final Pattern isCharset = Pattern.compile("[" + charSet.getValue() + "]", Pattern.UNICODE_CHARACTER_CLASS);

--- a/src/org/rascalmpl/library/String.rsc
+++ b/src/org/rascalmpl/library/String.rsc
@@ -519,8 +519,15 @@ import String;
 squeeze("hello", "el");
 ```
 }
-@javaClass{org.rascalmpl.library.Prelude}
-public java str squeeze(str src, str charSet);
+public str squeeze(str src, str charSet) {
+  if (charSet == "") {
+    return src;
+  }
+  return visit(src) {
+    case /<c:.><c>+/ => c
+      when /[<charSet>]/ := c
+  }
+}
 
 
 

--- a/src/org/rascalmpl/library/String.rsc
+++ b/src/org/rascalmpl/library/String.rsc
@@ -524,8 +524,7 @@ public str squeeze(str src, str charSet) {
     return src;
   }
   return visit(src) {
-    case /<c:.><c>+/ => c
-      when /[<charSet>]/ := c
+    case /<c:[<charSet>]><c>+/ => c
   }
 }
 

--- a/src/org/rascalmpl/library/String.rsc
+++ b/src/org/rascalmpl/library/String.rsc
@@ -519,14 +519,8 @@ import String;
 squeeze("hello", "el");
 ```
 }
-public str squeeze(str src, str charSet) {
-  if (charSet == "") {
-    return src;
-  }
-  return visit(src) {
-    case /<c:[<charSet>]><c>+/ => c
-  }
-}
+@javaClass{org.rascalmpl.library.Prelude}
+public java str squeeze(str src, str charSet);
 
 
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
@@ -249,14 +249,14 @@ test bool tstSplit(str S1, str S2) = areOverlapping(S1,S2) || isEmpty(S1) || isE
 
 // squeeze
 
-private str rascalSqueeze(str s, str charSet) {
-  return visit (s) {
-    case /<c:.>(<c>)+/ => "<c>"
-      when /[<charSet>]/ := c
-  };
+test bool tstSqueeze1(str S) = /<c:[a-zA-Z]><c>/ !:= squeeze(S, "a-zA-Z");
+test bool tstSqueeze2(str S) = squeeze(S, "") == S;
+test bool tstSqueeze3(str S) {
+  if (/<c:[a-z]><c>/ := S) {
+    return /<c><c>/ := squeeze(S, "0-9");
+  }
+  return true;
 }
-
-test bool tstSqueeze1(str S) = rascalSqueeze(S, "a-zA-Z") == squeeze(S, "a-zA-Z");
 
 
 test bool tstStartsWith(str S1, str S2) = startsWith(S1+S2, S1);

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
@@ -258,6 +258,8 @@ test bool tstSqueeze3(str S) {
   return true;
 }
 
+test bool tstSqueezeUnicode() = squeeze("Hi 🍝🍝World", "🍝") == "Hi 🍝World";
+
 
 test bool tstStartsWith(str S1, str S2) = startsWith(S1+S2, S1);
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
@@ -3,7 +3,6 @@ module lang::rascal::tests::basic::Strings1
 import String;
 import List;
 import util::Math;
-import IO;
 
 test bool subscription(str S){
   R = "";

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
@@ -259,6 +259,11 @@ test bool tstSqueeze3(str S) {
 }
 
 test bool tstSqueezeUnicode() = squeeze("Hi 🍝🍝World", "🍝") == "Hi 🍝World";
+test bool tstSqueezeCase1() = squeeze("abc", "a-c") == "abc";
+test bool tstSqueezeCase2() = squeeze("aabc", "a-c") == "abc";
+test bool tstSqueezeCase3() = squeeze("aabcc", "a-c") == "abc";
+test bool tstSqueezeCase4() = squeeze("aabbcc", "a-c") == "abc";
+test bool tstSqueezeCase5() = squeeze("aaabc", "a-c") == "abc";
 
 
 test bool tstStartsWith(str S1, str S2) = startsWith(S1+S2, S1);

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
@@ -3,6 +3,7 @@ module lang::rascal::tests::basic::Strings1
 import String;
 import List;
 import util::Math;
+import IO;
 
 test bool subscription(str S){
   R = "";
@@ -247,6 +248,16 @@ test bool tstSize(str S) = size(S) == size(chars(S));
 test bool tstSplit(str S1, str S2) = areOverlapping(S1,S2) || isEmpty(S1) || isEmpty(S2) || contains(S2, S1) || S1[-1] == S2[0] || S1[0] == S2[-1] || split(S1, S2 + S1 + S2 + S1) == [S2, S2];
 
 // squeeze
+
+private str rascalSqueeze(str s, str charSet) {
+  return visit (s) {
+    case /<c:.>(<c>)+/ => "<c>"
+      when /[<charSet>]/ := c
+  };
+}
+
+test bool tstSqueeze1(str S) = rascalSqueeze(S, "a-zA-Z") == squeeze(S, "a-zA-Z");
+
 
 test bool tstStartsWith(str S1, str S2) = startsWith(S1+S2, S1);
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Strings1.rsc
@@ -252,7 +252,7 @@ test bool tstSplit(str S1, str S2) = areOverlapping(S1,S2) || isEmpty(S1) || isE
 test bool tstSqueeze1(str S) = /<c:[a-zA-Z]><c>/ !:= squeeze(S, "a-zA-Z");
 test bool tstSqueeze2(str S) = squeeze(S, "") == S;
 test bool tstSqueeze3(str S) {
-  if (/<c:[a-z]><c>/ := S) {
+  if (/<c:[a-zA-Z]><c>/ := S) {
     return /<c><c>/ := squeeze(S, "0-9");
   }
   return true;


### PR DESCRIPTION
I noticed we still had a commons-lang dependency. I thought we got rid of that 10y back when most of their string functions weren't safe for unicode.

There was on function still using it, so I rewrote that in regular rascal. I see no reasson to keep this in Java, unless it becomes a bottleneck.

And I added tests for it (that I first tested on the original code).