### PR TITLE
Renamed 'symbol' field in skipped production to 'def'

### DIFF
--- a/src/org/rascalmpl/library/ParseTree.rsc
+++ b/src/org/rascalmpl/library/ParseTree.rsc
@@ -192,7 +192,7 @@ data Production
 
 data Production
      = \error(Symbol def, Production prod, int dot)
-     | \skipped(Symbol symbol);
+     | \skipped(Symbol def);
 
 @synopsis{Attributes in productions.}
 @description{


### PR DESCRIPTION
By aligning this field with the other alternatives of `Production`, code can be written more generic.