### PR TITLE
Added profile to pom for creation of unshaded Rascal jar

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
             tests (buildjet-4vcpu-ubuntu-2204-arm)
           ttl: 15
 
-      - name: Deploy
+      - name: Deploy shaded jar
         if: startsWith(github.ref, 'refs/tags/v')
         uses: usethesource/releases-maven-action@v1
         with:
@@ -104,6 +104,19 @@ jobs:
           ssh-known-host: ${{ secrets.RELEASE_SSH_KNOWN_HOSTS }}
           ssh-username: ${{ secrets.RELEASE_SSH_USERNAME }}
           ssh-private-key: ${{ secrets.RELEASE_SSH_PRIVATE_KEY }}
+
+      - name: Deploy unshaded jar
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: usethesource/releases-maven-action@v1
+        with:
+          maven-username: ${{ secrets.RELEASE_MAVEN_USERNAME }}
+          maven-password: ${{ secrets.RELEASE_MAVEN_PASSWORD }}
+          maven-local-port: ${{ secrets.RELEASE_MAVEN_LOCAL_PORT }}
+          ssh-hostname: ${{ secrets.RELEASE_SSH_SERVER }}
+          ssh-known-host: ${{ secrets.RELEASE_SSH_KNOWN_HOSTS }}
+          ssh-username: ${{ secrets.RELEASE_SSH_USERNAME }}
+          ssh-private-key: ${{ secrets.RELEASE_SSH_PRIVATE_KEY }}
+          maven-options: -Punshaded
 
       - name: Prepare Draft Release
         uses: softprops/action-gh-release@v2

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lucence-version>7.5.0</lucence-version>
-        <maven-version>3.9.8</maven-version>
+        <maven-version>3.9.9</maven-version>
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>2</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.5.2</version>
                 <executions>
                     <execution>
                         <id>test</id>
@@ -261,7 +261,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.7.1</version>
+                <version>3.8.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -277,7 +277,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <arguments>-Drascal.compile.skip -Drascal.tutor.skip -DskipTests</arguments>
@@ -286,7 +286,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.0</version>
                 <executions>
                     <execution>
                         <id>download-licenses</id>
@@ -454,22 +454,22 @@
         <dependency> <!-- used by the compression uri feature-->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.1</version>
+            <version>1.27.1</version>
         </dependency>
         <dependency> <!-- needed by commons-compress for compressed+...://...zst -->
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.5.5-11</version>
+            <version>1.5.6-8</version>
         </dependency>
         <dependency> <!-- used for base32 encoding in IO and String, needed anyway for commons-compress -->
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.17.0</version>
+            <version>1.17.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>jline</groupId>
@@ -479,7 +479,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>2.2</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
@@ -519,7 +519,7 @@
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
-            <version>74.2</version>
+            <version>76.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -529,7 +529,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>3.7.1</version>
+            <version>3.8.1</version>
         </dependency>
         <dependency> <!-- needed for maven-embedder-->
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -572,12 +572,6 @@
                                                 <Specification-Vendor>http://www.usethesource.io</Specification-Vendor>
                                             </manifestEntries>
                                         </transformer>
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                            <resource>org/rascalmpl/uri/resolvers.config</resource>
-                                        </transformer>
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                            <resource>io/usethesource/vallang/type/types.config</resource>
-                                        </transformer>
                                     </transformers>
                                     <relocations>
                                         <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -547,4 +547,82 @@
             <version>${maven-version}</version>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>unshaded</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                            <manifestEntries>
+                                                <Name>rascal</Name>
+                                                <Main-Class>org.rascalmpl.shell.RascalShell</Main-Class>
+                                                <Specification-Version>${project.version}</Specification-Version>
+                                                <Specification-Vendor>http://www.usethesource.io</Specification-Vendor>
+                                            </manifestEntries>
+                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                            <resource>org/rascalmpl/uri/resolvers.config</resource>
+                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                            <resource>io/usethesource/vallang/type/types.config</resource>
+                                        </transformer>
+                                    </transformers>
+                                    <relocations>
+                                        <relocation>
+                                            <pattern>org.fusesource.jansi</pattern>
+                                            <shadedPattern>org.rascalmpl.fusesource.jansi</shadedPattern>
+                                            <excludes>
+                                                <exclude>org.fusesource.jansi.internal.*</exclude>
+                                            </excludes>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>jline</pattern>
+                                            <shadedPattern>org.rascalmpl.jline</shadedPattern>
+                                        </relocation>
+                                    </relocations>
+                                    <filters>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/*.SF</exclude>
+                                                <exclude>META-INF/*.DSA</exclude>
+                                                <exclude>META-INF/*.RSA</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
+                                    <artifactSet>
+                                        <includes>
+                                            <include>jline:*</include>
+                                        </includes>
+                                    </artifactSet>
+                                    <shadedClassifierName>unshaded</shadedClassifierName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <configuration>
+                            <skipDownloadLicenses>true</skipDownloadLicenses>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -602,6 +602,7 @@
                                         </includes>
                                     </artifactSet>
                                     <shadedClassifierName>unshaded</shadedClassifierName>
+				    <shadedArtifactAttached>true</shadedArtifactAttached>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Since the recent addition of several maven dependencies, `rascal-maven-plugin` no longer works due to multiple dependency injection errors. This PR adds a maven profile for `rascal` that produces an unshaded jar/pom, which removes unintended dependency injection.