### PR TITLE
Fix assigning to list element at negative index.

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Lists.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Lists.rsc
@@ -285,9 +285,9 @@ test bool assignStep13() { L = [0,1,2,3,4,5,6,7,8,9]; L[-1,-3..] = [10,20,30,40,
 
 // TODO: add tests for /= and &= 
 
-@ignoreInterpreter{} test bool AssignFromEnd1(){ L = [0,1,2,3,4,5,6,7,8,9]; L[-1] = 90; return L ==  [0,1,2,3,4,5,6,7,8,90]; }
-@ignoreInterpreter{} test bool AssignFromEnd2(){ L = [0,1,2,3,4,5,6,7,8,9]; L[-2] = 80; return L ==  [0,1,2,3,4,5,6,7,80,9]; }
-@ignoreInterpreter{} test bool AssignFromEnd3(){ L = [0,1,2,3,4,5,6,7,8,9]; L[-10] = 10; return L == [10,1,2,3,4,5,6,7,8,9]; }
+test bool AssignFromEnd1(){ L = [0,1,2,3,4,5,6,7,8,9]; L[-1] = 90; return L ==  [0,1,2,3,4,5,6,7,8,90]; }
+test bool AssignFromEnd2(){ L = [0,1,2,3,4,5,6,7,8,9]; L[-2] = 80; return L ==  [0,1,2,3,4,5,6,7,80,9]; }
+test bool AssignFromEnd3(){ L = [0,1,2,3,4,5,6,7,8,9]; L[-10] = 10; return L == [10,1,2,3,4,5,6,7,8,9]; }
 
 // Library functions
 

--- a/src/org/rascalmpl/semantics/dynamic/Assignable.java
+++ b/src/org/rascalmpl/semantics/dynamic/Assignable.java
@@ -459,6 +459,9 @@ public abstract class Assignable extends org.rascalmpl.ast.Assignable {
 				try {
 					IList list = (IList) rec.getValue();
 					int index = ((IInteger) subscript.getValue()).intValue();
+					if (index < 0) {
+						index += list.length();
+					}
 					__eval.__setValue(__eval.newResult(list.get(index), __eval
 							.__getValue()));
 					list = list.put(index, __eval.__getValue().getValue());


### PR DESCRIPTION
Fix the IndexOutOfBounds error that occurrs when assigning to a negative list index, even if the element exists.

Closes #2123.