### PR TITLE
Removed redundant character creation caching

### DIFF
--- a/src/org/rascalmpl/parser/gtd/result/out/CharNodeFlattener.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/CharNodeFlattener.java
@@ -16,10 +16,7 @@ import org.rascalmpl.parser.gtd.result.CharNode;
 /**
  * A converter for character result nodes.
  */
-@SuppressWarnings("unchecked")
 public class CharNodeFlattener<T, P>{
-	private final T[] cache = (T[]) new Object[128];
-	
 	public CharNodeFlattener(){
 		super();
 	}
@@ -28,17 +25,6 @@ public class CharNodeFlattener<T, P>{
 	 * Converts the given character result node to the UPTR format.
 	 */
 	public T convertToUPTR(INodeConstructorFactory<T, P> nodeConstructorFactory, CharNode node){
-		int charNumber = node.getCharacter();
-		
-		// Cache 7-bit ASCII character results.
-		if(charNumber < 128){
-			T result = cache[charNumber];
-			if(result != null) return result;
-			
-			result = nodeConstructorFactory.createCharNode(charNumber);
-			cache[charNumber] = result;
-		}
-		
-		return nodeConstructorFactory.createCharNode(charNumber);
+		return nodeConstructorFactory.createCharNode(node.getCharacter());
 	}
 }


### PR DESCRIPTION
Character node caching in `CharNodeFlattener` was redundant (and implemented slighty wrong) as exactly the same caching is already done in `RascalValueFactory`.