### PR TITLE
feat/error recovery robust field projection

### DIFF
--- a/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
+++ b/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
@@ -145,6 +145,22 @@ public class ConcreteSyntaxResult extends ConstructorResult {
 					}
 				}
 			}
+			else if (ProductionAdapter.isError(prod)) {
+				var eprod = ProductionAdapter.getErrorProd(prod);
+				int dot = ProductionAdapter.getErrorDot(prod);
+				IList syms = ProductionAdapter.getSymbols(eprod);
+				String tmp = Names.name(name);
+
+				// only look before the dot.
+				for (int i = 0; i < dot; i++) {
+					var sym = syms.get(i);
+					if (SymbolAdapter.isLabel((IConstructor) sym)) {
+						if (SymbolAdapter.getLabel((IConstructor) sym).equals(tmp)) {
+							return ResultFactory.bool(true, ctx);
+						}
+					}
+				}
+			}
 		}
 		return super.has(name);
 	}

--- a/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
+++ b/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
@@ -55,6 +55,7 @@ public class ConcreteSyntaxResult extends ConstructorResult {
 				return ResultFactory.bool(Names.name(name).equals(consName), ctx);
 			}
 		}
+		
 		return ResultFactory.bool(false, ctx);
 	}
 	

--- a/src/org/rascalmpl/values/parsetrees/ProductionAdapter.java
+++ b/src/org/rascalmpl/values/parsetrees/ProductionAdapter.java
@@ -16,6 +16,7 @@
 package org.rascalmpl.values.parsetrees;
 
 import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.IListWriter;
 import io.usethesource.vallang.INode;
@@ -206,4 +207,12 @@ public class ProductionAdapter {
 		}
 		return false;
 	}
+
+    public static int getErrorDot(IConstructor prod) {
+       return ((IInteger) prod.get("dot")).intValue();
+    }
+
+    public static IConstructor getErrorProd(IConstructor prod) {
+       return (IConstructor) prod.get("prod");
+    }
 }

--- a/src/org/rascalmpl/values/parsetrees/ProductionAdapter.java
+++ b/src/org/rascalmpl/values/parsetrees/ProductionAdapter.java
@@ -38,10 +38,15 @@ public class ProductionAdapter {
 	 * @return a constructor name if present or null otherwise
 	 */
 	public static String getConstructorName(IConstructor tree) {
-		IConstructor def = getDefined(tree);
+		if (isDefault(tree)) {
+			IConstructor def = getDefined(tree);
 		
-		if (SymbolAdapter.isLabel(def)) {
-			return SymbolAdapter.getLabel(def);
+			if (SymbolAdapter.isLabel(def)) {
+				return SymbolAdapter.getLabel(def);
+			}
+		}
+		else if (isError(tree)) {
+			return "recovered";
 		}
 		
 		return null;

--- a/src/org/rascalmpl/values/parsetrees/TreeAdapter.java
+++ b/src/org/rascalmpl/values/parsetrees/TreeAdapter.java
@@ -194,6 +194,26 @@ public class TreeAdapter {
 						return null;
 				}
 			}
+			else if (ProductionAdapter.isError(prod)) {
+				var eprod = ProductionAdapter.getErrorProd(prod);
+				int dot = ProductionAdapter.getErrorDot(prod);
+				int index = SymbolAdapter.indexOfLabel(ProductionAdapter.getSymbols(eprod), field);
+				IList args = getArgs(tree);
+
+				if (index != -1) {
+					if (index < dot) {
+						// changing the normal part of the tree
+						return setArgs(tree, args.put(index, repl));
+					}
+					else if (index == dot) {
+						// extending the accepted part of the tree by one field
+						eprod = prod.set("prod", IRascalValueFactory.getInstance().integer(dot + 1));
+						return setProduction(setArgs(tree, args.append(repl)), eprod);
+					}
+
+					// otherwise we return null which indicates the field does not exist.
+				}
+			}
 		}
 
 		return null;

--- a/src/org/rascalmpl/values/parsetrees/TreeAdapter.java
+++ b/src/org/rascalmpl/values/parsetrees/TreeAdapter.java
@@ -210,8 +210,10 @@ public class TreeAdapter {
 						eprod = prod.set("prod", IRascalValueFactory.getInstance().integer(dot + 1));
 						return setProduction(setArgs(tree, args.append(repl)), eprod);
 					}
-
-					// otherwise we return null which indicates the field does not exist.
+					else {
+						// otherwise we return null which indicates the field does not exist.
+						return null;
+					}
 				}
 			}
 		}
@@ -306,22 +308,8 @@ public class TreeAdapter {
 						return new FieldResult(sym, (ITree) tree.getArgs().get(index));
 					}
 					else {
-						// We have the right prodction and the field would be there, if we didn't recover from a parse error
-						// and are missing some of the children (including the indicated field).
-						// So we return a quasi tree that is of the right type, but it otherwise just an error tree
-						// like its parent. This tree does not have content, because we wouldn't know which of the skipped
-						// parts are meant.
-						var vf = IRascalValueFactory.getInstance();
-						// @PieterOlivier is this the right way to do this? I just need an empty tree of the right symbol.
-						var skipped = vf.constructor(RascalValueFactory.Production_Skipped);
-						var skippedProd = vf.constructor(RascalValueFactory.Production_Error, sym, skipped, vf.integer(0));
-						var skippedTree = vf.appl(skippedProd);
-						var parentLoc = getLocation(tree);
-						if (parentLoc != null) {
-							// TODO @PieterOlivier I guess we need the location of the last parsed element, and use an
-							// empty range that is just beyond that. But for now I'd like to test with this.
-						}
-						return new FieldResult(sym, skippedTree);
+						// we simply don't have that field yet. too bad.
+						return null;
 					}
 				}
 			}


### PR DESCRIPTION
This experiment makes parse tree instances (ITree's in  Java) which happen to have error productions robust again field projection (in the interpreter)

* if the field is before the error "dot", it just works as normal field projection
* if the field is on or beyond the error dot, then we return a fresh error tree of the right type but without content.

Of course further field projection on such a stub would not work anymore, because there is no more production to work with. So this gives only one layer of robustness. A future version of this could recursively keep returning empty error stubs, but I don't know how to obtain the right type for those trees from the interpreter. 

The questions are:
* does this help to remove many scattered `hasError` checks?
* is this predictable and understandable behavior for the field projection semantics?
* @PaulKlint  compiled version of tree field projection {sh,w,c}ould also have this semantics?
* what did I forget?


At the very least field projection should work for fields which are before the dot. The rest is open for discussion I think.