### PR TITLE
Fixed @<column> requirement implementation

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/AtColumnRequirement.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/AtColumnRequirement.rsc
@@ -5,32 +5,18 @@ import Exception;
 
 lexical C = C C C | "a"@2 | "b";
 
-test bool testA() {
+bool testParse(str input, bool shouldParse) {
     try {
-        parse(#C, "a");
-    } catch ParseError(e): {
-        return true;
+        parse(#C, input);
+    } catch ParseError(_): {
+        return !shouldParse;
     }
 
-    return false;
+    return shouldParse;
 }
 
-test bool testBab() {
-    try {
-        parse(#C, "bab");
-    } catch ParseError(e): {
-        return true;
-    }
+test bool testA() = testParse("a", false);
 
-    return false;
-}
+test bool testBab() = testParse("bab", false);
 
-test bool testBba() {
-    try {
-        parse(#C, "bba");
-    } catch ParseError(e): {
-        return false;
-    }
-
-    return true;
-}
+test bool testBba() = testParse("bba", true);

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/AtColumnRequirement.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/AtColumnRequirement.rsc
@@ -1,0 +1,36 @@
+module lang::rascal::tests::concrete::AtColumnRequirement
+
+import ParseTree;
+import Exception;
+
+lexical C = C C C | "a"@2 | "b";
+
+test bool testA() {
+    try {
+        parse(#C, "a");
+    } catch ParseError(e): {
+        return true;
+    }
+
+    return false;
+}
+
+test bool testBab() {
+    try {
+        parse(#C, "bab");
+    } catch ParseError(e): {
+        return true;
+    }
+
+    return false;
+}
+
+test bool testBba() {
+    try {
+        parse(#C, "bba");
+    } catch ParseError(e): {
+        return false;
+    }
+
+    return true;
+}

--- a/src/org/rascalmpl/parser/gtd/stack/filter/precede/AtColumnRequirement.java
+++ b/src/org/rascalmpl/parser/gtd/stack/filter/precede/AtColumnRequirement.java
@@ -27,7 +27,7 @@ public class AtColumnRequirement implements IEnterFilter{
 	}
 	
 	public boolean isFiltered(int[] input, int start, PositionStore positionStore){
-		return positionStore.isAtColumn(start, column);
+		return !positionStore.isAtColumn(start, column);
 	}
 	
 	public boolean isEqual(IEnterFilter otherEnterFilter){


### PR DESCRIPTION
The Rascal "@" syntax column requirement was implemented incorrectly. Filtering was done if the current column was the expected column while it should have been the other way around.
This PR fixes this issue.