### PR TITLE
Add bin folders of dependencies to the classpath when they're open in the workspace

### DIFF
--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -546,7 +546,6 @@ public class PathConfig {
                                 libsWriter.append(childConfig.getBin());
                                 break;
                             case COMPILER:
-                                // FIXME (?): Add something to `srcsWriter` here?
                                 libsWriter.append(setTargetScheme(projectLoc));
                                 break;
                         }

--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -543,8 +543,10 @@ public class PathConfig {
                         switch (mode) {
                             case INTERPRETER:
                                 srcsWriter.appendAll(childConfig.getSrcs());
+                                libsWriter.append(childConfig.getBin());
                                 break;
                             case COMPILER:
+                                // FIXME (?): Add something to `srcsWriter` here?
                                 libsWriter.append(setTargetScheme(projectLoc));
                                 break;
                         }


### PR DESCRIPTION
**Before this PR,** when a REPL was created in a project, and when one of its dependencies (as declared in the POM) was open in the same workspace:
  - the `src` folder of the dependency was loaded from the workspace;
  - the `bin` folder of the dependency wasn't loaded at all (neither from the workspace, nor from the local Maven repository).

**After this PR,** the `bin` folder is loaded from the workspace, too. This PR fixes the following issue (in `rascal-language-servers`):

  - https://github.com/usethesource/rascal-language-servers/issues/539

See the separate comments for additional clarification/questions.