### PR TITLE
Added an overload for Maven::runCommand

### DIFF
--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -779,8 +779,7 @@ public class PathConfig {
      */
 	private static IList getPomXmlCompilerClasspath(ISourceLocation manifestRoot) {
         try {
-            var tempFile = Maven.getTempFile("classpath");
-            var mavenOutput = Maven.runCommand(List.of("--quiet", "org.apache.maven.plugins:maven-dependency-plugin:3.8.1:build-classpath", "-DincludeScope=compile", "-Dmdep.outputFile=" + tempFile.toString()), manifestRoot, tempFile);
+            var mavenOutput = Maven.runCommand(tempFile -> List.of("--quiet", "org.apache.maven.plugins:maven-dependency-plugin:3.8.1:build-classpath", "-DincludeScope=compile", "-Dmdep.outputFile=" + tempFile.toString()), manifestRoot);
 
             // The classpath will be written to the temp file on a single line
             return Arrays.stream(mavenOutput.get(0).split(File.pathSeparator))
@@ -798,7 +797,7 @@ public class PathConfig {
                 .filter(x -> x != null) // Objects.nonNull is probably from a higher java version?
                 .collect(vf.listWriter());
         }
-        catch (IOException | RuntimeException e) {
+        catch (RuntimeException e) {
             return vf.list();
         }
     }

--- a/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
+++ b/src/org/rascalmpl/uri/file/MavenRepositoryURIResolver.java
@@ -103,7 +103,7 @@ public class MavenRepositoryURIResolver implements ISourceLocationInput, IClassl
             // only then we go for the expensive option and retrieve it from maven itself
             String configuredLocation = getLocalRepositoryLocationFromMavenCommand();
 
-            if (configuredLocation != null) {
+            if (configuredLocation != "") {
                 return URIUtil.createFileLocation(configuredLocation);
             }
             
@@ -122,25 +122,14 @@ public class MavenRepositoryURIResolver implements ISourceLocationInput, IClassl
      * to here are faster than the first.
      */
     private static String getLocalRepositoryLocationFromMavenCommand() {
-        try {
-            var tempFile = Maven.getTempFile("classpath");
-
-            Maven.runCommand(List.of(
-                "-q", 
-                "help:evaluate",
-                "-Dexpression=settings.localRepository",
-                "-Doutput=" + tempFile
-                ), null /* no current pom.xml file */, tempFile);
-            
-                
-            try (Stream<String> lines = Files.lines(Paths.get(tempFile.toString()))) {
-                return lines.collect(Collectors.joining()).trim(); 
-            }    
-        }
-        catch (IOException e) {
-            // it's ok to fail. that just happens.
-            return null;
-        }
+        var mavenOutput = Maven.runCommand(tempFile -> List.of(
+            "-q", 
+            "help:evaluate",
+            "-Dexpression=settings.localRepository",
+            "-Doutput=" + tempFile.toString()
+            ), null /* no current pom.xml file */);
+        
+        return mavenOutput.stream().collect(Collectors.joining()).trim(); 
     }
  
     /** 


### PR DESCRIPTION
Added an overload for Maven::runCommand that takes a function taking a Path, such that callers no longer have to explicitly create a temporary file, while still being able to use the path of the temporary file in the Maven parameters.