### PR TITLE
Base32 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
                             <goal>package</goal>
                         </goals>
                     </execution>
+                     <!-- turned off for bootstrapping purposes 
                     <execution>
                         <id>default-cli</id>
                         <phase>compile</phase>
@@ -176,7 +177,7 @@
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal</ignore>
                             </ignores>
                         </configuration>
-                        </execution>
+                        </execution>-->
                 </executions>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -421,12 +421,17 @@
         <dependency> <!-- used by the compression uri feature-->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.0</version>
+            <version>1.26.1</version>
         </dependency>
         <dependency> <!-- needed by commons-compress for compressed+...://...zst -->
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
             <version>1.5.5-11</version>
+        </dependency>
+        <dependency> <!-- used for base32 encoding in IO and String, needed anyway for commons-compress -->
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.17.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/org/rascalmpl/library/IO.rsc
+++ b/src/org/rascalmpl/library/IO.rsc
@@ -563,6 +563,9 @@ Use `readFile(file, inferCharset=false, charset=DEFAULT_CHARSET)` instead.
 public str readFileEnc(loc file, str charset) throws PathNotFound, IO
   = readFile(file, inferCharset=false, charset=charset);
 
+@synopsis{Read the content of a file and return it as a base-64 encoded string.}
+@description {
+}
 @javaClass{org.rascalmpl.library.Prelude}
 public java str readBase64(loc file)
 throws PathNotFound, IO;
@@ -572,6 +575,9 @@ Use readBase64 instead. Uuencode was a misnomer.
 }
 public str uuencode(loc file) = readBase64(file);
 
+@synopsis{Decode a base-64 encoded string and write the resulting bytes to a file.}
+@description {
+}
 @javaClass{org.rascalmpl.library.Prelude}
 public java void writeBase64(loc file, str content)
 throws PathNotFound, IO;
@@ -581,10 +587,16 @@ Use writeBase64 instead. Uudecode was a misnomer.
 }
 public void uudecode(loc file, str content) = writeBase64(file, content);
 
+@synopsis{Read the content of a file and return it as a base-32 encoded string.}
+@description {
+}
 @javaClass{org.rascalmpl.library.Prelude}
 public java str readBase32(loc file)
 throws PathNotFound, IO;
 
+@synopsis{Decode a base-32 encoded string and write the resulting bytes to a file.}
+@description {
+}
 @javaClass{org.rascalmpl.library.Prelude}
 public java void writeBase32(loc file, str content)
 throws PathNotFound, IO;

--- a/src/org/rascalmpl/library/IO.rsc
+++ b/src/org/rascalmpl/library/IO.rsc
@@ -567,7 +567,7 @@ public str readFileEnc(loc file, str charset) throws PathNotFound, IO
 @description {
 }
 @javaClass{org.rascalmpl.library.Prelude}
-public java str readBase64(loc file)
+public java str readBase64(loc file, bool includePadding=true)
 throws PathNotFound, IO;
 
 @deprecated{
@@ -591,7 +591,7 @@ public void uudecode(loc file, str content) = writeBase64(file, content);
 @description {
 }
 @javaClass{org.rascalmpl.library.Prelude}
-public java str readBase32(loc file)
+public java str readBase32(loc file, bool includePadding=true, int lineWidth=0)
 throws PathNotFound, IO;
 
 @synopsis{Decode a base-32 encoded string and write the resulting bytes to a file.}
@@ -711,7 +711,10 @@ public java str createLink(str title, str target);
 
 
 @javaClass{org.rascalmpl.library.Prelude}
-public java str toBase64(loc file)
+@deprecated{
+  use `readBase64` instead.
+}
+public java str toBase64(loc file, bool includePadding=true)
 throws PathNotFound, IO;
 
 @javaClass{org.rascalmpl.library.Prelude}

--- a/src/org/rascalmpl/library/IO.rsc
+++ b/src/org/rascalmpl/library/IO.rsc
@@ -577,10 +577,17 @@ public java void writeBase64(loc file, str content)
 throws PathNotFound, IO;
 
 @deprecated{
-Use writeBase65 instead. Uudecode was a misnomer.
+Use writeBase64 instead. Uudecode was a misnomer.
 }
 public void uudecode(loc file, str content) = writeBase64(file, content);
 
+@javaClass{org.rascalmpl.library.Prelude}
+public java str readBase32(loc file)
+throws PathNotFound, IO;
+
+@javaClass{org.rascalmpl.library.Prelude}
+public java void writeBase32(loc file, str content)
+throws PathNotFound, IO;
 
 @synopsis{Read the contents of a file and return it as a list of bytes.}
 @javaClass{org.rascalmpl.library.Prelude}

--- a/src/org/rascalmpl/library/IO.rsc
+++ b/src/org/rascalmpl/library/IO.rsc
@@ -591,7 +591,7 @@ public void uudecode(loc file, str content) = writeBase64(file, content);
 @description {
 }
 @javaClass{org.rascalmpl.library.Prelude}
-public java str readBase32(loc file, bool includePadding=true, int lineWidth=0)
+public java str readBase32(loc file, bool includePadding=true)
 throws PathNotFound, IO;
 
 @synopsis{Decode a base-32 encoded string and write the resulting bytes to a file.}

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -3409,24 +3409,22 @@ public class Prelude {
 	    }
 	}
 
-	public IString toBase32(IString in, IString charset, IBool includePadding) {
+	public IString toBase32(IString in, IString charsetName, IBool includePadding) {
 		Base32 encoder = new Base32();
-		ByteBuffer buffer = Charset.forName(charset.getValue()).encode(in.getValue());
-		byte[] data = new byte[buffer.limit()];
-		buffer.get(data);
-		String encoded = encoder.encodeToString(data);
+		Charset charset = Charset.forName(charsetName.getValue());
+		String encoded = encoder.encodeToString(in.getValue().getBytes(charset));
 		if (!includePadding.getValue()) {
 			encoded = encoded.replace("=", "");
 		}
 		return values.string(encoded);
 	}
 
-	public IString fromBase32(IString in, IString charset) {
+	public IString fromBase32(IString in, IString charsetName) {
 		// The only relevant field we want to change is the policy
 		Base32 decoder = new Base32(0, new byte[0], false, (byte) '=', CodecPolicy.LENIENT);
 		byte[] data = decoder.decode(in.getValue());
-		ByteBuffer buffer = ByteBuffer.wrap(data);
-		return values.string(Charset.forName(charset.getValue()).decode(buffer).toString());
+		Charset charset = Charset.forName(charsetName.getValue());
+		return values.string(new String(data, charset));
 	}
 
 	public IValue toLowerCase(IString s)

--- a/src/org/rascalmpl/library/String.rsc
+++ b/src/org/rascalmpl/library/String.rsc
@@ -540,6 +540,12 @@ public java str toBase64(str src);
 @javaClass{org.rascalmpl.library.Prelude}
 public java str fromBase64(str src);
 
+@javaClass{org.rascalmpl.library.Prelude}
+public java str toBase32(str src);
+
+@javaClass{org.rascalmpl.library.Prelude}
+public java str fromBase32(str src);
+
 
 @synopsis{Word wrap a string to fit in a certain width.}
 @description{

--- a/src/org/rascalmpl/library/String.rsc
+++ b/src/org/rascalmpl/library/String.rsc
@@ -21,6 +21,8 @@ module String
 extend Exception;
 import List;
 
+@synopsis{All functions in this module that have a charset parameter use this as default.}
+private str DEFAULT_CHARSET = "UTF-8";
 
 @synopsis{Center a string in given space.}
 @description{
@@ -534,17 +536,37 @@ public java str capitalize(str src);
 @javaClass{org.rascalmpl.library.Prelude}
 public java str uncapitalize(str src);
 
+@synopsis{Base-64 encode the characters of a string.}
+@description{
+   Convert the characters of a string to a list of bytes using UTF-8 encoding and then encode these bytes using base-64 encoding
+   as defined by RFC 4648: https://www.ietf.org/rfc/rfc4648.txt.
+}
 @javaClass{org.rascalmpl.library.Prelude}
-public java str toBase64(str src);
+public java str toBase64(str src, str charset=DEFAULT_CHARSET);
 
+@synopsis{Decode a base-32 encoded string.}
+@description {
+  Convert a base-32 encoded string to bytes and then convert these bytes to a string using the specified cahracter set.
+  The base-32 encoding used is defined by RFC 4648: https://www.ietf.org/rfc/rfc4648.txt.
+}
 @javaClass{org.rascalmpl.library.Prelude}
-public java str fromBase64(str src);
+public java str fromBase64(str src, str charset=DEFAULT_CHARSET);
 
+@synopsis{Base-32 encode the characters of a string.}
+@description{
+   Convert the characters of a string to a list of bytes using UTF-8 encoding and then encode these bytes using base-32 encoding
+   as defined by RFC 4648: https://www.ietf.org/rfc/rfc4648.txt.
+}
 @javaClass{org.rascalmpl.library.Prelude}
-public java str toBase32(str src);
+public java str toBase32(str src, str charset=DEFAULT_CHARSET, bool includePadding=true);
 
+@synopsis{Decode a base-32 encoded string.}
+@description {
+  Convert a base-32 encoded string to bytes and then convert these bytes to a string using the specified cahracter set.
+  The base-32 encoding used is defined by RFC 4648: https://www.ietf.org/rfc/rfc4648.txt.
+}
 @javaClass{org.rascalmpl.library.Prelude}
-public java str fromBase32(str src);
+public java str fromBase32(str src, str charset=DEFAULT_CHARSET);
 
 
 @synopsis{Word wrap a string to fit in a certain width.}

--- a/src/org/rascalmpl/library/String.rsc
+++ b/src/org/rascalmpl/library/String.rsc
@@ -558,7 +558,7 @@ public java str fromBase64(str src, str charset=DEFAULT_CHARSET);
    as defined by RFC 4648: https://www.ietf.org/rfc/rfc4648.txt.
 }
 @javaClass{org.rascalmpl.library.Prelude}
-public java str toBase32(str src, str charset=DEFAULT_CHARSET, bool includePadding=true, int lineWidth=0);
+public java str toBase32(str src, str charset=DEFAULT_CHARSET, bool includePadding=true);
 
 @synopsis{Decode a base-32 encoded string.}
 @description {

--- a/src/org/rascalmpl/library/String.rsc
+++ b/src/org/rascalmpl/library/String.rsc
@@ -542,7 +542,7 @@ public java str uncapitalize(str src);
    as defined by RFC 4648: https://www.ietf.org/rfc/rfc4648.txt.
 }
 @javaClass{org.rascalmpl.library.Prelude}
-public java str toBase64(str src, str charset=DEFAULT_CHARSET);
+public java str toBase64(str src, str charset=DEFAULT_CHARSET, bool includePadding=true);
 
 @synopsis{Decode a base-32 encoded string.}
 @description {
@@ -558,7 +558,7 @@ public java str fromBase64(str src, str charset=DEFAULT_CHARSET);
    as defined by RFC 4648: https://www.ietf.org/rfc/rfc4648.txt.
 }
 @javaClass{org.rascalmpl.library.Prelude}
-public java str toBase32(str src, str charset=DEFAULT_CHARSET, bool includePadding=true);
+public java str toBase32(str src, str charset=DEFAULT_CHARSET, bool includePadding=true, int lineWidth=0);
 
 @synopsis{Decode a base-32 encoded string.}
 @description {

--- a/src/org/rascalmpl/library/lang/rascal/tests/library/IO.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/library/IO.rsc
@@ -5,17 +5,17 @@ import DateTime;
 import String;
 
 test bool testFileCopyCompletely() {
-    writeFile(|memory:///longFile|, "123456789");
-    writeFile(|memory:///shortFile|, "321");
+    writeFile(|tmp:///longFile|, "123456789");
+    writeFile(|tmp:///shortFile|, "321");
 
-    copy(|memory:///shortFile|, |memory:///longFile|, overwrite=true);
+    copy(|tmp:///shortFile|, |tmp:///longFile|, overwrite=true);
 
-    return readFile(|memory:///longFile|) == readFile(|memory:///shortFile|);
+    return readFile(|tmp:///longFile|) == readFile(|tmp:///shortFile|);
 }
 
 test bool watchDoesNotCrashOnURIRewrites() {
-    writeFile(|memory:///watchDoesNotCrashOnURIRewrites/someFile.txt|, "123456789");
-    watch(|memory:///watchDoesNotCrashOnURIRewrites|, true, void (LocationChangeEvent event) { 
+    writeFile(|tmp:///watchDoesNotCrashOnURIRewrites/someFile.txt|, "123456789");
+    watch(|tmp:///watchDoesNotCrashOnURIRewrites|, true, void (LocationChangeEvent event) { 
         // this should trigger the failing test finally
         remove(event.src); 
     });
@@ -23,8 +23,8 @@ test bool watchDoesNotCrashOnURIRewrites() {
 }
 
 test bool createdDoesNotCrashOnURIRewrites() {
-    writeFile(|memory:///createdDoesNotCrashOnURIRewrites/someFile.txt|, "123456789");
-    return created(|memory:///createdDoesNotCrashOnURIRewrites/someFile.txt|) <= now();
+    writeFile(|tmp:///createdDoesNotCrashOnURIRewrites/someFile.txt|, "123456789");
+    return created(|tmp:///createdDoesNotCrashOnURIRewrites/someFile.txt|) <= now();
 }
 
 test bool testWriteBase32() {

--- a/src/org/rascalmpl/library/lang/rascal/tests/library/IO.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/library/IO.rsc
@@ -5,17 +5,17 @@ import DateTime;
 import String;
 
 test bool testFileCopyCompletely() {
-    writeFile(|tmp:///longFile|, "123456789");
-    writeFile(|tmp:///shortFile|, "321");
+    writeFile(|memory:///longFile|, "123456789");
+    writeFile(|memory:///shortFile|, "321");
 
-    copy(|tmp:///shortFile|, |tmp:///longFile|, overwrite=true);
+    copy(|memory:///shortFile|, |memory:///longFile|, overwrite=true);
 
-    return readFile(|tmp:///longFile|) == readFile(|tmp:///shortFile|);
+    return readFile(|memory:///longFile|) == readFile(|memory:///shortFile|);
 }
 
 test bool watchDoesNotCrashOnURIRewrites() {
-    writeFile(|tmp:///watchDoesNotCrashOnURIRewrites/someFile.txt|, "123456789");
-    watch(|tmp:///watchDoesNotCrashOnURIRewrites|, true, void (LocationChangeEvent event) { 
+    writeFile(|memory:///watchDoesNotCrashOnURIRewrites/someFile.txt|, "123456789");
+    watch(|memory:///watchDoesNotCrashOnURIRewrites|, true, void (LocationChangeEvent event) { 
         // this should trigger the failing test finally
         remove(event.src); 
     });
@@ -23,19 +23,19 @@ test bool watchDoesNotCrashOnURIRewrites() {
 }
 
 test bool createdDoesNotCrashOnURIRewrites() {
-    writeFile(|tmp:///createdDoesNotCrashOnURIRewrites/someFile.txt|, "123456789");
-    return created(|tmp:///createdDoesNotCrashOnURIRewrites/someFile.txt|) <= now();
+    writeFile(|memory:///createdDoesNotCrashOnURIRewrites/someFile.txt|, "123456789");
+    return created(|memory:///createdDoesNotCrashOnURIRewrites/someFile.txt|) <= now();
 }
 
 test bool testWriteBase32() {
     str original = "Hello World!";
-    writeBase32(|tmp:///base32Test/writeTest.txt|, toBase32(original));
-    return original == readFile(|tmp:///base32Test/writeTest.txt|);
+    writeBase32(|memory:///base32Test/writeTest.txt|, toBase32(original));
+    return original == readFile(|memory:///base32Test/writeTest.txt|);
 }
 
 test bool testReadBase32() {
     str original = "Hello World!";
-    writeFile(|tmp:///base32Test/readTest.txt|, original);
-    str encoded = readBase32(|tmp:///base32Test/readTest.txt|);
+    writeFile(|memory:///base32Test/readTest.txt|, original);
+    str encoded = readBase32(|memory:///base32Test/readTest.txt|);
     return original == fromBase32(encoded);
 }

--- a/src/org/rascalmpl/library/lang/rascal/tests/library/IO.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/library/IO.rsc
@@ -2,6 +2,7 @@ module lang::rascal::tests::library::IO
 
 import IO;
 import DateTime;
+import String;
 
 test bool testFileCopyCompletely() {
     writeFile(|tmp:///longFile|, "123456789");
@@ -24,4 +25,17 @@ test bool watchDoesNotCrashOnURIRewrites() {
 test bool createdDoesNotCrashOnURIRewrites() {
     writeFile(|tmp:///createdDoesNotCrashOnURIRewrites/someFile.txt|, "123456789");
     return created(|tmp:///createdDoesNotCrashOnURIRewrites/someFile.txt|) <= now();
+}
+
+test bool testWriteBase32() {
+    str original = "Hello World!";
+    writeBase32(|tmp:///base32Test/writeTest.txt|, toBase32(original));
+    return original == readFile(|tmp:///base32Test/writeTest.txt|);
+}
+
+test bool testReadBase32() {
+    str original = "Hello World!";
+    writeFile(|tmp:///base32Test/readTest.txt|, original);
+    str encoded = readBase32(|tmp:///base32Test/readTest.txt|);
+    return original == fromBase32(encoded);
 }

--- a/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
@@ -232,8 +232,5 @@ test bool toUpperCase3() = String::toUpperCase("abc") == "ABC";
 test bool toUpperCase4() = String::toUpperCase("abc123") == "ABC123";
   	
   
-  	
- 
-  	
-  
- 
+// Base32
+test bool toBase32() = toBase32("abc") == "abc";  	

--- a/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
@@ -261,5 +261,3 @@ test bool testBase32AllChars1() = testBase32("`1234567890-=~!@#$%^&*");
 test bool testBase32AllChars2() = testBase32("()_+qwertyuiop[]\\QWERTYUIOP");
 test bool testBase32AllChars3() = testBase32("{}|asdfghjkl;\'ASDFGHJKL:\"");
 test bool testBase32AllChars4() = testBase32("zxcvbnm,./ZXCVBNM\<\>? ");
-
-test bool toBase32LineWidth() = toBase32("abcdefghijklmnopqrstuvwxyz", lineWidth=8) == "MFRGGZDF\r\nMZTWQ2LK\r\nNNWG23TP\r\nOBYXE43U\r\nOV3HO6DZ\r\nPI======\r\n";

--- a/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
@@ -246,5 +246,3 @@ test bool testBase32AllChars1() = testBase32("`1234567890-=~!@#$%^&*");
 test bool testBase32AllChars2() = testBase32("()_+qwertyuiop[]\\QWERTYUIOP");
 test bool testBase32AllChars3() = testBase32("{}|asdfghjkl;\'ASDFGHJKL:\"");
 test bool testBase32AllChars4() = testBase32("zxcvbnm,./ZXCVBNM\<\>? ");
-
-test bool toBase32SingleNoPadding() = toBase32("a", includePadding=false) == "ME";

--- a/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
@@ -231,7 +231,22 @@ test bool toUpperCase2() = toUpperCase("") == "";
 test bool toUpperCase3() = String::toUpperCase("abc") == "ABC";
 test bool toUpperCase4() = String::toUpperCase("abc123") == "ABC123";
   	
-  
+
+// Base64
+bool testBase64(str s) {
+     return fromBase64(toBase64(s)) == s && fromBase64(toBase64(s, includePadding=false)) == s;
+}
+
+test bool toBase64Empty() = toBase64("") == "";
+test bool toBase64Single() = toBase64("a") == "YQ==";
+test bool toBase64SingleNoPadding() = toBase64("a", includePadding=false) == "YQ";
+
+test bool testBase64SomeChars() = testBase64("Hello World!");
+test bool testBase64AllChars1() = testBase64("`1234567890-=~!@#$%^&*");
+test bool testBase64AllChars2() = testBase64("()_+qwertyuiop[]\\QWERTYUIOP");
+test bool testBase64AllChars3() = testBase64("{}|asdfghjkl;\'ASDFGHJKL:\"");
+test bool testBase64AllChars4() = testBase64("zxcvbnm,./ZXCVBNM\<\>? ");
+
 // Base32
 bool testBase32(str s) {
      return fromBase32(toBase32(s)) == s && fromBase32(toBase32(s, includePadding=false)) == s;
@@ -246,3 +261,5 @@ test bool testBase32AllChars1() = testBase32("`1234567890-=~!@#$%^&*");
 test bool testBase32AllChars2() = testBase32("()_+qwertyuiop[]\\QWERTYUIOP");
 test bool testBase32AllChars3() = testBase32("{}|asdfghjkl;\'ASDFGHJKL:\"");
 test bool testBase32AllChars4() = testBase32("zxcvbnm,./ZXCVBNM\<\>? ");
+
+test bool toBase32LineWidth() = toBase32("abcdefghijklmnopqrstuvwxyz", lineWidth=8) == "MFRGGZDF\r\nMZTWQ2LK\r\nNNWG23TP\r\nOBYXE43U\r\nOV3HO6DZ\r\nPI======\r\n";

--- a/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/library/String.rsc
@@ -14,7 +14,7 @@
   *******************************************************************************/
   
 import String;
-  
+
 // center
   
 test bool center1() = center("a", 0) == "a";
@@ -233,4 +233,18 @@ test bool toUpperCase4() = String::toUpperCase("abc123") == "ABC123";
   	
   
 // Base32
-test bool toBase32() = toBase32("abc") == "abc";  	
+bool testBase32(str s) {
+     return fromBase32(toBase32(s)) == s && fromBase32(toBase32(s, includePadding=false)) == s;
+}
+
+test bool toBase32Empty() = toBase32("") == "";
+test bool toBase32EmptyNoPadding() = toBase32("", includePadding=false) == "";
+test bool toBase32Single() = toBase32("a") == "ME======";
+test bool toBase32SingleNoPadding() = toBase32("a", includePadding=false) == "ME";
+test bool testBase32SomeChars() = testBase32("Hello World!");
+test bool testBase32AllChars1() = testBase32("`1234567890-=~!@#$%^&*");
+test bool testBase32AllChars2() = testBase32("()_+qwertyuiop[]\\QWERTYUIOP");
+test bool testBase32AllChars3() = testBase32("{}|asdfghjkl;\'ASDFGHJKL:\"");
+test bool testBase32AllChars4() = testBase32("zxcvbnm,./ZXCVBNM\<\>? ");
+
+test bool toBase32SingleNoPadding() = toBase32("a", includePadding=false) == "ME";


### PR DESCRIPTION
This PR adds support for base-32 encoding, similar to the base-64 encoding that was already present. It also adds support for a "charset" and "includePadding" keyword parameters to the existing base-64 string functions.