### PR TITLE
Parser origin location was not forwarded properly

### DIFF
--- a/src/org/rascalmpl/values/RascalFunctionValueFactory.java
+++ b/src/org/rascalmpl/values/RascalFunctionValueFactory.java
@@ -549,7 +549,7 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
             }
             
             try {
-                return parseObject(methodName, input, readAll(input), allowAmbiguity, hasSideEffects, filters);
+                return parseObject(methodName, origin, readAll(input), allowAmbiguity, hasSideEffects, filters);
             }
             catch (ParseError pe) {
                 ISourceLocation errorLoc = pe.getLocation();


### PR DESCRIPTION
The `parse` function has an extra parameter in case the origin was not the same as the input location. But the origin was never properly passed on.