### PR TITLE
cleaning up the use of a commandline classpath

### DIFF
--- a/src/org/rascalmpl/exceptions/JavaCompilation.java
+++ b/src/org/rascalmpl/exceptions/JavaCompilation.java
@@ -14,13 +14,11 @@ package org.rascalmpl.exceptions;
 public class JavaCompilation extends RuntimeException {
 	private static final long serialVersionUID = 3200356264732532487L;
 	private final String source;
-	private final String classpath;
 	private final long line;
 	private final long column;
 
-	public JavaCompilation(String message, long line, long column, String source, String classpath, Exception cause) {
+	public JavaCompilation(String message, long line, long column, String source, Exception cause) {
 		super("Java compilation failed due to " + message, cause);
-		this.classpath = classpath;
 		this.source = source;
 		this.line = line;
 		this.column = column;
@@ -28,10 +26,6 @@ public class JavaCompilation extends RuntimeException {
 
 	public String getSource() {
 		return source;
-	}
-
-	public String getClasspath() {
-		return classpath;
 	}
 
 	public long getLine() {

--- a/src/org/rascalmpl/exceptions/RuntimeExceptionFactory.java
+++ b/src/org/rascalmpl/exceptions/RuntimeExceptionFactory.java
@@ -16,14 +16,9 @@
 *******************************************************************************/
 package org.rascalmpl.exceptions;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.Arrays;
-
 import org.rascalmpl.ast.AbstractAST;
-import org.rascalmpl.uri.URIUtil;
-
 import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.ISourceLocation;
@@ -459,18 +454,7 @@ public class RuntimeExceptionFactory {
 	}
 
 	public static Throw javaCompilerException(JavaCompilation e, AbstractAST ast, StackTrace trace) {
-		IList cp = Arrays.stream(e.getClasspath().split(File.pathSeparator))
-			.map(j -> {
-				try {
-					return URIUtil.createFileLocation(j);
-				}
-				catch (URISyntaxException e1) {
-					return URIUtil.rootLocation("failedToParseLocation");
-				}
-			})
-			.collect(VF.listWriter());
-			
-		return new Throw(VF.constructor(JavaCompilation, VF.string(e.getMessage()),  VF.integer(e.getLine()), VF.integer(e.getColumn()), VF.string(e.getSource()), cp), ast != null ? ast.getLocation() : null, trace);
+		return new Throw(VF.constructor(JavaCompilation, VF.string(e.getMessage()),  VF.integer(e.getLine()), VF.integer(e.getColumn()), VF.string(e.getSource())), ast != null ? ast.getLocation() : null, trace);
 	}
 
 	public static Throw javaException(Throwable targetException, AbstractAST ast, StackTrace rascalTrace) throws ImplementationError {

--- a/src/org/rascalmpl/interpreter/Configuration.java
+++ b/src/org/rascalmpl/interpreter/Configuration.java
@@ -23,45 +23,25 @@ public class Configuration {
 	public static final String RASCAL_MODULE_SEP = "::";
 	public static final String RASCAL_PATH_SEP = "/";
 	
-	private static final String RASCAL_JAVA_COMPILER_CLASSPATH = "rascal.java.classpath";
 	public final static String PROFILING_PROPERTY = "rascal.profiling";
 	public final static String GENERATOR_PROFILING_PROPERTY = "rascal.generatorProfiling";
 	public final static String TRACING_PROPERTY = "rascal.tracing";
 	public final static String ERRORS_PROPERTY = "rascal.errors";
 	
-	private String javaClassPath = getDefaultString(RASCAL_JAVA_COMPILER_CLASSPATH, System.getProperty("java.class.path"));
-  private boolean profiling = getDefaultBoolean(PROFILING_PROPERTY, false);
-  private boolean generatorProfiling = getDefaultBoolean(GENERATOR_PROFILING_PROPERTY, false);
-  private boolean tracing = getDefaultBoolean(TRACING_PROPERTY, false);
-  private boolean errors = getDefaultBoolean(ERRORS_PROPERTY, false);
-  
-	private static String getDefaultString(String property, String def) {
-	  String prop = System.getProperty(property);
-	  if (prop == null) {
-	    return def;
-	  }
-	  else {
-	    return prop;
-	  }
-	}
+  	private boolean profiling = getDefaultBoolean(PROFILING_PROPERTY, false);
+  	private boolean generatorProfiling = getDefaultBoolean(GENERATOR_PROFILING_PROPERTY, false);
+  	private boolean tracing = getDefaultBoolean(TRACING_PROPERTY, false);
+  	private boolean errors = getDefaultBoolean(ERRORS_PROPERTY, false);
 	
 	private static boolean getDefaultBoolean(String property, boolean def) {
-    String prop = System.getProperty(property);
-    if (prop == null) {
-      return def;
-    }
-    else {
-      return prop.equals("true");
-    }
-  }
-	
-	public String getRascalJavaClassPathProperty() {
-		return javaClassPath;
-	}
-	
-	public void setRascalJavaClassPathProperty(String path) {
-		javaClassPath = path;
-	}
+		String prop = System.getProperty(property);
+		if (prop == null) {
+			return def;
+		}
+		else {
+		return prop.equals("true");
+		}
+  	}
 	
 	public boolean getProfilingProperty(){
 		return profiling;
@@ -80,16 +60,16 @@ public class Configuration {
 	}
 	
 	public void setErrors(boolean errors) {
-    this.errors = errors;
-  }
+    	this.errors = errors;
+  	}
 	
 	public void setProfiling(boolean profiling) {
-	  this.profiling = profiling;
+	  	this.profiling = profiling;
 	}
 	
 	public void setGeneratorProfiling(boolean profiling) {
-		  this.generatorProfiling = profiling;
-		}
+		this.generatorProfiling = profiling;
+	}
 	
 	public void setTracing(boolean tracing) {
 	  this.tracing = tracing;

--- a/src/org/rascalmpl/library/lang/java/JavaCompilerForRascal.java
+++ b/src/org/rascalmpl/library/lang/java/JavaCompilerForRascal.java
@@ -1,11 +1,8 @@
 package org.rascalmpl.library.lang.java;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaFileObject;
@@ -13,7 +10,6 @@ import org.rascalmpl.interpreter.utils.JavaCompiler;
 import org.rascalmpl.interpreter.utils.JavaCompilerException;
 import org.rascalmpl.interpreter.utils.JavaFileObjectImpl;
 import org.rascalmpl.library.Messages;
-import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.uri.classloaders.SourceLocationClassLoader;
 
@@ -29,15 +25,6 @@ public class JavaCompilerForRascal {
 	
 	public JavaCompilerForRascal(IValueFactory vf) {
 		this.vf = vf;
-	}
-
-	private ISourceLocation safeResolve(ISourceLocation l) {
-		try {
-			return URIResolverRegistry.getInstance().logicalToPhysical(l);
-		}
-		catch (IOException e) {
-			return l;
-		}
 	}	
 
 	/**

--- a/src/org/rascalmpl/library/util/Eval.java
+++ b/src/org/rascalmpl/library/util/Eval.java
@@ -223,8 +223,6 @@ public class Eval {
 			this.eval = new Evaluator(vf, input, stderr, stdout, root, heap, services);
 
 			eval.addRascalSearchPathContributor(StandardLibraryContributor.getInstance());
-			eval.setMonitor(services);        
-			eval.getConfiguration().setRascalJavaClassPathProperty(PathConfig.resolveCurrentRascalRuntimeJar().getPath());
 			eval.setMonitor(services);
 
 			if (!pcfg.getSrcs().isEmpty()) {

--- a/src/org/rascalmpl/parser/ParserGenerator.java
+++ b/src/org/rascalmpl/parser/ParserGenerator.java
@@ -58,7 +58,6 @@ public class ParserGenerator {
 		GlobalEnvironment heap = new GlobalEnvironment();
 		ModuleEnvironment scope = new ModuleEnvironment("$parsergenerator$", heap);
 		this.evaluator = new Evaluator(ValueFactoryFactory.getValueFactory(), Reader.nullReader(), out, out, scope, heap, monitor);
-		this.evaluator.getConfiguration().setRascalJavaClassPathProperty(config.getRascalJavaClassPathProperty());
 		this.evaluator.getConfiguration().setGeneratorProfiling(config.getGeneratorProfilingProperty());
 		evaluator.addRascalSearchPathContributor(StandardLibraryContributor.getInstance());		
 		this.evaluator.setBootstrapperProperty(true);

--- a/src/org/rascalmpl/runtime/utils/ExecutionTools.java
+++ b/src/org/rascalmpl/runtime/utils/ExecutionTools.java
@@ -72,10 +72,10 @@ public class ExecutionTools<T> {
 		} catch (JavaCompilerException e) {
 			if (!e.getDiagnostics().getDiagnostics().isEmpty()) {
 		        Diagnostic<? extends JavaFileObject> msg = e.getDiagnostics().getDiagnostics().iterator().next();
-		        throw new JavaCompilation(msg.getMessage(null), msg.getLineNumber(), msg.getColumnNumber(), interfaceModule, classModule, e);
+		        throw new JavaCompilation(msg.getMessage(null), msg.getLineNumber(), msg.getColumnNumber(), classModule, e);
 		    }
 		    else {
-		        throw new JavaCompilation(e.getMessage(), 0, 0, interfaceModule, classModule, e);
+		        throw new JavaCompilation(e.getMessage(), 0, 0, classModule, e);
 		    }
 		}
 	}

--- a/src/org/rascalmpl/runtime/utils/JavaBridge.java
+++ b/src/org/rascalmpl/runtime/utils/JavaBridge.java
@@ -26,7 +26,6 @@
  */
 package org.rascalmpl.runtime.utils;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -39,26 +38,11 @@ import org.rascalmpl.exceptions.JavaCompilation;
 import org.rascalmpl.library.util.PathConfig;
 
 import io.usethesource.vallang.ISourceLocation;
-import io.usethesource.vallang.IValue;
 
 
 public class JavaBridge {
-    private String javaCompilerPath;
 
     public JavaBridge(List<ClassLoader> classLoaders, PathConfig config) {
-        // TODO: @jurgenvinju this used to say `config.getJavaCompilerPath` but that is not is not available anymore (removed in #1969)? 
-        //StringBuilder sw = new StringBuilder();
-        //for(IValue v : config.getJavaCompilerPath()) {
-        //    if(sw.length() > 0) sw.append(":");
-        //    sw.append(v.toString());
-        //}
-        //javaCompilerPath = sw.toString();
-        try {
-            javaCompilerPath = config.resolveCurrentRascalRuntimeJar().getPath(); // TODO: review if this is correct, as it's now not a path anymore
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
         if (ToolProvider.getSystemJavaCompiler() == null) {
             throw new ImplementationError("Could not find an installed System Java Compiler, please provide a Java Runtime that includes the Java Development Tools (JDK 1.6 or higher).");
         }
@@ -71,21 +55,21 @@ public class JavaBridge {
     public <T> Class<T> compileJava(ISourceLocation loc, String className, Class<?> parent, String source) {
         try {
             // watch out, if you start sharing this compiler, classes will not be able to reload
-            List<String> commandline = Arrays.asList(new String[] {"-proc:none", "-cp", javaCompilerPath});
+            List<String> commandline = Arrays.asList(new String[] {"-proc:none"});
             JavaCompiler<T> javaCompiler = new JavaCompiler<T>(parent.getClassLoader(), null, commandline);
             Class<T> result = javaCompiler.compile(className, source, null, Object.class);
             return result;
         } 
         catch (ClassCastException e) {
-            throw new JavaCompilation(e.getMessage(), 0, 0, className, className, e);
+            throw new JavaCompilation(e.getMessage(), 0, 0, className, e);
         } 
         catch (JavaCompilerException e) {
             if (!e.getDiagnostics().getDiagnostics().isEmpty()) {
                 Diagnostic<? extends JavaFileObject> msg = e.getDiagnostics().getDiagnostics().iterator().next();
-                throw new JavaCompilation(msg.getMessage(null), msg.getLineNumber(), msg.getColumnNumber(), className, javaCompilerPath, e);
+                throw new JavaCompilation(msg.getMessage(null), msg.getLineNumber(), msg.getColumnNumber(), className, e);
             }
             else {
-                throw new JavaCompilation(e.getMessage(), 0, 0,  className, javaCompilerPath, e);
+                throw new JavaCompilation(e.getMessage(), 0, 0,  className, e);
             }
         }
     }

--- a/src/org/rascalmpl/tutor/lang/rascal/tutor/repl/TutorCommandExecutor.java
+++ b/src/org/rascalmpl/tutor/lang/rascal/tutor/repl/TutorCommandExecutor.java
@@ -54,13 +54,6 @@ public class TutorCommandExecutor {
             protected Evaluator buildEvaluator(Reader input, PrintWriter stdout, PrintWriter stderr, IDEServices services) {
                 var eval = super.buildEvaluator(input, stdout, stderr, services);
 
-                try {
-                    eval.getConfiguration().setRascalJavaClassPathProperty(PathConfig.resolveCurrentRascalRuntimeJar().getPath());
-                }
-                catch (IOException e) {
-                    services.warning(e.getMessage(), URIUtil.rootLocation("unknown"));
-                }
-
                 if (!pcfg.getSrcs().isEmpty()) {
                     ISourceLocation projectRoot = inferProjectRoot((ISourceLocation) pcfg.getSrcs().get(0));
                     String projectName = new RascalManifest().getProjectName(projectRoot);

--- a/src/org/rascalmpl/uri/libraries/MemoryResolver.java
+++ b/src/org/rascalmpl/uri/libraries/MemoryResolver.java
@@ -25,9 +25,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 
-import javax.tools.JavaFileObject;
-
-import org.rascalmpl.interpreter.utils.JavaFileObjectImpl;
 import org.rascalmpl.library.Prelude;
 import org.rascalmpl.uri.FileTree;
 import org.rascalmpl.uri.ISourceLocationInputOutput;


### PR DESCRIPTION
The `-cp path/to/rascal.jar` option for the JavaBridge has been replaced by the `SourceLocationClassLoader` and the Java compiler now reads the necessary classfiles from there. This is (a) more general and (b) more flexible, since it allows classes to be loaded from any `loc` scheme. It is an improvement of the JDK javac interface that makes this possible. made somewhere between java 9 and java 11. 

As a result the "javaCompilerClassPath" configuration parameter of the interpreter and its JavaBridge is no longer required. This PR removes all of its definitions and uses. 

Leaving this stuff in could be confusing for the future. Since it wires a the interpreter, the Configuration class, the JavaBridge and the JavaCompiler class together without ever having an effect. 

* [ ] A test is failing in StaticTestingUtils; have to see what that is. 
