### PR TITLE
Fixed the maven-shade-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,11 @@
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>org/rascalmpl/uri/resolvers.config</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>io/usethesource/vallang/type/types.config</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/sisu/javax.inject.Named</resource> <!-- Needed for dependency injection in MavenCli -->
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer"/> <!-- Needed for dependency injection in MavenCli -->


### PR DESCRIPTION
@PaulKlint noticed that the Rascal jar was broken after the recent merge of the [Maven branch](https://github.com/usethesource/rascal/actions/runs/12028537370), in which the configuration of the `maven-shade-plugin` was updated. It turns out that the plugin was configured incorrectly, which is fixed in this PR.