### PR TITLE
Always load Rascal modules and Java classes of `std` from the current `rascal`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,22 @@
                 </excludes>
             </resource>
             <resource>
+                <targetPath>test/org/rascalmpl/benchmark</targetPath>
+                <directory>test/org/rascalmpl/benchmark</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                    <exclude>**/*.class</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <targetPath>test/org/rascalmpl/test/data</targetPath>
+                <directory>test/org/rascalmpl/test/data</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                    <exclude>**/*.class</exclude>
+                </excludes>
+            </resource>
+            <resource>
                 <directory>.</directory>
                 <filtering>false</filtering>
                 <includes>

--- a/src/org/rascalmpl/interpreter/utils/RascalManifest.java
+++ b/src/org/rascalmpl/interpreter/utils/RascalManifest.java
@@ -68,13 +68,16 @@ public class RascalManifest {
      * This looks into the META-INF/MANIFEST.MF file for a Name and Specification-Version
      */
     public String getManifestVersionNumber(ISourceLocation project) throws IOException {
-        Manifest mf = new Manifest(javaManifest(project));
+        InputStream is = javaManifest(project);
+        if (is != null) {
+            Manifest mf = new Manifest(is);
 
-        String bundleName = mf.getMainAttributes().getValue("Name");
-        if (bundleName != null && bundleName.equals("rascal")) {
-            String result = mf.getMainAttributes().getValue("Specification-Version");
-            if (result != null) {
-                return result;
+            String bundleName = mf.getMainAttributes().getValue("Name");
+            if (bundleName != null && bundleName.equals("rascal")) {
+                String result = mf.getMainAttributes().getValue("Specification-Version");
+                if (result != null) {
+                    return result;
+                }
             }
         }
 

--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -810,7 +810,19 @@ public class PathConfig {
      */
     public void printInterpreterConfigurationStatus(PrintWriter out) {
         out.println("Module paths:");
-        getSrcs().forEach((f) -> out.println(" ".repeat(4) + f));
+        getSrcs().forEach((f) -> {
+            var s = f.toString();
+            if (((ISourceLocation) f).getScheme().equals("std")) {
+                s += " at ";
+                try {
+                    s += resolveCurrentRascalRuntimeJar();
+                }
+                catch (IOException e) {
+                    s += "unknown physical location";
+                }
+            }
+            out.println(" ".repeat(4) + s);
+        });
         out.println("JVM library classpath:");
         getLibsAndTarget().forEach((l) -> out.println(" ".repeat(4) + l));
         out.flush();

--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -474,15 +474,18 @@ public class PathConfig {
         IListWriter srcsWriter = vf.listWriter();
         IListWriter messages = vf.listWriter();
 
-        // Always add the standard library, also for the project named "rascal".
-        // If the "current" version (as per `resolveCurrentRascalRuntimeJar`) is
-        // different from the version of `manifestRoot`, then:
-        //   - Rascal modules inside `std` are loaded from the current version.
-        //   - Rascal modules outside `std` are loaded from `manifestRoot`.
-        //   - Java classes (regardless of inside/outside `std`) are loaded from
-        //     the current version. Thus, Rascal modules and Java classes inside
-        //     `std` -- but not outside! -- are consistently loaded.
+        // Approach:
+        //   - Rascal modules of `rascal` inside `std` are loaded from the
+        //     "current `rascal`" (as per `resolveCurrentRascalRuntimeJar`).
+        //   - Rascal modules of `rascal` outside `std` are loaded from the
+        //     "current project" of this path config (as per `manifestRoot`).
+        //   - Java classes of `rascal`, regardless of inside/outside `std`, are
+        //     loaded from the current `rascal`.
+        //
+        // Thus, Rascal modules and Java classes of `rascal` inside `std` are
+        // guaranteed to be consistently loaded from the same version.
         try {
+            srcsWriter.append(URIUtil.rootLocation("std"));
             libsWriter.append(resolveCurrentRascalRuntimeJar());
         }
         catch (IOException e) {


### PR DESCRIPTION
### Overview

This PR implements the following approach for loading Rascal modules and Java classes of `rascal`:
  - Rascal modules of `rascal` **inside** `std` are loaded from the "current `rascal`" (as per `resolveCurrentRascalRuntimeJar`).
  - Rascal modules of `rascal` **outside** `std` are loaded from the "current project" of the path config.
  - Java classes of `rascal`, regardless of inside/outside `std`, are loaded from the "current `rascal`" (as per `resolveCurrentRascalRuntimeJar`).

Thus, after this PR:
  - ✔️ Rascal modules and Java classes of `rascal` inside `std` must be loaded from the same version. This partly fixes usethesource/rascal-language-servers#538.

  - ⚠️ Rascal modules and Java classes of `rascal` outside `std` may be loaded from different versions. However, currently, there are no Rascal modules of `rascal` outside `std` that rely on Java classes. Moreover, after the merge of `typepal` and `rascal-core` into `rascal`: (1) there are no Rascal modules of `typepal` that rely on Java classes; (2) there are a few Rascal modules of `rascal-core` that rely on Java classes, but the impact seems negligible in the context of this PR.
    
  - ⚠️ REPLs created in VS Code always load the version of `std` of the deployed `rascal.jar` (part of the VS Code extension), which is put on the class path of the REPL's JVM. Even when `rascal` itself is open in the workspace, changes made to `std` will *not* be loaded in the REPL. To test such changes, a standalone Rascal shell needs to be created (but it doesn't have debugging support).

See the comments below for a few more details.

### Examples (VS Code)

#### Create REPL in `rascal`

```
Rascal 0.40.8-EXTENSION
Rascal-lsp Unknown
Module paths:
    |std:///|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal/test/org/rascalmpl/benchmark|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal/test/org/rascalmpl/test/data|
    |jar+file:///C:/Users/sung-/.vscode/extensions/usethesource.rascalmpl-0.12.0-head/assets/jars/rascal-lsp.jar!/|
JVM library classpath:
    |file:///C:/Users/sung-/.vscode/extensions/usethesource.rascalmpl-0.12.0-head/assets/jars/rascal.jar|
    |mvn://org.rascalmpl--rascal-p2-dependencies-repackaged--0.6.0|
    |mvn://junit--junit--4.13.2|
    ...
    |mvn://com.ibm.icu--icu4j--74.2|
    |file:///C:/Users/sung-/.vscode/extensions/usethesource.rascalmpl-0.12.0-head/assets/jars/rascal-lsp.jar|
    |project://rascal/target/classes|
```

![image](https://github.com/user-attachments/assets/f310fb41-7456-42be-a284-e0fb5ff70977)

#### Create REPL in `typepal` (*with* `rascal` open in the workspace)

```
Rascal 0.40.8-EXTENSION
Rascal-lsp Unknown
Module paths:
    |std:///|
    |project://rascal/test/org/rascalmpl/benchmark|
    |project://rascal/test/org/rascalmpl/test/data|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/typepal/src|
    |jar+file:///C:/Users/sung-/.vscode/extensions/usethesource.rascalmpl-0.12.0-head/assets/jars/rascal-lsp.jar!/|
JVM library classpath:
    |file:///C:/Users/sung-/.vscode/extensions/usethesource.rascalmpl-0.12.0-head/assets/jars/rascal.jar|
    |mvn://junit--junit--4.13.1|
    ...
    |mvn://com.ibm.icu--icu4j--74.2|
    |file:///C:/Users/sung-/.vscode/extensions/usethesource.rascalmpl-0.12.0-head/assets/jars/rascal-lsp.jar|
    |project://typepal/target/classes|
```

![image](https://github.com/user-attachments/assets/74990572-16a8-4734-b879-658ad8db1054)

#### Create REPL in `typepal` (*without* `rascal` open in the workspace)

```
Rascal 0.40.8-EXTENSION
Rascal-lsp Unknown
Module paths:
    |std:///|
    |mvn://org.rascalmpl--rascal--0.40.8-REPOSITORY/test/org/rascalmpl/benchmark|
    |mvn://org.rascalmpl--rascal--0.40.8-REPOSITORY/test/org/rascalmpl/test/data|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/typepal/src|
    |jar+file:///C:/Users/sung-/.vscode/extensions/usethesource.rascalmpl-0.12.0-head/assets/jars/rascal-lsp.jar!/|
JVM library classpath:
    |file:///C:/Users/sung-/.vscode/extensions/usethesource.rascalmpl-0.12.0-head/assets/jars/rascal.jar|
    |mvn://junit--junit--4.13.1|
    |mvn://org.hamcrest--hamcrest-core--1.3|
    |file:///C:/Users/sung-/.vscode/extensions/usethesource.rascalmpl-0.12.0-head/assets/jars/rascal-lsp.jar|
    |project://typepal/target/classes|
```

![image](https://github.com/user-attachments/assets/918c7854-0f2f-41e8-86a9-e4dede037362)

### Example (`RascalShell`)

#### Create REPL in `rascal` (using a `RascalShell` in *the same* `rascal`)

```
Version: Not specified
Module paths:
    |std:///|
    |file:///C:/Users/sung-/Desktop/rascal3/rascal/test/org/rascalmpl/benchmark|
    |file:///C:/Users/sung-/Desktop/rascal3/rascal/test/org/rascalmpl/test/data|
JVM library classpath:
    |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes|
    |mvn://org.rascalmpl--rascal-p2-dependencies-repackaged--0.6.0|
    |mvn://junit--junit--4.13.2|
    ...
    |mvn://com.ibm.icu--icu4j--74.2|
    |project://rascal/target/classes|
[INFO]    /C:/Users/sung-/Desktop/rascal3/rascal/pom.xml:0:0: Using Rascal standard library at |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes|. Version: Not specified.
```

#### Create REPL in `rascal` (using a `RascalShell` in *a different* `rascal`)

```
Version: Not specified
Module paths:
    |std:///|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal/test/org/rascalmpl/benchmark|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal/test/org/rascalmpl/test/data|
JVM library classpath:
    |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes|
    |mvn://org.rascalmpl--rascal-p2-dependencies-repackaged--0.6.0|
    |mvn://junit--junit--4.13.2|
    ...
    |mvn://com.ibm.icu--icu4j--74.2|
    |project://rascal/target/classes|
[INFO]    /C:/Users/sung-/Desktop/rascal-which-version/projects/rascal/pom.xml:0:0: Using Rascal standard library at |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes|. Version: Not specified.
[INFO]    /C:/Users/sung-/Desktop/rascal-which-version/projects/rascal/pom.xml:0:0: Ignoring Rascal standard library at |project://rascal/target/classes| (self-application)
```

#### Create REPL in `typepal`

```
Version: Not specified
Module paths:
    |std:///|
    |mvn://org.rascalmpl--rascal--0.40.8-REPOSITORY/test/org/rascalmpl/benchmark|
    |mvn://org.rascalmpl--rascal--0.40.8-REPOSITORY/test/org/rascalmpl/test/data|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/typepal/src|
JVM library classpath:
    |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes|
    |mvn://junit--junit--4.13.1|
    |mvn://org.hamcrest--hamcrest-core--1.3|
    |project://typepal/target/classes|
[INFO]    /C:/Users/sung-/Desktop/rascal-which-version/projects/typepal/pom.xml:0:0: Using Rascal standard library at |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes|. Version: Not specified.
[INFO]    /C:/Users/sung-/Desktop/rascal-which-version/projects/typepal/pom.xml:0:0: Ignoring Rascal standard library at |mvn://org.rascalmpl--rascal--0.40.8-REPOSITORY| (dependency in POM)
```