### PR TITLE
Added support for following prefix-shared productions when determining end matcher

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/PrefixSharingRecoveryTest.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/PrefixSharingRecoveryTest.rsc
@@ -1,0 +1,19 @@
+module lang::rascal::tests::concrete::recovery::PrefixSharingRecoveryTest
+
+import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+
+layout Layout = [\ ]* !>> [\ ];
+
+start syntax Prog = Expr Expr;
+
+syntax Expr = [s] "+" "1"
+    | [s] "+" "2";
+
+test bool prefixSharedOk() = checkRecovery(#Prog, "s+2s+1", []);
+
+// When taking prefix sharing into account when determining end matchers in the error recover,
+// prefixSharedError1()  and 2 will succeed.
+// However, this costs considerable performance for very little gain in practice,
+// so for now we have disabled the prefix sharing support in `addPrefixSharedEndMatchers` 
+//test bool prefixSharedError1() = checkRecovery(#Prog, "s-1s+1", ["-1"], visualize=false);
+test bool prefixSharedError2() = checkRecovery(#Prog, "s-2s+1", ["-2"], visualize=false);

--- a/src/org/rascalmpl/parser/uptr/recovery/ToTokenRecoverer.java
+++ b/src/org/rascalmpl/parser/uptr/recovery/ToTokenRecoverer.java
@@ -147,6 +147,13 @@ public class ToTokenRecoverer implements IRecoverer<IConstructor> {
 			return nodes; // No other nodes would be useful
 		}
 
+		// If we are the top-level node, just skip the rest of the input
+		if (!recoveryNode.isEndNode() && isTopLevelProduction(recoveryNode)) {
+			result = SkippingStackNode.createResultUntilEndOfInput(uri, input, startLocation);
+			nodes.add(new SkippingStackNode<>(stackNodeIdDispenser.dispenseId(), prod, result, startLocation));
+			return nodes; // No other nodes would be useful
+		}
+
 		// Find the last token of this production and skip until after that
 		List<InputMatcher> endMatchers = findEndMatchers(recoveryNode.getProduction()[recoveryNode.getDot()]);
 		for (InputMatcher endMatcher : endMatchers) {
@@ -234,7 +241,13 @@ public class ToTokenRecoverer implements IRecoverer<IConstructor> {
 
 		throw new AssertionError("No end node found?"); // Should not happen, last node is always an end node
 	}
-	
+
+	// Check if a node is a top-level production (i.e., its parent production node has no parents and
+	// starts at position -1)
+	private boolean isTopLevelProduction(AbstractStackNode<IConstructor> node) {
+		return node.getProduction()[0].getStartLocation() == -1;
+	}
+
 	private void addEndMatchers(AbstractStackNode<IConstructor>[] prod, int dot, List<InputMatcher> matchers, Set<Integer> visitedNodes) {
 		if (prod == null || dot < 0 || dot >= prod.length) {
 			return;


### PR DESCRIPTION
For now, this support has been turned off because it seems to cost a lot of performance for very little gain.