### PR TITLE
Feat/remove auto disambiguation

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/BasicRecoveryTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/BasicRecoveryTests.rsc
@@ -32,12 +32,3 @@ test bool basicOk() = checkRecovery(#S, "a b c $", []);
 test bool abx() = checkRecovery(#S, "a b x $", ["x "]);
 
 test bool axc() = checkRecovery(#S, "a x c $", ["x c"]);
-
-test bool autoDisambiguation() {
-    str input = "a x $";
-
-    assert checkRecovery(#S, input, ["x "]);
-
-    Tree autoDisambiguated = parser(#S, allowRecovery=true, allowAmbiguity=false)(input, |unknown:///|);
-    return size(findAllErrors(autoDisambiguated)) == 1;
-}

--- a/src/org/rascalmpl/library/util/ErrorRecovery.java
+++ b/src/org/rascalmpl/library/util/ErrorRecovery.java
@@ -217,4 +217,8 @@ public class ErrorRecovery {
             collectErrors((ITree) alt, errors, processedTrees);
         }
     }
+
+    public void checkForRegularAmbiguities(IConstructor parseForest) {
+        disambiguate(parseForest, false, new HashMap<>());
+    }
 }

--- a/src/org/rascalmpl/library/util/ErrorRecovery.rsc
+++ b/src/org/rascalmpl/library/util/ErrorRecovery.rsc
@@ -51,3 +51,6 @@ This filter removes error trees until no ambiguities caused by error recovery ar
 Note that regular ambiguous trees remain in the parse forest unless `allowAmbiguity` is set to false in which case an error is thrown.
 }
 java Tree disambiguateErrors(Tree t, bool allowAmbiguity=true);
+
+Tree(Tree) createErrorFilter(bool allowAmbiguity) =
+    Tree(Tree t)  { return disambiguateErrors(t, allowAmbiguity=allowAmbiguity); };

--- a/src/org/rascalmpl/values/RascalFunctionValueFactory.java
+++ b/src/org/rascalmpl/values/RascalFunctionValueFactory.java
@@ -583,15 +583,7 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
             if (allowRecovery) {
                 recoverer = new ToTokenRecoverer(uri, parserInstance, new StackNodeIdDispenser(parserInstance));
             }
-            ITree parseForest = (ITree) parserInstance.parse(methodName, uri, input, exec, new DefaultNodeFlattener<>(), new UPTRNodeFactory(allowRecovery || allowAmbiguity), recoverer, debugListener);
-
-            if (!allowAmbiguity && allowRecovery && filters.isEmpty()) {
-                // Filter error-induced ambiguities
-                RascalValueFactory valueFactory = (RascalValueFactory) ValueFactoryFactory.getValueFactory();
-                parseForest = (ITree) new ErrorRecovery(valueFactory).disambiguateErrors(parseForest, valueFactory.bool(false));
-            }
-
-            return parseForest;
+            return (ITree) parserInstance.parse(methodName, uri, input, exec, new DefaultNodeFlattener<>(), new UPTRNodeFactory(allowRecovery || allowAmbiguity), recoverer, debugListener);
         }
     }
     

--- a/src/org/rascalmpl/values/RascalFunctionValueFactory.java
+++ b/src/org/rascalmpl/values/RascalFunctionValueFactory.java
@@ -583,7 +583,15 @@ public class RascalFunctionValueFactory extends RascalValueFactory {
             if (allowRecovery) {
                 recoverer = new ToTokenRecoverer(uri, parserInstance, new StackNodeIdDispenser(parserInstance));
             }
-            return (ITree) parserInstance.parse(methodName, uri, input, exec, new DefaultNodeFlattener<>(), new UPTRNodeFactory(allowRecovery || allowAmbiguity), recoverer, debugListener);
+            ITree parseForest = (ITree) parserInstance.parse(methodName, uri, input, exec, new DefaultNodeFlattener<>(), new UPTRNodeFactory(allowRecovery || allowAmbiguity), recoverer, debugListener);
+
+            if (!allowAmbiguity && allowRecovery) {
+                // Check for 'regular' (non-error) ambiguities
+                RascalValueFactory valueFactory = (RascalValueFactory) ValueFactoryFactory.getValueFactory();
+                new ErrorRecovery(valueFactory).checkForRegularAmbiguities(parseForest);
+            }
+
+            return parseForest;
         }
     }
     


### PR DESCRIPTION
This PR removes the automatic disambiguation of error trees when allowRecovery=true but allowAmbiguity=false.

Note that in this case a separate check is needed for 'regular' ambiguities (which are not allowed).