### PR TITLE
Fixed bug where cycles where always considered unequal

### DIFF
--- a/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
+++ b/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
@@ -247,6 +247,15 @@ public class ConcreteSyntaxResult extends ConstructorResult {
 			return bool(true, ctx);
 		}
 
+		if (TreeAdapter.isCycle(left) && TreeAdapter.isCycle(right)) {
+			IConstructor type1 = TreeAdapter.getCycleType(left);
+			IConstructor type2 = TreeAdapter.getCycleType(right);
+			int length1 = TreeAdapter.getCycleLength(left);
+			int length2 = TreeAdapter.getCycleLength(right);
+
+			return bool(type1.equals(type2) && length1 == length2, ctx);
+		}
+
 		return bool(false, ctx);
 	}
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/ParseTreeEquality.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/ParseTreeEquality.rsc
@@ -1,0 +1,10 @@
+module lang::rascal::tests::concrete::ParseTreeEquality
+
+import ParseTree;
+
+bool testCycleEquality() {
+    Tree cycle1 = cycle(sort("X"), 3);
+    Tree cycle2 = cycle(sort("X"), 3);
+
+    return cycle1 == cycle2;
+}


### PR DESCRIPTION
Parsetrees with cycles where always considered as "not equal" because the equality check in the interpreter did not check for the cycle case.