### PR TITLE
Fix small copy/paste error in Prelude.java regarding doc comment of the `last` function

### DIFF
--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -1748,7 +1748,7 @@ public class Prelude {
 	}
 
 	public IValue last(IList lst)
-	// @doc{head -- get the last element of a list}
+	// @doc{last -- get the last element of a list}
 	{
 	   if(lst.length() > 0){
 	      return lst.get(lst.length() - 1);


### PR DESCRIPTION
The name of the function in the doc comment should be last but is head.