### PR TITLE
Fix location in bootstrap code

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/grammar/Bootstrap.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/grammar/Bootstrap.rsc
@@ -44,7 +44,7 @@ public void bootstrapAst(loc rascalHome) {
 
 public void bootParser(Grammar gr, loc rascalHome) {
   source = newGenerate(package, rootName, gr);
-  writeFile(rascalHome + "lang/rascal/syntax/<rootName>.java", source);
+  writeFile(rascalHome + "src/org/rascalmpl/library/lang/rascal/syntax/<rootName>.java", source);
 }
 
 public void bootAST(Grammar g, loc rascalHome) {


### PR DESCRIPTION
I was using module `Bootstrap` (in the context of #2083), but the generated parser wasn't written to the expected/existing file. Thought I'd fix it in this separate PR first (i.e., there are some other unexpected bootstrap diffs in #2083, but their severity/timeline-to-fix isn't clear yet).