### PR TITLE
Fixed logic around fallback resolver in URIResolverRegistry

### DIFF
--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -404,7 +404,8 @@ public class URIResolverRegistry {
 		}
 		var fallBack = fallbackLogicalResolver;
 		if (fallBack != null) {
-			return resolveAndFixOffsets(loc == null ? original : loc, fallBack, Collections.emptyList());
+			var fallbackResult = resolveAndFixOffsets(loc == null ? original : loc, fallBack, Collections.emptyList());
+			return fallbackResult == null ? loc : fallbackResult;
 		}
 		return loc;
 	}

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -406,7 +406,7 @@ public class URIResolverRegistry {
 			loc = original;
 		}
 		if (fallbackLogicalResolver != null) {
-			var fallbackResult = resolveAndFixOffsets(loc == null ? original : loc, fallbackLogicalResolver, Collections.emptyList());
+			var fallbackResult = resolveAndFixOffsets(loc, fallbackLogicalResolver, Collections.emptyList());
 			return fallbackResult == null ? loc : fallbackResult;
 		}
 		return loc;

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -402,11 +402,9 @@ public class URIResolverRegistry {
 			ILogicalSourceLocationResolver resolver = map.get(auth);
 			loc = resolveAndFixOffsets(loc, resolver, map.values());
 		}
-		if (loc == null) {
-			loc = original;
-		}
+		
 		if (fallbackLogicalResolver != null) {
-			var fallbackResult = resolveAndFixOffsets(loc, fallbackLogicalResolver, Collections.emptyList());
+			var fallbackResult = resolveAndFixOffsets(loc == null ? original : loc, fallbackLogicalResolver, Collections.emptyList());
 			return fallbackResult == null ? loc : fallbackResult;
 		}
 		return loc;

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -402,9 +402,11 @@ public class URIResolverRegistry {
 			ILogicalSourceLocationResolver resolver = map.get(auth);
 			loc = resolveAndFixOffsets(loc, resolver, map.values());
 		}
-		var fallBack = fallbackLogicalResolver;
-		if (fallBack != null) {
-			var fallbackResult = resolveAndFixOffsets(loc == null ? original : loc, fallBack, Collections.emptyList());
+		if (loc == null) {
+			loc = original;
+		}
+		if (fallbackLogicalResolver != null) {
+			var fallbackResult = resolveAndFixOffsets(loc == null ? original : loc, fallbackLogicalResolver, Collections.emptyList());
 			return fallbackResult == null ? loc : fallbackResult;
 		}
 		return loc;


### PR DESCRIPTION
Fixed a (latent) bug where the result of logical source location resolution would be de facto discarded by the fallback resolver returning `null`. This popped up during evolution of the `FallbackResolver` class in the `rascal-lsp` project.