### PR TITLE
Improved the licenses generated into our shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,16 @@
         <rascal-maven.version>0.28.1</rascal-maven.version>
     </properties>
 
+    <licenses>
+        <license>
+            <name>BSD-2-Clause</name>
+            <url>https://opensource.org/license/BSD-2-Clause</url>
+            <distribution>repo</distribution>
+            <!-- we cannot define multiple licenses in this maven block, as it would mean the user can choose either of the licenses -->
+            <comments>Note, some older files are still licensed under Eclipse v1</comments>
+        </license>
+    </licenses>
+
 
     <build>
         <sourceDirectory>src</sourceDirectory>
@@ -54,6 +64,9 @@
                     <include>META-INF/RASCAL.MF</include>
                     <include>rascal-DEPENDENCIES.txt</include>
                 </includes>
+            </resource>
+            <resource>
+                <directory>${project.build.directory}/generated-resources</directory>
             </resource>
         </resources>
         <testSourceDirectory>test</testSourceDirectory>
@@ -269,6 +282,19 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.4.0</version>
+                <executions>
+                    <execution>
+                        <id>download-licenses</id>
+                        <goals>
+                            <goal>download-licenses</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
@@ -291,6 +317,11 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>org/rascalmpl/uri/resolvers.config</resource>
                                     <resource>io/usethesource/vallang/type/types.config </resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                    <addHeader>false</addHeader>
                                 </transformer>
                             </transformers>
                             <relocations>


### PR DESCRIPTION
This PR introduces the following changes:

- defined our license in the `pom.xml` file. I had to say only bsd2, as also saying epl1 would be interpreted that our users can pick either license for the whole code)
- the `NOTICE` file of all shaded dependencies are properly merged
- the `LICENSE` file of all shaded dependencies are properly merged (future work: it looked like at some point the tutor did that, but that is currently not working)
- a new `licenses/` folder is generated with all the downstream licenses, and a xml with a list of all the dependencies and their licenses is stored in the `licenses.xml` file in the jar.