### PR TITLE
Fixed size inconsistency between allocating and enlarging

### DIFF
--- a/src/org/rascalmpl/parser/gtd/stack/AbstractStackNode.java
+++ b/src/org/rascalmpl/parser/gtd/stack/AbstractStackNode.java
@@ -669,7 +669,7 @@ public abstract class AbstractStackNode<P>{
 			}
 			
 			if(propagatedPrefixes == null){
-				propagatedPrefixes = new BitSet(edgesMapSize);
+				propagatedPrefixes = new BitSet(possibleMaxSize);
 			}else{
 				propagatedPrefixes.enlargeTo(possibleMaxSize);
 			}


### PR DESCRIPTION
In some rare cases (after error recovery), the `propagatedPrefixes` bitset was too small. This was caused by a difference in size between allocating a new bitset and enlarging the bitset.
This is solved in this PR.