### PR TITLE
Fixing issue #2009

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/Character.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/Character.rsc
@@ -51,7 +51,7 @@ test bool charClassExtendedRanges() = (#[A-M N-Z]).symbol == \char-class([range(
 
 test bool asciiEscape() = \char-class([range(0,127)]) == #[\a00-\a7F].symbol;
 test bool utf16Escape() = \char-class([range(0,65535)]) == #[\u0000-\uFFFF].symbol;
-test bool utf24Escape() = \char-class([range(0,1114111)]) == #[\U000000-\U10FFFF].symbol;
+test bool utf32Escape() = \char-class([range(0,1114111)]) == #[\U000000-\U10FFFF].symbol;
 test bool highLowSurrogateRange1() = \char-class([range(9312,12991)]) == #[①-㊿].symbol;
 test bool highLowSurrogateRange2() = \char-class([range(127829,127829)]) == #[🍕].symbol;
 test bool differentEscapesSameResult1() = #[\a00-\a7F] == #[\u0000-\u007F];
@@ -86,9 +86,12 @@ test bool unicodeCharacterClassSubtype2() {
 
 test bool literalAsciiEscape1() = lit("\n") == #"\a0A".symbol;
 test bool literalAsciiEscape2() = lit("w") == #"\a77".symbol;
+test bool literalAsciiEscape3() = lit("\f") == #"\a0C".symbol;
+test bool literalAsciiEscape4() = lit("\n") == #"\n".symbol;
+test bool literalAsciiEscape5() = lit("\f") == #"\f".symbol;
 test bool literalUtf16Escape() = lit("\n") == #"\u000A".symbol;
-test bool literalUtf24Escape1() = lit("\n") == #"\U00000A".symbol;
-test bool literalUtf24Escape2() = lit("🍕") == #"\U01F355".symbol;
+test bool literalUtf32Escape1() = lit("\n") == #"\U00000A".symbol;
+test bool literalUtf32Escape2() = lit("🍕") == #"\U01F355".symbol;
 
 // ambiguity in this syntax must be resolved first
 //test bool differenceCC() = (#[a-zA-Z] - [A-Z]).symbol == (#[a-z]).symbol;

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/Character.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/Character.rsc
@@ -49,13 +49,13 @@ test bool charClassOrderedRanges() = (#[a-z A-Z]).symbol == \char-class([range(6
 test bool charClassMergedRanges() = (#[A-Z F-G]).symbol == \char-class([range(65,90)]);
 test bool charClassExtendedRanges() = (#[A-M N-Z]).symbol == \char-class([range(65,90)]);
 
-test bool asciiEscape() = \char-class([range(0,127)]) := #[\a00-aFF].symbol;
-test bool utf16Escape() = \char-class([range(0,65535)]) := #[\u0000-\uFFFF].symbol;
-test bool utf24Escape() = \char-class([range(0,1114111)]) := #[\U000000-\U10FFFF].symbol;
-test bool highLowSurrogateRange1() = \char-class([range(9312,12991)]) := #[①-㊿].symbol;
-test bool highLowSurrogateRange2() = \char-class([range(127829,127829)]) := #[🍕].symbol;
-test bool differentEscapesSameResult1() = #[\a00-aFF] == #[\u0000-\u00FF];
-test bool differentEscapesSameResult2() = #[\a00-aFF] == #[\u0000-\u00FF];
+test bool asciiEscape() = \char-class([range(0,127)]) == #[\a00-\a7F].symbol;
+test bool utf16Escape() = \char-class([range(0,65535)]) == #[\u0000-\uFFFF].symbol;
+test bool utf24Escape() = \char-class([range(0,1114111)]) == #[\U000000-\U10FFFF].symbol;
+test bool highLowSurrogateRange1() = \char-class([range(9312,12991)]) == #[①-㊿].symbol;
+test bool highLowSurrogateRange2() = \char-class([range(127829,127829)]) == #[🍕].symbol;
+test bool differentEscapesSameResult1() = #[\a00-\a7F] == #[\u0000-\u007F];
+test bool differentEscapesSameResult2() = #[\a00-\a7F] == #[\U000000-\U00007F];
 
 /* to avoid a known ambiguity */
 alias NotAZ = ![A-Z];

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/Character.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/Character.rsc
@@ -49,6 +49,41 @@ test bool charClassOrderedRanges() = (#[a-z A-Z]).symbol == \char-class([range(6
 test bool charClassMergedRanges() = (#[A-Z F-G]).symbol == \char-class([range(65,90)]);
 test bool charClassExtendedRanges() = (#[A-M N-Z]).symbol == \char-class([range(65,90)]);
 
+test bool asciiEscape() = \char-class([range(0,127)]) := #[\a00-aFF].symbol;
+test bool utf16Escape() = \char-class([range(0,65535)]) := #[\u0000-\uFFFF].symbol;
+test bool utf24Escape() = \char-class([range(0,1114111)]) := #[\U000000-\U10FFFF].symbol;
+test bool highLowSurrogateRange1() = \char-class([range(9312,12991)]) := #[①-㊿].symbol;
+test bool highLowSurrogateRange2() = \char-class([range(127829,127829)]) := #[🍕].symbol;
+test bool differentEscapesSameResult1() = #[\a00-aFF] == #[\u0000-\u00FF];
+test bool differentEscapesSameResult2() = #[\a00-aFF] == #[\u0000-\u00FF];
+
+/* to avoid a known ambiguity */
+alias NotAZ = ![A-Z];
+
+test bool unicodeCharacterClassSubtype1() {
+  Tree t = char(charAt("⑭", 0));
+
+  if ([①-㊿] circled := t) {
+    assert [⑭] _ := circled;
+    assert NotAZ _ := circled;
+    return true;
+  }
+
+  return false;
+}
+
+test bool unicodeCharacterClassSubtype2() {
+  Tree t = char(charAt("🍕", 0));
+
+  if ([🍕] pizza := t) {
+    assert [\a00-🍕] _ := pizza;
+    assert NotAZ _ := pizza;
+    return true;
+  }
+
+  return false;
+}
+
 // ambiguity in this syntax must be resolved first
 //test bool differenceCC() = (#[a-zA-Z] - [A-Z]).symbol == (#[a-z]).symbol;
 //test bool unionCC()      = (#[a-z] || [A-Z]).symbol == (#[A-Za-z]).symbol;

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/Character.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/Character.rsc
@@ -84,6 +84,12 @@ test bool unicodeCharacterClassSubtype2() {
   return false;
 }
 
+test bool literalAsciiEscape1() = lit("\n") == #"\a0A".symbol;
+test bool literalAsciiEscape2() = lit("w") == #"\a77".symbol;
+test bool literalUtf16Escape() = lit("\n") == #"\u000A".symbol;
+test bool literalUtf24Escape1() = lit("\n") == #"\U00000A".symbol;
+test bool literalUtf24Escape2() = lit("🍕") == #"\U01F355".symbol;
+
 // ambiguity in this syntax must be resolved first
 //test bool differenceCC() = (#[a-zA-Z] - [A-Z]).symbol == (#[a-z]).symbol;
 //test bool unionCC()      = (#[a-z] || [A-Z]).symbol == (#[A-Za-z]).symbol;

--- a/src/org/rascalmpl/values/parsetrees/SymbolFactory.java
+++ b/src/org/rascalmpl/values/parsetrees/SymbolFactory.java
@@ -294,24 +294,22 @@ public class SymbolFactory {
 
 	private static IValue char2int(Char character) {
 		String s = ((Char.Lexical) character).getString();
-		if (s.matches("\\\\[auU][0-9A-F]+")) {
-			// ascii escape (a), utf16 escape (u) or utf24 escape (U)
-			return factory.integer(Integer.parseInt(s.substring(2), 16));
-		}
-		else if (s.startsWith("\\")) {
+		if (s.startsWith("\\")) {
 			// builtin escape
 			int cha = s.codePointAt(1);
+			if (cha == 'a' | cha == 'u' | cha == 'U') {
+				if (s.matches("\\\\[auU][0-9A-Fa-f]+")) {
+					// ascii escape (a), utf16 escape (u) or utf32 escape (U)
+					return factory.integer(Integer.parseInt(s.substring(2), 16));
+				}
+			}
 			switch (cha) {
 				case 't': return factory.integer('\t');
 				case 'n': return factory.integer('\n');
 				case 'r': return factory.integer('\r');
-				case '\"' : return factory.integer('\"');
-				case '\'' : return factory.integer('\'');
-				case '-' : return factory.integer('-');
-				case '<' : return factory.integer('<');
-				case '>' : return factory.integer('>');
-				case '\\' : return factory.integer('\\');
-				default: return factory.integer(cha);
+				case 'f': return factory.integer('\f');
+				case 'b': return factory.integer('\b');
+				default: return factory.integer(cha); //fallback is just the character thats escaped
 			}
 		}
 		else {

--- a/src/org/rascalmpl/values/parsetrees/SymbolFactory.java
+++ b/src/org/rascalmpl/values/parsetrees/SymbolFactory.java
@@ -354,7 +354,7 @@ public class SymbolFactory {
 				case '<' : return factory.integer('<');
 				case '>' : return factory.integer('>');
 				case '\\' : return factory.integer('\\');
-				default: return factory.integer(s.codePointAt(1));
+				default: return factory.integer(cha);
 			}
 		}
 		else {

--- a/src/org/rascalmpl/values/parsetrees/SymbolFactory.java
+++ b/src/org/rascalmpl/values/parsetrees/SymbolFactory.java
@@ -337,31 +337,30 @@ public class SymbolFactory {
 
 	private static IValue char2int(Char character) {
 		String s = ((Char.Lexical) character).getString();
-		if (s.startsWith("\\")) {
-			if (s.length() > 1 && java.lang.Character.isDigit(s.charAt(1))) { // octal escape
-				// TODO
-				throw new NotYetImplemented("octal escape sequence in character class types");
-			}
-			if (s.length() > 1 && s.charAt(1) == 'u') { // octal escape
-				// TODO
-				throw new NotYetImplemented("unicode escape sequence in character class types");
-			}
-			char cha = s.charAt(1);
-			switch (cha) {
-			case 't': return factory.integer('\t');
-			case 'n': return factory.integer('\n');
-			case 'r': return factory.integer('\r');
-			case '\"' : return factory.integer('\"');
-			case '\'' : return factory.integer('\'');
-			case '-' : return factory.integer('-');
-			case '<' : return factory.integer('<');
-			case '>' : return factory.integer('>');
-			case '\\' : return factory.integer('\\');
-			}
-			s = s.substring(1);
+		if (s.matches("\\\\[auU][0-9A-F]+")) {
+			// ascii escape (a), utf16 escape (u) or utf24 escape (U)
+			return factory.integer(Integer.parseInt(s.substring(2), 16));
 		}
-		char cha = s.charAt(0);
-		return factory.integer(cha);
+		else if (s.startsWith("\\")) {
+			// builtin escape
+			int cha = s.codePointAt(1);
+			switch (cha) {
+				case 't': return factory.integer('\t');
+				case 'n': return factory.integer('\n');
+				case 'r': return factory.integer('\r');
+				case '\"' : return factory.integer('\"');
+				case '\'' : return factory.integer('\'');
+				case '-' : return factory.integer('-');
+				case '<' : return factory.integer('<');
+				case '>' : return factory.integer('>');
+				case '\\' : return factory.integer('\\');
+				default: return factory.integer(s.codePointAt(1));
+			}
+		}
+		else {
+			// just a single character (but possibly two char's)
+			return factory.integer(s.codePointAt(0));
+		}
 	}
 	
 	public static IConstructor charClass(int ch) {

--- a/src/org/rascalmpl/values/parsetrees/SymbolFactory.java
+++ b/src/org/rascalmpl/values/parsetrees/SymbolFactory.java
@@ -13,6 +13,8 @@
 *******************************************************************************/
 package org.rascalmpl.values.parsetrees;
 
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.List;
 
 import org.rascalmpl.ast.CaseInsensitiveStringConstant;
@@ -34,6 +36,8 @@ import io.usethesource.vallang.IListWriter;
 import io.usethesource.vallang.IString;
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.IValueFactory;
+import io.usethesource.vallang.exceptions.FactTypeUseException;
+import io.usethesource.vallang.io.StandardTextReader;
 
 import org.rascalmpl.values.RascalValueFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
@@ -197,63 +201,16 @@ public class SymbolFactory {
 	}
 
 	private static IValue literal2Symbol(StringConstant sep) {
-		String lit = ((StringConstant.Lexical) sep).getString();
-		StringBuilder builder = new StringBuilder(lit.length());
-		
-		// TODO: did we deal with all escapes here? probably not!
-		for (int i = 1; i < lit.length() - 1; i++) {
-			if (lit.charAt(i) == '\\') {
-				i++;
-				switch (lit.charAt(i)) {
-				case 'b':
-					builder.append('\b');
-					break;
-				case 'f':
-					builder.append('\f');
-					break;
-				case 'n':
-					builder.append('\n');
-					break;
-				case 't':
-					builder.append('\t');
-					break;
-				case 'r':
-					builder.append('\r');
-					break;
-				case '\\':
-					builder.append('\\');
-					break;
-				case '\"':
-					builder.append('\"');
-					break;
-				case '>':
-					builder.append('>');
-					break;
-				case '<':
-					builder.append('<');
-					break;
-				case '\'':
-					builder.append('\'');
-					break;
-				case 'u':
-					while (lit.charAt(i++) == 'u');
-					builder.append((char) Integer.decode("0x" + lit.substring(i, i+4)).intValue());
-					i+=4;
-					break;
-				default:
-					// octal escape
-					int a = lit.charAt(i++);
-					int b = lit.charAt(i++);
-					int c = lit.charAt(i);
-					builder.append( (char) (100 * a + 10 * b + c));	
-				}
-			}
-			else {
-				builder.append(lit.charAt(i));
-			}
+		try {
+			String lit = ((StringConstant.Lexical) sep).getString();
+			// this should be the exact notation for string literals in vallang
+			IValue string = new StandardTextReader().read(factory, new StringReader(lit));
+
+			return factory.constructor(RascalValueFactory.Symbol_Lit, string);
 		}
-		
-		return factory.constructor(RascalValueFactory.Symbol_Lit, factory.string(builder.toString()));
+		catch (FactTypeUseException | IOException e) {
+			throw new RuntimeException("Internal error: parsed stringconstant notation does not coincide with vallang stringconstant notation");
+		}
 	}
 	
 	private static IValue ciliteral2Symbol(CaseInsensitiveStringConstant constant) {


### PR DESCRIPTION
The SymbolFactory  is/was still implementating the escaping and character encoding of SDF2 and not that of Rascal. This produces weird errors with unicode characters and escapes (\a, \u and \U).

