### PR TITLE
Updated code that expected legacy grammar categories

### DIFF
--- a/src/org/rascalmpl/library/analysis/grammars/LOC.rsc
+++ b/src/org/rascalmpl/library/analysis/grammars/LOC.rsc
@@ -129,6 +129,7 @@ bool isLayout(amb({*_, appl(prod(\layouts(_), _, _), _)})) = true;
 default bool isLayout(Tree t) = false;
 
 bool isComment(appl(p:prod(_, _, {*_, \tag("category"("Comment"))}), _)) = true;
+bool isComment(appl(p:prod(_, _, {*_, \tag("category"("comment"))}), _)) = true;
 default bool isComment(Tree _) = false;
 
 

--- a/src/org/rascalmpl/library/lang/box/util/Tree2Box.rsc
+++ b/src/org/rascalmpl/library/lang/box/util/Tree2Box.rsc
@@ -17,7 +17,7 @@ we can specialize for more cases more easily than in the original paper. For exa
 comment styles are automatically recognized.
 
 The current algorithm, not extended, additionally guarantees that no comments are lost as long as their grammar
-rules have been tagged with `@category="Comment"`
+rules have been tagged with `@category="comment"` or the legacy `@category="Comment"`
 
 Another new feature is the normalization of case-insensitive literals. By providing ((toUpper)) or ((toLower))
 the mapping algorithm will change every instance of a case-insensitive literal accordingly before translating
@@ -138,20 +138,20 @@ default Box toBox(t:appl(Production p, list[Tree] args), FO opts = fo()) {
         // comments, then layout positions are reduced to U([]) which dissappears
         // by splicing the empty list.
         case <prod(layouts(_), _, _), list[Tree] content>:
-            return U([toBox(u, opts=opts) | /u:appl(prod(_, _, {*_,\tag("category"("Comment"))}), _) <- content]);
+            return U([toBox(u, opts=opts) | /u:appl(prod(_, _, {*_,\tag("category"(/^[Cc]omment$/))}), _) <- content]);
 
         // single line comments are special, since they have the newline in a literal
         // we must guarantee that the formatter will print the newline, but we don't 
         // want an additional newline due to the formatter. We do remove any unnecessary
         // spaces
-        case <prod(_, [lit(_), *_, lit("\n")], {*_, /\tag("category"("Comment"))}), list[Tree] elements>:
+        case <prod(_, [lit(_), *_, lit("\n")], {*_, /\tag("category"(/^[Cc]omment$/))}), list[Tree] elements>:
             return V([
                     H([toBox(elements[0], opts=opts), 
                         H([L(e) | e <- words("<elements[..-1]>")], hs=1)
                     ], hs=1)
                 ]);
 
-        case <prod(_, [lit(_),conditional(\iter-star(notNl),{\end-of-line()})], {*_, /\tag("category"("Comment"))}), list[Tree] elements>:
+        case <prod(_, [lit(_),conditional(\iter-star(notNl),{\end-of-line()})], {*_, /\tag("category"(/^[Cc]omment$/))}), list[Tree] elements>:
             return V([
                     H([toBox(elements[0], opts=opts), 
                         H([L(w) | e <- elements[1..], w <- words("<e>")], hs=1)
@@ -159,7 +159,7 @@ default Box toBox(t:appl(Production p, list[Tree] args), FO opts = fo()) {
                 ]);
 
         // multiline comments are rewrapped for the sake of readability and fitting on the page
-        case <prod(_, [lit(_), *_, lit(_)], {*_, /\tag("category"("Comment"))}), list[Tree] elements>:
+        case <prod(_, [lit(_), *_, lit(_)], {*_, /\tag("category"(/^[Cc]omment$/))}), list[Tree] elements>:
             return HV([toBox(elements[0], opts=opts),                     // recurse in case its a ci literal 
                       *[L(w) | e <- elements[1..-1], w <- words("<e>")], // wrap a nice paragraph
                       toBox(elements[-1], opts=opts)                     // recurse in case its a ci literal 

--- a/src/org/rascalmpl/values/parsetrees/TreeAdapter.java
+++ b/src/org/rascalmpl/values/parsetrees/TreeAdapter.java
@@ -44,9 +44,10 @@ public class TreeAdapter {
 	public static final String NORMAL = "Normal";
 	public static final String TYPE = "Type";
 	public static final String IDENTIFIER = "Identifier";
-	public static final String VARIABLE = "Variable";
-	public static final String CONSTANT = "Constant";
-	public static final String COMMENT = "Comment";
+	public static final String VARIABLE = "variable";
+	public static final String CONSTANT = "constant";
+	public static final String COMMENT = "comment";
+	public static final String COMMENT_LEGACY = "Comment";
 	public static final String TODO = "Todo";
 	public static final String QUOTE = "Quote";
 	public static final String META_AMBIGUITY = "MetaAmbiguity";
@@ -127,7 +128,8 @@ public class TreeAdapter {
 		IConstructor treeProd = getProduction(tree);
 		if (treeProd != null) {
 			String treeProdCategory = ProductionAdapter.getCategory(treeProd);
-			if (treeProdCategory != null && treeProdCategory.equals(COMMENT))
+			if (treeProdCategory != null &&
+				(treeProdCategory.equals(COMMENT) || treeProdCategory.equals(COMMENT_LEGACY)))
 				return true;
 		}
 		return false;
@@ -455,6 +457,9 @@ public class TreeAdapter {
 			ansiOpen.put(META_KEYWORD, Ansi.ansi().fg(Color.MAGENTA));
 			ansiClose.put(META_KEYWORD, Ansi.ansi().fg(Color.DEFAULT));
 
+			ansiOpen.put(VARIABLE, Ansi.ansi().a(Attribute.ITALIC).fgBright(Color.GREEN));
+			ansiClose.put(VARIABLE, Ansi.ansi().a(Attribute.ITALIC_OFF).fgBright(Color.DEFAULT));
+
 			ansiOpen.put(META_VARIABLE, Ansi.ansi().a(Attribute.ITALIC).fgBright(Color.GREEN));
 			ansiClose.put(META_VARIABLE, Ansi.ansi().a(Attribute.ITALIC_OFF).fgBright(Color.DEFAULT));
 
@@ -466,6 +471,9 @@ public class TreeAdapter {
 
 			ansiOpen.put(COMMENT, Ansi.ansi().a(Attribute.ITALIC).fg(Color.GREEN));
 			ansiClose.put(COMMENT, Ansi.ansi().a(Attribute.ITALIC_OFF).fg(Color.DEFAULT));
+
+			ansiOpen.put(COMMENT_LEGACY, Ansi.ansi().a(Attribute.ITALIC).fg(Color.GREEN));
+			ansiClose.put(COMMENT_LEGACY, Ansi.ansi().a(Attribute.ITALIC_OFF).fg(Color.DEFAULT));
 		}
 
 		/**


### PR DESCRIPTION
#2083 brought some changes to `@category` tags on productions in the Rascal grammar. This PR updates the standard library in places where the legacy tags were expected. This PR fixes https://github.com/usethesource/rascal-language-servers/issues/597.