### PR TITLE
Link based parse memoization

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/MemoCycleTest.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/MemoCycleTest.rsc
@@ -1,0 +1,38 @@
+module lang::rascal::tests::concrete::MemoCycleTest
+
+import ParseTree;
+import vis::Text;
+import IO;
+
+syntax S = T | U;
+
+syntax T = X T? | "$";
+
+syntax U = X T? | "$";
+
+syntax X = "b"? | "c";
+
+test bool memoCycleBug() {
+   Tree tree = parse(#S, "bc$", |unknown:///|, allowAmbiguity=true);
+   if (amb({appl1, appl2 }) := tree) {
+
+      // Find the suspect alternative
+      Tree suspectAppl = appl1;
+      if (appl2.prod.symbols == [sort("T")]) {
+         suspectAppl = appl2;
+      }
+
+      if (appl(_, [amb({alt1,alt2})]) := suspectAppl) {
+         /* Yield of one of the alternatives should be empty because all we have left is a cycle:
+         T = X  T?
+         ├─ X = "b"?
+         │  └─ "b"?
+         └─ T?
+            └─ cycle(T, 2)
+         */
+         return "<alt1>" == "" || "<alt2>" == "";
+      }
+   }
+
+   return false;
+}

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/MemoCycleTest.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/MemoCycleTest.rsc
@@ -2,7 +2,6 @@ module lang::rascal::tests::concrete::MemoCycleTest
 
 import ParseTree;
 import vis::Text;
-import IO;
 
 syntax S = T | U;
 
@@ -12,6 +11,7 @@ syntax U = X T? | "$";
 
 syntax X = "b"? | "c";
 
+// Test for regression of a bug in the node flattener
 test bool memoCycleBug() {
    Tree tree = parse(#S, "bc$", |unknown:///|, allowAmbiguity=true);
    if (amb({appl1, appl2 }) := tree) {

--- a/src/org/rascalmpl/parser/gtd/result/out/DefaultNodeFlattener.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/DefaultNodeFlattener.java
@@ -53,18 +53,18 @@ public class DefaultNodeFlattener<P, T, S> implements INodeFlattener<T, S>{
 	/**
 	 * Convert the given node.
 	 */
-	public T convert(INodeConstructorFactory<T, S> nodeConstructorFactory, AbstractNode node, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	public T convert(INodeConstructorFactory<T, S> nodeConstructorFactory, AbstractNode node, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		switch(node.getTypeIdentifier()){
 			case CharNode.ID:
 				return charNodeConverter.convertToUPTR(nodeConstructorFactory, (CharNode) node);
 			case LiteralNode.ID:
 				return literalNodeConverter.convertToUPTR(nodeConstructorFactory, (LiteralNode) node);
 			case SortContainerNode.ID:
-				return sortContainerNodeConverter.convertToUPTR(this, nodeConstructorFactory, (SortContainerNode<P>) node, stack, depth, cycleMark, positionStore, filteringTracker, actionExecutor, environment);
+				return sortContainerNodeConverter.convertToUPTR(this, nodeConstructorFactory, (SortContainerNode<P>) node, stack, depth, positionStore, filteringTracker, actionExecutor, environment);
 			case ExpandableContainerNode.ID:
-				return listContainerNodeConverter.convertToUPTR(this, nodeConstructorFactory, (ExpandableContainerNode<P>) node, stack, depth, cycleMark, positionStore, filteringTracker, actionExecutor, environment);
+				return listContainerNodeConverter.convertToUPTR(this, nodeConstructorFactory, (ExpandableContainerNode<P>) node, stack, depth, positionStore, filteringTracker, actionExecutor, environment);
 			case RecoveredNode.ID:
-				return convert(nodeConstructorFactory, ((SortContainerNode<S>) node).getFirstAlternative().getNode(), stack, depth, cycleMark, positionStore, filteringTracker, actionExecutor, environment);
+				return convert(nodeConstructorFactory, ((SortContainerNode<S>) node).getFirstAlternative().getNode(), stack, depth, positionStore, filteringTracker, actionExecutor, environment);
 			case SkippedNode.ID:
 				return recoveryNodeConverter.convertToUPTR(nodeConstructorFactory, (SkippedNode) node); 
 			default:
@@ -76,6 +76,6 @@ public class DefaultNodeFlattener<P, T, S> implements INodeFlattener<T, S>{
 	 * Converts the given parse tree to a tree in UPTR format.
 	 */
 	public T convert(INodeConstructorFactory<T, S> nodeConstructorFactory, AbstractNode parseTree, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object rootEnvironment){
-		return convert(nodeConstructorFactory, parseTree, new IndexedStack<AbstractNode>(), 0, new CycleMark(), positionStore, filteringTracker, actionExecutor, rootEnvironment);
+		return convert(nodeConstructorFactory, parseTree, new IndexedStack<>(), 0, positionStore, filteringTracker, actionExecutor, rootEnvironment);
 	}
 }

--- a/src/org/rascalmpl/parser/gtd/result/out/INodeFlattener.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/INodeFlattener.java
@@ -26,32 +26,5 @@ public interface INodeFlattener<T, P>{
 	 */
 	T convert(INodeConstructorFactory<T, P> nodeConstructorFactory, AbstractNode parseTree, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object rootEnvironment);
 	
-	T convert(INodeConstructorFactory<T, P> nodeConstructorFactory, AbstractNode parseTree, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object rootEnvironment);
-	
-	/**
-	 * Internal helper structure for cycle detection and handling.
-	 */
-	static class CycleMark{
-		public int depth = Integer.MAX_VALUE;
-		
-		public CycleMark(){
-			super();
-		}
-		
-		/**
-		 * Marks the depth at which a cycle was detected.
-		 */
-		public void setMark(int depth){
-			if(depth < this.depth){
-				this.depth = depth;
-			}
-		}
-		
-		/**
-		 * Resets the mark.
-		 */
-		public void reset(){
-			depth = Integer.MAX_VALUE;
-		}
-	}
+	T convert(INodeConstructorFactory<T, P> nodeConstructorFactory, AbstractNode parseTree, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object rootEnvironment);	
 }

--- a/src/org/rascalmpl/parser/gtd/result/out/ListContainerNodeFlattener.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/ListContainerNodeFlattener.java
@@ -12,6 +12,7 @@
 package org.rascalmpl.parser.gtd.result.out;
 
 import java.net.URI;
+import java.util.Map;
 
 import org.rascalmpl.parser.gtd.location.PositionStore;
 import org.rascalmpl.parser.gtd.result.AbstractNode;
@@ -40,11 +41,14 @@ public class ListContainerNodeFlattener<P, T, S>{
 	private final IntegerKeyedHashMap<ObjectIntegerKeyedHashMap<Object, T>> preCache;
 	private final IntegerKeyedHashMap<ObjectIntegerKeyedHashSet<T>> cache;
 	
+	private final Map<Link, ArrayList<T>> linkCache;
+
 	public ListContainerNodeFlattener(){
 		super();
 
 		preCache = new IntegerKeyedHashMap<ObjectIntegerKeyedHashMap<Object, T>>();
 		cache = new IntegerKeyedHashMap<ObjectIntegerKeyedHashSet<T>>();
+		linkCache = new java.util.HashMap<>();
 	}
 	
 	/**
@@ -235,7 +239,21 @@ public class ListContainerNodeFlattener<P, T, S>{
 	/**
 	 * Gather all the alternatives ending with the given child.
 	 */
-	protected void gatherAlternatives(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache, PositionStore positionStore, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	protected void gatherAlternatives(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache, PositionStore positionStore, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment, boolean hasSideEffects){
+		ArrayList<T> gatheredAlts;
+
+		if (!hasSideEffects) {
+			gatheredAlts = linkCache.get(child);
+			if (gatheredAlts != null) {
+				for (int i=0; i<gatheredAlts.size(); i++) {
+					gatheredAlternatives.add(gatheredAlts.get(i));
+				}
+				return;
+			}
+
+		}
+		gatheredAlts = new ArrayList<T>();
+
 		AbstractNode childNode = child.getNode();
 		
 		if(!(childNode.isEpsilon() && child.getPrefixes() == null)){ // Has non-epsilon results.
@@ -244,18 +262,26 @@ public class ListContainerNodeFlattener<P, T, S>{
 				CycleNode cycle = gatherCycle(child, new AbstractNode[]{childNode}, blackList);
 				if(cycle != null){ // Encountered a cycle.
 					if(cycle.cycle.length == 1){
-						gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, cycle), gatheredAlternatives, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
+						gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, cycle), gatheredAlts, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
 					}else{
 						ForwardLink<AbstractNode> cycleLink = new ForwardLink<AbstractNode>(NO_NODES, cycle);
-						gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(cycleLink, childNode), gatheredAlternatives, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
+						gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(cycleLink, childNode), gatheredAlts, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
 					}
 					return;
 				}
 			}
 			// Encountered non-cyclic child.
-			gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, childNode), gatheredAlternatives, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
+			gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, childNode), gatheredAlts, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
 		}else{ // Has a single epsilon result.
-			buildAlternative(converter, nodeConstructorFactory, noChildren, NO_NODES, production, gatheredAlternatives, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+			buildAlternative(converter, nodeConstructorFactory, noChildren, NO_NODES, production, gatheredAlts, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+		}
+
+		for (int i = 0; i < gatheredAlts.size(); i++) {
+			gatheredAlternatives.add(gatheredAlts.get(i));
+		}
+
+		if (!hasSideEffects) {
+			linkCache.put(child, gatheredAlts);
 		}
 	}
 	
@@ -461,17 +487,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 		Object rhs = nodeConstructorFactory.getRhs(node.getFirstProduction());
 		boolean hasSideEffects = actionExecutor.isImpure(rhs);
 		
-		if(depth <= cycleMark.depth){ // Only check for sharing if we are not currently inside a cycle.
-			if(!hasSideEffects){ // If this sort node and its direct and indirect children do not rely on side-effects from semantic actions, check the cache for existing results.
-				ObjectIntegerKeyedHashMap<Object, T> levelCache = preCache.get(offset);
-				if(levelCache != null){
-					T cachedResult = levelCache.get(rhs, endOffset);
-					if(cachedResult != null){
-						return cachedResult;
-					}
-				}
-			}
-			
+		if (depth <= cycleMark.depth) {
 			cycleMark.reset();
 		}
 		
@@ -503,12 +519,12 @@ public class ListContainerNodeFlattener<P, T, S>{
 		// Gather the alternatives.
 		HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache = new HashMap<ArrayList<Link>, SharedPrefix<T>>();
 		ArrayList<T> gatheredAlternatives = new ArrayList<T>();
-		gatherAlternatives(converter, nodeConstructorFactory, node.getFirstAlternative(), gatheredAlternatives, node.getFirstProduction(), stack, childDepth, cycleMark, sharedPrefixCache, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+		gatherAlternatives(converter, nodeConstructorFactory, node.getFirstAlternative(), gatheredAlternatives, node.getFirstProduction(), stack, childDepth, cycleMark, sharedPrefixCache, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
 		ArrayList<Link> alternatives = node.getAdditionalAlternatives();
 		ArrayList<P> productions = node.getAdditionalProductions();
 		if(alternatives != null){
 			for(int i = alternatives.size() - 1; i >= 0; --i){
-				gatherAlternatives(converter, nodeConstructorFactory, alternatives.get(i), gatheredAlternatives, productions.get(i), stack, childDepth, cycleMark, sharedPrefixCache, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+				gatherAlternatives(converter, nodeConstructorFactory, alternatives.get(i), gatheredAlternatives, productions.get(i), stack, childDepth, cycleMark, sharedPrefixCache, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
 			}
 		}
 		
@@ -537,38 +553,22 @@ public class ListContainerNodeFlattener<P, T, S>{
 		
 		stack.dirtyPurge(); // Pop this node off the stack.
 		
-		if(result != null && depth < cycleMark.depth){ // Only share the constructed tree if we are not in a cycle.
-			if(!hasSideEffects){ // Cache side-effect free tree.
-				ObjectIntegerKeyedHashMap<Object, T> levelCache = preCache.get(offset);
-				if(levelCache != null){
-					T cachedResult = levelCache.get(rhs, endOffset);
-					if(cachedResult != null){
-						return cachedResult;
-					}
-					
-					levelCache.putUnsafe(rhs, endOffset, result);
-					return result;
+		if (hasSideEffects) {
+			// Cache tree with side-effects to keep as much sharing as possible in the resulting parse forest
+			ObjectIntegerKeyedHashSet<T> levelCache = cache.get(offset);
+			if(levelCache != null){
+				T cachedResult = levelCache.getEquivalent(result, endOffset);
+				if(cachedResult != null){
+					return cachedResult;
 				}
 				
-				levelCache = new ObjectIntegerKeyedHashMap<Object, T>();
-				levelCache.putUnsafe(rhs, endOffset, result);
-				preCache.put(offset, levelCache);
-			}else{ // Cache tree with side-effects.
-				ObjectIntegerKeyedHashSet<T> levelCache = cache.get(offset);
-				if(levelCache != null){
-					T cachedResult = levelCache.getEquivalent(result, endOffset);
-					if(cachedResult != null){
-						return cachedResult;
-					}
-					
-					levelCache.putUnsafe(result, endOffset);
-					return result;
-				}
-				
-				levelCache = new ObjectIntegerKeyedHashSet<T>();
 				levelCache.putUnsafe(result, endOffset);
-				cache.putUnsafe(offset, levelCache);
+				return result;
 			}
+			
+			levelCache = new ObjectIntegerKeyedHashSet<T>();
+			levelCache.putUnsafe(result, endOffset);
+			cache.putUnsafe(offset, levelCache);
 		}
 		
 		return result;

--- a/src/org/rascalmpl/parser/gtd/result/out/ListContainerNodeFlattener.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/ListContainerNodeFlattener.java
@@ -18,7 +18,6 @@ import org.rascalmpl.parser.gtd.location.PositionStore;
 import org.rascalmpl.parser.gtd.result.AbstractNode;
 import org.rascalmpl.parser.gtd.result.ExpandableContainerNode;
 import org.rascalmpl.parser.gtd.result.action.IActionExecutor;
-import org.rascalmpl.parser.gtd.result.out.INodeFlattener.CycleMark;
 import org.rascalmpl.parser.gtd.result.struct.Link;
 import org.rascalmpl.parser.gtd.util.ArrayList;
 import org.rascalmpl.parser.gtd.util.ForwardLink;
@@ -104,7 +103,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 	 * Construct the UPTR representation for the given production.
 	 * Additionally, it handles all semantic actions related 'events' associated with it.
 	 */
-	private Object buildAlternative(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, T[] prefix, ForwardLink<AbstractNode> postFix, Object production, ArrayList<T> gatheredAlternatives, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	private Object buildAlternative(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, T[] prefix, ForwardLink<AbstractNode> postFix, Object production, ArrayList<T> gatheredAlternatives, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		Object newEnvironment = actionExecutor.enteringListProduction(production, environment); // Fire a 'entering production' event to enable environment handling.
 		
 		ArrayList<T> children = new ArrayList<T>();
@@ -122,7 +121,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 			newEnvironment = actionExecutor.enteringListNode(production, index++, newEnvironment); // Fire a 'entering node' event when converting a child to enable environment handling.
 			
 			if(!(node instanceof CycleNode)){ // Not a cycle.
-				T constructedNode = converter.convert(nodeConstructorFactory, node, stack, depth, cycleMark, positionStore, filteringTracker, actionExecutor, newEnvironment);
+				T constructedNode = converter.convert(nodeConstructorFactory, node, stack, depth, positionStore, filteringTracker, actionExecutor, newEnvironment);
 				if(constructedNode == null){
 					actionExecutor.exitedListProduction(production, true, newEnvironment); // Filtered.
 					return null;
@@ -131,7 +130,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 				children.add(constructedNode);
 			}else{ // Cycle.
 				CycleNode cycleNode = (CycleNode) node;
-				T[] constructedCycle = constructCycle(converter, nodeConstructorFactory, production, cycleNode, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, newEnvironment);
+				T[] constructedCycle = constructCycle(converter, nodeConstructorFactory, production, cycleNode, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, newEnvironment);
 				if(constructedCycle == null){
 					actionExecutor.exitedListProduction(production, true, newEnvironment); // Filtered.
 					return null;
@@ -166,7 +165,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 	/**
 	 * Construct the UPTR representation for the given cycle.
 	 */
-	private T[] constructCycle(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Object production, CycleNode cycleNode, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	private T[] constructCycle(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Object production, CycleNode cycleNode, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		Object newEnvironment = actionExecutor.enteringListProduction(production, environment); // Fire a 'entering production' event to enable environment handling.
 		
 		AbstractNode[] cycleElements = cycleNode.cycle;
@@ -177,7 +176,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 			convertedCycle = (T[]) new Object[1];
 			
 			newEnvironment = actionExecutor.enteringListNode(production, 0, newEnvironment); // Fire a 'entering node' event when converting a child to enable environment handling.
-			T element = converter.convert(nodeConstructorFactory, cycleElements[0], stack, depth, cycleMark, positionStore, filteringTracker, actionExecutor, newEnvironment);
+			T element = converter.convert(nodeConstructorFactory, cycleElements[0], stack, depth, positionStore, filteringTracker, actionExecutor, newEnvironment);
 			if(element == null){
 				actionExecutor.exitedListProduction(production, true, newEnvironment); // Filtered.
 				return null;
@@ -189,10 +188,10 @@ public class ListContainerNodeFlattener<P, T, S>{
 			convertedCycle = (T[]) new Object[nrOfCycleElements + 1];
 			
 			newEnvironment = actionExecutor.enteringListNode(production, 0, newEnvironment); // Fire a 'entering node' event when converting a child to enable environment handling.
-			convertedCycle[0] = converter.convert(nodeConstructorFactory, cycleElements[nrOfCycleElements - 1], stack, depth, cycleMark, positionStore, filteringTracker, actionExecutor, newEnvironment);
+			convertedCycle[0] = converter.convert(nodeConstructorFactory, cycleElements[nrOfCycleElements - 1], stack, depth, positionStore, filteringTracker, actionExecutor, newEnvironment);
 			for(int i = 0; i < nrOfCycleElements; ++i){
 				newEnvironment = actionExecutor.enteringListNode(production, i + 1, newEnvironment); // Fire a 'entering node' event when converting a child to enable environment handling.
-				T element = converter.convert(nodeConstructorFactory, cycleElements[i], stack, depth, cycleMark, positionStore, filteringTracker, actionExecutor, newEnvironment);
+				T element = converter.convert(nodeConstructorFactory, cycleElements[i], stack, depth, positionStore, filteringTracker, actionExecutor, newEnvironment);
 				if(element == null) {
 					actionExecutor.exitedListProduction(production, true, newEnvironment); // Filtered.
 					return null;
@@ -239,7 +238,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 	/**
 	 * Gather all the alternatives ending with the given child.
 	 */
-	protected void gatherAlternatives(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache, PositionStore positionStore, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment, boolean hasSideEffects){
+	protected void gatherAlternatives(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache, PositionStore positionStore, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment, boolean hasSideEffects){
 		ArrayList<T> gatheredAlts;
 
 		if (!hasSideEffects) {
@@ -262,18 +261,18 @@ public class ListContainerNodeFlattener<P, T, S>{
 				CycleNode cycle = gatherCycle(child, new AbstractNode[]{childNode}, blackList);
 				if(cycle != null){ // Encountered a cycle.
 					if(cycle.cycle.length == 1){
-						gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, cycle), gatheredAlts, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
+						gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, cycle), gatheredAlts, production, stack, depth, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
 					}else{
 						ForwardLink<AbstractNode> cycleLink = new ForwardLink<AbstractNode>(NO_NODES, cycle);
-						gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(cycleLink, childNode), gatheredAlts, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
+						gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(cycleLink, childNode), gatheredAlts, production, stack, depth, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
 					}
 					return;
 				}
 			}
 			// Encountered non-cyclic child.
-			gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, childNode), gatheredAlts, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
+			gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, childNode), gatheredAlts, production, stack, depth, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
 		}else{ // Has a single epsilon result.
-			buildAlternative(converter, nodeConstructorFactory, noChildren, NO_NODES, production, gatheredAlts, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+			buildAlternative(converter, nodeConstructorFactory, noChildren, NO_NODES, production, gatheredAlts, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
 		}
 
 		for (int i = 0; i < gatheredAlts.size(); i++) {
@@ -288,11 +287,11 @@ public class ListContainerNodeFlattener<P, T, S>{
 	/**
 	 * Gathers all alternatives for the given production related to the given child and postfix.
 	 */
-	private void gatherProduction(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ForwardLink<AbstractNode> postFix, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache, PositionStore positionStore, ArrayList<AbstractNode> blackList, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	private void gatherProduction(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ForwardLink<AbstractNode> postFix, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache, PositionStore positionStore, ArrayList<AbstractNode> blackList, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		do{
 			ArrayList<Link> prefixes = child.getPrefixes();
 			if(prefixes == null){ // Start of the production encountered.
-				buildAlternative(converter, nodeConstructorFactory, noChildren, postFix, production, gatheredAlternatives, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+				buildAlternative(converter, nodeConstructorFactory, noChildren, postFix, production, gatheredAlternatives, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
 				return;
 			}
 			
@@ -301,7 +300,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 				Link prefix = prefixes.get(0);
 				
 				if(prefix == null){ // Start of the production encountered.
-					buildAlternative(converter, nodeConstructorFactory, noChildren, postFix, production, gatheredAlternatives, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+					buildAlternative(converter, nodeConstructorFactory, noChildren, postFix, production, gatheredAlternatives, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
 					return;
 				}
 				
@@ -321,7 +320,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 			}
 			
 			// Multiple prefixes, so the list is ambiguous at this point.
-			gatherAmbiguousProduction(converter, nodeConstructorFactory, prefixes, postFix, gatheredAlternatives, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
+			gatherAmbiguousProduction(converter, nodeConstructorFactory, prefixes, postFix, gatheredAlternatives, production, stack, depth, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
 			
 			break;
 		}while(true);
@@ -330,19 +329,19 @@ public class ListContainerNodeFlattener<P, T, S>{
 	/**
 	 * Gathers all alternatives for the given ambiguous production related to the given child and postfix.
 	 */
-	private void gatherAmbiguousProduction(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, ArrayList<Link> prefixes, ForwardLink<AbstractNode> postFix, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache, PositionStore positionStore, ArrayList<AbstractNode> blackList, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	private void gatherAmbiguousProduction(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, ArrayList<Link> prefixes, ForwardLink<AbstractNode> postFix, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache, PositionStore positionStore, ArrayList<AbstractNode> blackList, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		// Check if we've been at this node before. If so reuse the cached prefix.
 		SharedPrefix<T> sharedPrefix = sharedPrefixCache.get(prefixes);
 		if(sharedPrefix != null){
 			T[] cachedPrefix = sharedPrefix.prefix;
 			if(cachedPrefix != null){
-				buildAlternative(converter, nodeConstructorFactory, cachedPrefix, postFix, production, gatheredAlternatives, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, sharedPrefix.environment);
+				buildAlternative(converter, nodeConstructorFactory, cachedPrefix, postFix, production, gatheredAlternatives, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, sharedPrefix.environment);
 			}
 			
 			// Check if there is a null prefix in this node's prefix list (this can happen if this node both start the list and has an empty prefix).
 			for(int i = prefixes.size() - 1; i >= 0; --i){
 				if(prefixes.get(i) == null){
-					buildAlternative(converter, nodeConstructorFactory, noChildren, postFix, production, gatheredAlternatives, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+					buildAlternative(converter, nodeConstructorFactory, noChildren, postFix, production, gatheredAlternatives, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
 				}
 			}
 			
@@ -356,7 +355,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 			Link prefix = prefixes.get(i);
 			
 			if(prefix == null){ // List start node encountered.
-				buildAlternative(converter, nodeConstructorFactory, noChildren, postFix, production, gatheredAlternatives, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+				buildAlternative(converter, nodeConstructorFactory, noChildren, postFix, production, gatheredAlternatives, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
 			}else{
 				AbstractNode prefixNode = prefix.getNode();
 				if(blackList.contains(prefixNode)) continue; // Prefix node is not allowed (due to being part of a cycle already gathered cycle).
@@ -364,12 +363,12 @@ public class ListContainerNodeFlattener<P, T, S>{
 				if(prefixNode.isEmpty() && !prefixNode.isNonterminalSeparator()){ // Possibly a cycle (separators can't start or end cycles, only elements can).
 					CycleNode cycle = gatherCycle(prefix, new AbstractNode[]{prefixNode}, blackList);
 					if(cycle != null){ // Encountered a cycle.
-						gatherProduction(converter, nodeConstructorFactory, prefix, new ForwardLink<AbstractNode>(NO_NODES, cycle), gatheredPrefixes, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
+						gatherProduction(converter, nodeConstructorFactory, prefix, new ForwardLink<AbstractNode>(NO_NODES, cycle), gatheredPrefixes, production, stack, depth, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
 						continue;
 					}
 				}
 				
-				gatherProduction(converter, nodeConstructorFactory, prefix, new ForwardLink<AbstractNode>(NO_NODES, prefixNode), gatheredPrefixes, production, stack, depth, cycleMark, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
+				gatherProduction(converter, nodeConstructorFactory, prefix, new ForwardLink<AbstractNode>(NO_NODES, prefixNode), gatheredPrefixes, production, stack, depth, sharedPrefixCache, positionStore, blackList, offset, endOffset, filteringTracker, actionExecutor, environment);
 			}
 		}
 		
@@ -386,7 +385,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 				prefixAlternativeChildren[i] = prefixAlternativeChildrenList.get(i);
 			}
 			
-			Object newEnvironment = buildAlternative(converter, nodeConstructorFactory, prefixAlternativeChildren, postFix, production, gatheredAlternatives, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+			Object newEnvironment = buildAlternative(converter, nodeConstructorFactory, prefixAlternativeChildren, postFix, production, gatheredAlternatives, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
 			
 			sharedPrefixCache.put(prefixes, new SharedPrefix<T>(newEnvironment != null ? prefixAlternativeChildren : null, newEnvironment));
 		}else if(nrOfGatheredPrefixes > 0){ // Ambiguous prefix.
@@ -419,7 +418,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 						filteredAlternativeChildren[i] = filteredAlternativeChildrenList.get(i);
 					}
 					
-					Object newEnvironment = buildAlternative(converter, nodeConstructorFactory, filteredAlternativeChildren, postFix, production, gatheredAlternatives, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+					Object newEnvironment = buildAlternative(converter, nodeConstructorFactory, filteredAlternativeChildren, postFix, production, gatheredAlternatives, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
 					
 					sharedPrefixCache.put(prefixes, new SharedPrefix<T>(newEnvironment != null ? filteredAlternativeChildren : null, newEnvironment));
 					return;
@@ -428,7 +427,7 @@ public class ListContainerNodeFlattener<P, T, S>{
 			
 			T[] prefixNodes = (T[]) new Object[]{prefixResult};
 			
-			Object newEnvironment = buildAlternative(converter, nodeConstructorFactory, prefixNodes, postFix, production, gatheredAlternatives, stack, depth, cycleMark, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
+			Object newEnvironment = buildAlternative(converter, nodeConstructorFactory, prefixNodes, postFix, production, gatheredAlternatives, stack, depth, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment);
 			
 			sharedPrefixCache.put(prefixes, new SharedPrefix<T>(newEnvironment != null ? prefixNodes : null, newEnvironment));
 		}
@@ -480,16 +479,12 @@ public class ListContainerNodeFlattener<P, T, S>{
 	/**
 	 * Converts the given expandable container result node to the UPTR format.
 	 */
-	public T convertToUPTR(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, ExpandableContainerNode<P> node, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	public T convertToUPTR(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, ExpandableContainerNode<P> node, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		int offset = node.getOffset();
 		int endOffset = node.getEndOffset();
 		
 		Object rhs = nodeConstructorFactory.getRhs(node.getFirstProduction());
 		boolean hasSideEffects = actionExecutor.isImpure(rhs);
-		
-		if (depth <= cycleMark.depth) {
-			cycleMark.reset();
-		}
 		
 		S sourceLocation = null;
 		URI input = node.getInput();
@@ -507,8 +502,6 @@ public class ListContainerNodeFlattener<P, T, S>{
 				filteringTracker.setLastFiltered(offset, endOffset);
 			}
 			
-			cycleMark.setMark(index);
-			
 			return cycle;
 		}
 		
@@ -519,12 +512,12 @@ public class ListContainerNodeFlattener<P, T, S>{
 		// Gather the alternatives.
 		HashMap<ArrayList<Link>, SharedPrefix<T>> sharedPrefixCache = new HashMap<ArrayList<Link>, SharedPrefix<T>>();
 		ArrayList<T> gatheredAlternatives = new ArrayList<T>();
-		gatherAlternatives(converter, nodeConstructorFactory, node.getFirstAlternative(), gatheredAlternatives, node.getFirstProduction(), stack, childDepth, cycleMark, sharedPrefixCache, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
+		gatherAlternatives(converter, nodeConstructorFactory, node.getFirstAlternative(), gatheredAlternatives, node.getFirstProduction(), stack, childDepth, sharedPrefixCache, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
 		ArrayList<Link> alternatives = node.getAdditionalAlternatives();
 		ArrayList<P> productions = node.getAdditionalProductions();
 		if(alternatives != null){
 			for(int i = alternatives.size() - 1; i >= 0; --i){
-				gatherAlternatives(converter, nodeConstructorFactory, alternatives.get(i), gatheredAlternatives, productions.get(i), stack, childDepth, cycleMark, sharedPrefixCache, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
+				gatherAlternatives(converter, nodeConstructorFactory, alternatives.get(i), gatheredAlternatives, productions.get(i), stack, childDepth, sharedPrefixCache, positionStore, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
 			}
 		}
 		

--- a/src/org/rascalmpl/parser/gtd/result/out/SortContainerNodeFlattener.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/SortContainerNodeFlattener.java
@@ -19,7 +19,6 @@ import org.rascalmpl.parser.gtd.location.PositionStore;
 import org.rascalmpl.parser.gtd.result.AbstractNode;
 import org.rascalmpl.parser.gtd.result.SortContainerNode;
 import org.rascalmpl.parser.gtd.result.action.IActionExecutor;
-import org.rascalmpl.parser.gtd.result.out.INodeFlattener.CycleMark;
 import org.rascalmpl.parser.gtd.result.struct.Link;
 import org.rascalmpl.parser.gtd.util.ArrayList;
 import org.rascalmpl.parser.gtd.util.ForwardLink;
@@ -35,7 +34,6 @@ public class SortContainerNodeFlattener<P, T, S>{
 	@SuppressWarnings("unchecked")
 	private final static ForwardLink<AbstractNode> NO_NODES = ForwardLink.TERMINATOR;
 
-	private final IntegerKeyedHashMap<ObjectIntegerKeyedHashMap<Object, T>> preCache;
 	private final IntegerKeyedHashMap<ObjectIntegerKeyedHashSet<T>> cache;
 
 	private final Map<Link, ArrayList<T>> linkCache;
@@ -43,16 +41,14 @@ public class SortContainerNodeFlattener<P, T, S>{
 	public SortContainerNodeFlattener(){
 		super();
 		
-		preCache = new IntegerKeyedHashMap<ObjectIntegerKeyedHashMap<Object, T>>();
-		cache = new IntegerKeyedHashMap<ObjectIntegerKeyedHashSet<T>>();
-
+		cache = new IntegerKeyedHashMap<>();
 		linkCache = new HashMap<>();
 	}
 	
 	/**
 	 * Gather all the alternatives ending with the given child.
 	 */
-	private void gatherAlternatives(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment, boolean hasSideEffects){
+	private void gatherAlternatives(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment, boolean hasSideEffects){
 		ArrayList<T> gatheredAlts = null;
 
 		if (!hasSideEffects) {
@@ -62,7 +58,7 @@ public class SortContainerNodeFlattener<P, T, S>{
 				found = false;
 				gatheredAlts = new ArrayList<>();
 				gatherAlternativesUncached(converter, nodeConstructorFactory, child, gatheredAlts, production, stack, 
-					depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker,
+					depth, positionStore, sourceLocation, offset, endOffset, filteringTracker,
 					actionExecutor, environment);
 			}
 			for (int i=0; i<gatheredAlts.size(); i++) {
@@ -73,35 +69,35 @@ public class SortContainerNodeFlattener<P, T, S>{
 			}
 		} else {
 			gatherAlternativesUncached(converter, nodeConstructorFactory, child, gatheredAlternatives, production, stack, 
-				depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker,
+				depth, positionStore, sourceLocation, offset, endOffset, filteringTracker,
 				actionExecutor, environment);
 		}
 	}
 
-	private void gatherAlternativesUncached(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	private void gatherAlternativesUncached(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		AbstractNode resultNode = child.getNode();
 		
 		if(!(resultNode.isEpsilon() && child.getPrefixes() == null)){ // Has non-epsilon results.
-			gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, resultNode), gatheredAlternatives, production, stack, depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
+			gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, resultNode), gatheredAlternatives, production, stack, depth, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
 		}else{ // Has a single epsilon result.
 			buildAlternative(converter, nodeConstructorFactory, NO_NODES, 
-				gatheredAlternatives, production, stack, depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
+				gatheredAlternatives, production, stack, depth, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
 		}
 	}
 	
 	/**
 	 * Gathers all alternatives for the given production related to the given child and postfix.
 	 */
-	private void gatherProduction(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ForwardLink<AbstractNode> postFix, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	private void gatherProduction(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ForwardLink<AbstractNode> postFix, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		ArrayList<Link> prefixes = child.getPrefixes();
 		if(prefixes == null){ // Reached the start of the production.
-			buildAlternative(converter, nodeConstructorFactory, postFix, gatheredAlternatives, production, stack, depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
+			buildAlternative(converter, nodeConstructorFactory, postFix, gatheredAlternatives, production, stack, depth, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
 			return;
 		}
 		
 		for(int i = prefixes.size() - 1; i >= 0; --i){ // Traverse all the prefixes (can be more then one in case of ambiguity).
 			Link prefix = prefixes.get(i);
-			gatherProduction(converter, nodeConstructorFactory, prefix, new ForwardLink<AbstractNode>(postFix, prefix.getNode()), gatheredAlternatives, production, stack, depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
+			gatherProduction(converter, nodeConstructorFactory, prefix, new ForwardLink<AbstractNode>(postFix, prefix.getNode()), gatheredAlternatives, production, stack, depth, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
 		}
 	}
 	
@@ -109,7 +105,7 @@ public class SortContainerNodeFlattener<P, T, S>{
 	 * Construct the UPTR representation for the given production.
 	 * Additionally, it handles all semantic actions related 'events' associated with it.
 	 */
-	private void buildAlternative(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, ForwardLink<AbstractNode> postFix, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	private void buildAlternative(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, ForwardLink<AbstractNode> postFix, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		Object newEnvironment = actionExecutor.enteringProduction(production, environment); // Fire a 'entering production' event to enable environment handling.
 		
 		int postFixLength = postFix.length;
@@ -120,7 +116,7 @@ public class SortContainerNodeFlattener<P, T, S>{
 			
 			newEnvironment = actionExecutor.enteringNode(production, i, newEnvironment); // Fire a 'entering node' event when converting a child to enable environment handling.
 			
-			T constructedNode = converter.convert(nodeConstructorFactory, node, stack, depth, cycleMark, positionStore, filteringTracker, actionExecutor, environment);
+			T constructedNode = converter.convert(nodeConstructorFactory, node, stack, depth, positionStore, filteringTracker, actionExecutor, environment);
 			if(constructedNode == null){
 				actionExecutor.exitedProduction(production, true, newEnvironment); // Filtered.
 				return;
@@ -148,17 +144,13 @@ public class SortContainerNodeFlattener<P, T, S>{
 	/**
 	 * Converts the given sort container result node to the UPTR format.
 	 */
-	public T convertToUPTR(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, SortContainerNode<P> node, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	public T convertToUPTR(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, SortContainerNode<P> node, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		int offset = node.getOffset();
 		int endOffset = node.getEndOffset();
 
 		Object firstProduction = node.getFirstProduction();
 		Object rhs = nodeConstructorFactory.getRhs(node.getFirstProduction());
 		boolean hasSideEffects = actionExecutor.isImpure(rhs);
-
-		if (depth <= cycleMark.depth) {
-			cycleMark.reset();
-		}
 
 		S sourceLocation = null;
 		URI input = node.getInput();
@@ -175,7 +167,6 @@ public class SortContainerNodeFlattener<P, T, S>{
 			}else{
 				filteringTracker.setLastFiltered(offset, endOffset);
 			}
-			cycleMark.setMark(index);
 			
 			return cycle;
 		}
@@ -187,12 +178,12 @@ public class SortContainerNodeFlattener<P, T, S>{
 		// Gather the alternatives.
 		ArrayList<T> gatheredAlternatives = new ArrayList<T>();
 
-		gatherAlternatives(converter, nodeConstructorFactory, node.getFirstAlternative(), gatheredAlternatives, firstProduction, stack, childDepth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
+		gatherAlternatives(converter, nodeConstructorFactory, node.getFirstAlternative(), gatheredAlternatives, firstProduction, stack, childDepth, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
 		ArrayList<Link> alternatives = node.getAdditionalAlternatives();
 		ArrayList<P> productions = node.getAdditionalProductions();
 		if(alternatives != null){
 			for(int i = alternatives.size() - 1; i >= 0; --i){
-				gatherAlternatives(converter, nodeConstructorFactory, alternatives.get(i), gatheredAlternatives, productions.get(i), stack, childDepth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
+				gatherAlternatives(converter, nodeConstructorFactory, alternatives.get(i), gatheredAlternatives, productions.get(i), stack, childDepth, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
 			}
 		}
 		

--- a/src/org/rascalmpl/parser/gtd/result/out/SortContainerNodeFlattener.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/SortContainerNodeFlattener.java
@@ -24,7 +24,6 @@ import org.rascalmpl.parser.gtd.util.ArrayList;
 import org.rascalmpl.parser.gtd.util.ForwardLink;
 import org.rascalmpl.parser.gtd.util.IndexedStack;
 import org.rascalmpl.parser.gtd.util.IntegerKeyedHashMap;
-import org.rascalmpl.parser.gtd.util.ObjectIntegerKeyedHashMap;
 import org.rascalmpl.parser.gtd.util.ObjectIntegerKeyedHashSet;
 
 /**

--- a/src/org/rascalmpl/parser/gtd/result/out/SortContainerNodeFlattener.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/SortContainerNodeFlattener.java
@@ -12,6 +12,8 @@
 package org.rascalmpl.parser.gtd.result.out;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.rascalmpl.parser.gtd.location.PositionStore;
 import org.rascalmpl.parser.gtd.result.AbstractNode;
@@ -32,27 +34,58 @@ import org.rascalmpl.parser.gtd.util.ObjectIntegerKeyedHashSet;
 public class SortContainerNodeFlattener<P, T, S>{
 	@SuppressWarnings("unchecked")
 	private final static ForwardLink<AbstractNode> NO_NODES = ForwardLink.TERMINATOR;
-	
+
 	private final IntegerKeyedHashMap<ObjectIntegerKeyedHashMap<Object, T>> preCache;
 	private final IntegerKeyedHashMap<ObjectIntegerKeyedHashSet<T>> cache;
-	
+
+	private final Map<Link, ArrayList<T>> linkCache;
+
 	public SortContainerNodeFlattener(){
 		super();
 		
 		preCache = new IntegerKeyedHashMap<ObjectIntegerKeyedHashMap<Object, T>>();
 		cache = new IntegerKeyedHashMap<ObjectIntegerKeyedHashSet<T>>();
+
+		linkCache = new HashMap<>();
 	}
 	
 	/**
 	 * Gather all the alternatives ending with the given child.
 	 */
-	private void gatherAlternatives(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
+	private void gatherAlternatives(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment, boolean hasSideEffects){
+		ArrayList<T> gatheredAlts = null;
+
+		if (!hasSideEffects) {
+			gatheredAlts = linkCache.get(child);
+			boolean found = true;
+			if (gatheredAlts == null) {
+				found = false;
+				gatheredAlts = new ArrayList<>();
+				gatherAlternativesUncached(converter, nodeConstructorFactory, child, gatheredAlts, production, stack, 
+					depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker,
+					actionExecutor, environment);
+			}
+			for (int i=0; i<gatheredAlts.size(); i++) {
+				gatheredAlternatives.add(gatheredAlts.get(i));
+			}
+			if (!found) {
+				linkCache.put(child, gatheredAlts);
+			}
+		} else {
+			gatherAlternativesUncached(converter, nodeConstructorFactory, child, gatheredAlternatives, production, stack, 
+				depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker,
+				actionExecutor, environment);
+		}
+	}
+
+	private void gatherAlternativesUncached(INodeFlattener<T, S> converter, INodeConstructorFactory<T, S> nodeConstructorFactory, Link child, ArrayList<T> gatheredAlternatives, Object production, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, S sourceLocation, int offset, int endOffset, FilteringTracker filteringTracker, IActionExecutor<T> actionExecutor, Object environment){
 		AbstractNode resultNode = child.getNode();
 		
 		if(!(resultNode.isEpsilon() && child.getPrefixes() == null)){ // Has non-epsilon results.
 			gatherProduction(converter, nodeConstructorFactory, child, new ForwardLink<AbstractNode>(NO_NODES, resultNode), gatheredAlternatives, production, stack, depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
 		}else{ // Has a single epsilon result.
-			buildAlternative(converter, nodeConstructorFactory, NO_NODES, gatheredAlternatives, production, stack, depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
+			buildAlternative(converter, nodeConstructorFactory, NO_NODES, 
+				gatheredAlternatives, production, stack, depth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
 		}
 	}
 	
@@ -122,21 +155,11 @@ public class SortContainerNodeFlattener<P, T, S>{
 		Object firstProduction = node.getFirstProduction();
 		Object rhs = nodeConstructorFactory.getRhs(node.getFirstProduction());
 		boolean hasSideEffects = actionExecutor.isImpure(rhs);
-		
-		if(depth <= cycleMark.depth){ // Only check for sharing if we are not currently inside a cycle.
-			if(!hasSideEffects){ // If this sort node and its direct and indirect children do not rely on side-effects from semantic actions, check the cache for existing results.
-				ObjectIntegerKeyedHashMap<Object, T> levelCache = preCache.get(offset);
-				if(levelCache != null){
-					T cachedResult = levelCache.get(rhs, endOffset);
-					if(cachedResult != null){
-						return cachedResult;
-					}
-				}
-			}
-			
+
+		if (depth <= cycleMark.depth) {
 			cycleMark.reset();
 		}
-		
+
 		S sourceLocation = null;
 		URI input = node.getInput();
 		if(!(node.isLayout() || input == null)){ // Construct a source location annotation if this sort container does not represent a layout non-terminal and if it's available.
@@ -163,12 +186,13 @@ public class SortContainerNodeFlattener<P, T, S>{
 		
 		// Gather the alternatives.
 		ArrayList<T> gatheredAlternatives = new ArrayList<T>();
-		gatherAlternatives(converter, nodeConstructorFactory, node.getFirstAlternative(), gatheredAlternatives, firstProduction, stack, childDepth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
+
+		gatherAlternatives(converter, nodeConstructorFactory, node.getFirstAlternative(), gatheredAlternatives, firstProduction, stack, childDepth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
 		ArrayList<Link> alternatives = node.getAdditionalAlternatives();
 		ArrayList<P> productions = node.getAdditionalProductions();
 		if(alternatives != null){
 			for(int i = alternatives.size() - 1; i >= 0; --i){
-				gatherAlternatives(converter, nodeConstructorFactory, alternatives.get(i), gatheredAlternatives, productions.get(i), stack, childDepth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment);
+				gatherAlternatives(converter, nodeConstructorFactory, alternatives.get(i), gatheredAlternatives, productions.get(i), stack, childDepth, cycleMark, positionStore, sourceLocation, offset, endOffset, filteringTracker, actionExecutor, environment, hasSideEffects);
 			}
 		}
 		
@@ -193,40 +217,25 @@ public class SortContainerNodeFlattener<P, T, S>{
 		
 		stack.dirtyPurge(); // Pop this node off the stack.
 		
-		if(result != null && depth < cycleMark.depth){ // Only share the constructed tree if we are not in a cycle.
-			if(!hasSideEffects){ // Cache side-effect free tree.
-				ObjectIntegerKeyedHashMap<Object, T> levelCache = preCache.get(offset);
-				if(levelCache != null){
-					T cachedResult = levelCache.get(rhs, endOffset);
-					if(cachedResult != null){
-						return cachedResult;
-					}
-					
-					levelCache.putUnsafe(rhs, endOffset, result);
-					return result;
+		if (hasSideEffects) {
+			// Cache tree with side-effects to keep as much sharing as possible in the resulting parse forest
+			ObjectIntegerKeyedHashSet<T> levelCache = cache.get(offset);
+			if(levelCache != null){
+				T cachedResult = levelCache.getEquivalent(result, endOffset);
+				if(cachedResult != null){
+					return cachedResult;
 				}
 				
-				levelCache = new ObjectIntegerKeyedHashMap<Object, T>();
-				levelCache.putUnsafe(rhs, endOffset, result);
-				preCache.put(offset, levelCache);
-			}else{ // Cache tree with side-effects.
-				ObjectIntegerKeyedHashSet<T> levelCache = cache.get(offset);
-				if(levelCache != null){
-					T cachedResult = levelCache.getEquivalent(result, endOffset);
-					if(cachedResult != null){
-						return cachedResult;
-					}
-					
-					levelCache.putUnsafe(result, endOffset);
-					return result;
-				}
-				
-				levelCache = new ObjectIntegerKeyedHashSet<T>();
 				levelCache.putUnsafe(result, endOffset);
-				cache.putUnsafe(offset, levelCache);
+				return result;
 			}
+			
+			levelCache = new ObjectIntegerKeyedHashSet<T>();
+			levelCache.putUnsafe(result, endOffset);
+			cache.putUnsafe(offset, levelCache);
 		}
 		
 		return result;
 	}
+
 }

--- a/src/org/rascalmpl/parser/gtd/result/out/VoidNodeFlattener.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/VoidNodeFlattener.java
@@ -33,7 +33,7 @@ public class VoidNodeFlattener implements INodeFlattener<AbstractNode, Object>{
 		return parseTree;
 	}
 	
-	public AbstractNode convert(INodeConstructorFactory<AbstractNode, Object> nodeConstructorFactory, AbstractNode parseTree, IndexedStack<AbstractNode> stack, int depth, CycleMark cycleMark, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<AbstractNode> actionExecutor, Object rootEnvironment){
+	public AbstractNode convert(INodeConstructorFactory<AbstractNode, Object> nodeConstructorFactory, AbstractNode parseTree, IndexedStack<AbstractNode> stack, int depth, PositionStore positionStore, FilteringTracker filteringTracker, IActionExecutor<AbstractNode> actionExecutor, Object rootEnvironment){
 		return parseTree;
 	}
 	


### PR DESCRIPTION
During conversion of the parse graph to a parse forest, `AbstractNode` was used as a memoization key. This turned out to be incorrect even with the "no memoization within cycles" hack.

The `memoCycleBug` test in this PR tests for this problem.

The solution turned out to be to use the `Link` objects as memoization key instead. This ensures correct conversion from parse graph to parse forest and as a bonus improved performance when a lot of cycles are present as memoization can occur normally within cycles.

Note that this means all of the `CycleMark` related code has also been removed as it was only used to disable memoization within cycles.
