### PR TITLE
Always load Rascal modules and Java classes of `std` from the current `rascal` (v2)

### DIFF
--- a/META-INF/RASCAL.MF
+++ b/META-INF/RASCAL.MF
@@ -1,5 +1,5 @@
 Project-Name: rascal
-Source: src/org/rascalmpl/library,src/org/rascalmpl/typepal,test/org/rascalmpl/benchmark,test//org/rascalmpl/test/data
+Source: src/org/rascalmpl/library,src/org/rascalmpl/compiler,src/org/rascalmpl/typepal,test/org/rascalmpl/benchmark,test//org/rascalmpl/test/data
 Courses: src/org/rascalmpl/courses
 
 

--- a/META-INF/RASCAL.MF
+++ b/META-INF/RASCAL.MF
@@ -1,5 +1,5 @@
 Project-Name: rascal
-Source: src/org/rascalmpl/library,test/org/rascalmpl/benchmark,test//org/rascalmpl/test/data
+Source: src/org/rascalmpl/library,src/org/rascalmpl/typepal,test/org/rascalmpl/benchmark,test//org/rascalmpl/test/data
 Courses: src/org/rascalmpl/courses
 
 

--- a/META-INF/RASCAL.MF
+++ b/META-INF/RASCAL.MF
@@ -1,5 +1,5 @@
 Project-Name: rascal
-Source: src/org/rascalmpl/library,src/org/rascalmpl/compiler,src/org/rascalmpl/typepal,test/org/rascalmpl/benchmark,test//org/rascalmpl/test/data
+Source: src/org/rascalmpl/library,src/org/rascalmpl/compiler,test/org/rascalmpl/benchmark,test//org/rascalmpl/test/data
 Courses: src/org/rascalmpl/courses
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,8 @@
                     <bin>${project.build.outputDirectory}</bin>
                     <srcs>
                         <src>${project.basedir}/src/org/rascalmpl/library</src>
+                        <src>${project.basedir}/src/org/rascalmpl/compiler</src>
+                        <src>${project.basedir}/src/org/rascalmpl/typepal</src>
                     </srcs>
                     <sourceLookup>|std:///|</sourceLookup>
                     <funding>${project.basedir}/FUNDING</funding>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,6 @@
                     <srcs>
                         <src>${project.basedir}/src/org/rascalmpl/library</src>
                         <src>${project.basedir}/src/org/rascalmpl/compiler</src>
-                        <src>${project.basedir}/src/org/rascalmpl/typepal</src>
                     </srcs>
                     <sourceLookup>|std:///|</sourceLookup>
                     <funding>${project.basedir}/FUNDING</funding>

--- a/src/org/rascalmpl/compiler/Compiler.rsc
+++ b/src/org/rascalmpl/compiler/Compiler.rsc
@@ -1,0 +1,4 @@
+module Compiler
+
+// TODO: This is intended to be a temporary placeholder module (useful for
+// testing `PathConfig` changes). It should be removed after the merge.

--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -788,7 +788,18 @@ public class PathConfig {
      */
     public void printInterpreterConfigurationStatus(PrintWriter out) {
         out.println("Module paths:");
-        getSrcs().forEach((f) -> out.println(" ".repeat(4) + f));
+        getSrcs().forEach(f -> {
+            var l = (ISourceLocation) f;
+            var s = " ".repeat(4) + l;
+            if (l.getScheme().equals("std")) {
+                try {
+                    s += " at " + URIResolverRegistry.getInstance().logicalToPhysical(l);
+                } catch (IOException e) {
+                    s += " at unknown physical location";
+                }
+            }
+            out.println(s);
+        });
         out.println("JVM library classpath:");
         getLibsAndTarget().forEach((l) -> out.println(" ".repeat(4) + l));
         out.flush();

--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -18,7 +18,6 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.jar.Manifest;
 
 import org.rascalmpl.interpreter.Configuration;

--- a/src/org/rascalmpl/typepal/Typepal.rsc
+++ b/src/org/rascalmpl/typepal/Typepal.rsc
@@ -1,5 +1,4 @@
 module Typepal
 
 // TODO: This is intended to be a temporary placeholder module (useful for
-// testing `PathConfig` changes). It should be removed when `typepal` has been
-// merged into `rascal`.
+// testing `PathConfig` changes). It should be removed after the merge.

--- a/src/org/rascalmpl/typepal/Typepal.rsc
+++ b/src/org/rascalmpl/typepal/Typepal.rsc
@@ -1,0 +1,5 @@
+module Typepal
+
+// TODO: This is intended to be a temporary placeholder module (useful for
+// testing `PathConfig` changes). It should be removed when `typepal` has been
+// merged into `rascal`.

--- a/src/org/rascalmpl/typepal/Typepal.rsc
+++ b/src/org/rascalmpl/typepal/Typepal.rsc
@@ -1,4 +1,0 @@
-module Typepal
-
-// TODO: This is intended to be a temporary placeholder module (useful for
-// testing `PathConfig` changes). It should be removed after the merge.


### PR DESCRIPTION
### Overview

This PR implements the following approach for loading Rascal modules of `rascal`:

https://github.com/usethesource/rascal/blob/d328b34e6e125146369ef8f5ed94421ce6e7c34d/src/org/rascalmpl/library/util/PathConfig.java#L667-L691

See also [this comment](https://github.com/usethesource/rascal/pull/2112#issuecomment-2618186651) for additional background/motivation.

Java classes of `rascal` are always loaded from the "current" `rascal` (as per `resolveCurrentRascalRuntimeJar()`).

Thus, after this PR:
  - ✔️ Rascal modules and Java classes of `rascal` inside `std` must be loaded from the same version. This partly fixes usethesource/rascal-language-servers#538.

  - ⚠️ Rascal modules and Java classes of `rascal` outside `std` may be loaded from different versions. However, currently, there are no Rascal modules of `rascal` outside `std` that rely on Java classes. Moreover, after the merge, there are a few Rascal modules of `rascal-core` that rely on Java classes, but the impact seems negligible in the context of this PR.
    
  - ⚠️ REPLs created in VS Code always load the version of `std` of the deployed `rascal.jar` (part of the VS Code extension), which is put on the class path of the REPL's JVM. Even when `rascal` itself is open in the workspace, changes made to `std` will *not* be loaded in the REPL. To test such changes, a standalone Rascal shell needs to be created (but it doesn't have debugging support).

### Examples (VS Code)

#### Create REPL in `rascal` (`typepal` open)

  - [ ] No compiler and TypePal
  - [ ] Compiler and TypePal from deployed `rascal.jar`
  - [x] Compiler and TypePal from open folders in workspace

```
Module paths:
    |std:///| at |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/library/|
    |project://rascal/src/org/rascalmpl/compiler| at |file:///c:/Users/sung-/Desktop/rascal-which-version/projects/rascal/src/org/rascalmpl/compiler|
    |project://typepal/src| at |file:///c:/Users/sung-/Desktop/rascal-which-version/projects/typepal/src|
    |jar+file:///C:/Users/sung-/Desktop/rascal-language-servers3/rascal-vscode-extension/assets/jars/rascal-lsp.jar!/|
```

#### Create REPL in `rascal` (`typepal` closed)

  - [x] No compiler and TypePal
  - [ ] Compiler and TypePal from deployed jars
  - [ ] Compiler and TypePal from workspace

```
Module paths:
    |std:///| at |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/library/|
    |jar+file:///C:/Users/sung-/Desktop/rascal-language-servers3/rascal-vscode-extension/assets/jars/rascal-lsp.jar!/|
```

#### Create REPL in `rascal-lsp` (`rascal` open, `typepal` open)

  - [ ] No compiler and TypePal
  - [ ] Compiler and TypePal from deployed jars
  - [x] Compiler and TypePal from workspace

```
Module paths:
    |std:///| at |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/library/|
    |project://rascal/src/org/rascalmpl/compiler| at |file:///c:/Users/sung-/Desktop/rascal-which-version/projects/rascal/src/org/rascalmpl/compiler|
    |project://typepal/src| at |file:///c:/Users/sung-/Desktop/rascal-which-version/projects/typepal/src|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal-language-servers/rascal-lsp/src/main/rascal|
```

#### Create REPL in `rascal-lsp` (`rascal` open, `typepal` closed)

  - [ ] No compiler and TypePal
  - [x] Compiler and TypePal from deployed jars
  - [ ] Compiler and TypePal from workspace

```
Module paths:
    |std:///| at |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/library/|
    |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/compiler|
    |jar+file:///C:/Users/sung-/.m2/repository/org/rascalmpl/typepal/0.14.0/typepal-0.14.0.jar!/src|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal-language-servers/rascal-lsp/src/main/rascal|
```

#### Create REPL in `rascal-lsp` (`rascal` closed, `typepal` open)

  - [ ] No compiler and TypePal
  - [x] Compiler and TypePal from deployed jars
  - [ ] Compiler and TypePal from workspace

```
Module paths:
    |std:///| at |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/library/|
    |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/compiler|
    |jar+file:///C:/Users/sung-/.m2/repository/org/rascalmpl/typepal/0.14.0/typepal-0.14.0.jar!/src|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal-language-servers/rascal-lsp/src/main/rascal|
```

#### Create REPL in `rascal-lsp` (`rascal` closed, `typepal` closed)

  - [ ] No compiler and TypePal
  - [x] Compiler and TypePal from deployed jars
  - [ ] Compiler and TypePal from workspace

```
Module paths:
    |std:///| at |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/library/|
    |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/compiler|
    |jar+file:///C:/Users/sung-/.m2/repository/org/rascalmpl/typepal/0.14.0/typepal-0.14.0.jar!/src|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal-language-servers/rascal-lsp/src/main/rascal|
```

#### Create REPL in `typepal` (`rascal` open)

  - [x] No compiler, TypePal from workspace
  - [ ] Compiler and TypePal from deployed jars
  - [ ] Compiler and TypePal from workspace

```
Module paths:
    |std:///| at |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/library/|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/typepal/src|
    |jar+file:///C:/Users/sung-/Desktop/rascal-language-servers3/rascal-vscode-extension/assets/jars/rascal-lsp.jar!/|
```

#### Create REPL in `typepal` (`rascal` closed)

  - [x] No compiler, TypePal from workspace
  - [ ] Compiler and TypePal from deployed jars
  - [ ] Compiler and TypePal from workspace

```
Module paths:
    |std:///| at |jar+file:///C:/Users/sung-/Desktop/rascal3/rascal/target/rascal-0.40.8-SNAPSHOT.jar!/org/rascalmpl/library/|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/typepal/src|
    |jar+file:///C:/Users/sung-/Desktop/rascal-language-servers3/rascal-vscode-extension/assets/jars/rascal-lsp.jar!/|
```

### Examples (`RascalShell`)

#### Create REPL in `rascal`

```
Module paths:
    |std:///| at |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes/org/rascalmpl/library/|
```

#### Create REPL in `rascal-lsp` (with TypePal jar on the class path)

```
Module paths:
    |std:///| at |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes/org/rascalmpl/library/|
    |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes/org/rascalmpl/compiler|
    |jar+file:///C:/Users/sung-/.m2/repository/org/rascalmpl/typepal/0.14.0/typepal-0.14.0.jar!/src|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal-language-servers/rascal-lsp/src/main/rascal|
```

#### Create REPL in `rascal-lsp` (without TypePal jar on the class path)

```
Module paths:
    |std:///| at |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes/org/rascalmpl/library/|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/rascal-language-servers/rascal-lsp/src/main/rascal|
```

#### Create REPL in `typepal`

```
Module paths:
    |std:///| at |file:///C:/Users/sung-/Desktop/rascal3/rascal/target/classes/org/rascalmpl/library/|
    |file:///C:/Users/sung-/Desktop/rascal-which-version/projects/typepal/src|
```