### PR TITLE
Replaced `==` with `equals` on two String objects

### DIFF
--- a/src/org/rascalmpl/values/parsetrees/TreeAdapter.java
+++ b/src/org/rascalmpl/values/parsetrees/TreeAdapter.java
@@ -941,9 +941,9 @@ public class TreeAdapter {
 		IListWriter writer = ValueFactoryFactory.getValueFactory().listWriter();
 		if (isAppl(tree)) {
 			String s = ProductionAdapter.getCategory(getProduction(tree));
-			if (s == category)
+			if (s.equals(category)) {
 				writer.append(tree);
-			else {
+			} else {
 				IList z = getArgs(tree);
 				for (IValue q : z) {
 					if (!(q instanceof IConstructor))


### PR DESCRIPTION
Two String objects where compared using `==`, this is hardly ever correct and can be unexpected by the callers of the `searchCategory` method.