### PR TITLE
Reimplemented `findAllErrors` function in Java

### DIFF
--- a/src/org/rascalmpl/library/util/ErrorRecovery.java
+++ b/src/org/rascalmpl/library/util/ErrorRecovery.java
@@ -199,8 +199,7 @@ public class ErrorRecovery {
         }
 
         IList args = TreeAdapter.getArgs(appl);
-        for (int i=0; i<args.size(); i++) {
-            IValue arg = args.get(i);
+        for (IValue arg : args) {
             collectErrors((ITree) arg, errors, processedTrees);
         }
     }

--- a/src/org/rascalmpl/library/util/ErrorRecovery.java
+++ b/src/org/rascalmpl/library/util/ErrorRecovery.java
@@ -189,26 +189,25 @@ public class ErrorRecovery {
     }
 
     private void collectApplErrors(ITree appl, IListWriter errors, Set<IConstructor> processedTrees) {
-        if (processedTrees.contains(appl)) {
+        if (!processedTrees.add(appl)) {
             return;
         }
-        processedTrees.add(appl);
 
         if (ProductionAdapter.isError(appl.getProduction())) {
             errors.append(appl);
         }
 
         IList args = TreeAdapter.getArgs(appl);
-        for (IValue arg : args) {
+        for (int i=0; i<args.size(); i++) {
+            IValue arg = args.get(i);
             collectErrors((ITree) arg, errors, processedTrees);
         }
     }
 
     private void collectAmbErrors(ITree amb, IListWriter errors, Set<IConstructor> processedTrees) {
-        if (processedTrees.contains(amb)) {
+        if (!processedTrees.add(amb)) {
             return;
         }
-        processedTrees.add(amb);
 
         for (IValue alt : TreeAdapter.getAlternatives(amb)) {
             collectErrors((ITree) alt, errors, processedTrees);

--- a/src/org/rascalmpl/library/util/ErrorRecovery.rsc
+++ b/src/org/rascalmpl/library/util/ErrorRecovery.rsc
@@ -7,8 +7,9 @@ import util::Maybe;
 @synopsis{Check if a parse tree contains any error nodes, the result of error recovery.}
 bool hasErrors(Tree tree) = /appl(error(_, _, _), _) := tree;
 
+@javaClass{org.rascalmpl.library.util.ErrorRecovery}
 @synopsis{Find all error productions in a parse tree.}
-list[Tree] findAllErrors(Tree tree) =  [err | /err:appl(error(_, _, _), _) := tree];
+java list[Tree] findAllErrors(Tree tree);
 
 @synopsis{Find the first production containing an error.}
 Tree findFirstError(/err:appl(error(_, _, _), _)) = err;

--- a/src/org/rascalmpl/values/parsetrees/ProductionAdapter.java
+++ b/src/org/rascalmpl/values/parsetrees/ProductionAdapter.java
@@ -144,6 +144,10 @@ public class ProductionAdapter {
 		return tree.getConstructorType() == RascalValueFactory.Production_Skipped;
 	}
 
+	public static boolean isError(IConstructor tree) {
+		return tree.getConstructorType() == RascalValueFactory.Production_Error;
+	}
+
 	public static boolean isSeparatedList(IConstructor tree) {
 		IConstructor rhs = getType(tree);
 		return SymbolAdapter.isIterPlusSeps(rhs) || SymbolAdapter.isIterStarSeps(rhs);


### PR DESCRIPTION
In rascal-lsp we need to call the `findAllErrors` function from Java.
