### PR TITLE
Consistently use new production categories in standard library

### DIFF
--- a/src/org/rascalmpl/library/lang/c90/syntax/C.rsc
+++ b/src/org/rascalmpl/library/lang/c90/syntax/C.rsc
@@ -30,11 +30,11 @@ syntax Statement
 
 syntax Expression 
 	= variable: Identifier 
-	| @category="Constant" HexadecimalConstant 
-	| @category="Constant" IntegerConstant 
-	| @category="Constant" CharacterConstant 
-	| @category="Constant" FloatingPointConstant 
-	| @category="Constant" StringConstant 
+	| @category="constant" HexadecimalConstant 
+	| @category="constant" IntegerConstant 
+	| @category="constant" CharacterConstant 
+	| @category="constant" FloatingPointConstant 
+	| @category="constant" StringConstant 
 	| Expression "[" Expression "]" 
 	| Expression "(" {NonCommaExpression ","}* ")" 
 	| "sizeof" "(" TypeName ")" 
@@ -309,5 +309,5 @@ layout LAYOUTLIST = LAYOUT* !>> [\ \t\n\r];
 
 lexical LAYOUT 
 	= whitespace: [\ \t\n\r] 
-	| @category="Comment" comment: Comment
+	| @category="comment" comment: Comment
 	;

--- a/src/org/rascalmpl/library/lang/c90/syntax/C.rsc
+++ b/src/org/rascalmpl/library/lang/c90/syntax/C.rsc
@@ -30,11 +30,11 @@ syntax Statement
 
 syntax Expression 
 	= variable: Identifier 
-	| @category="constant" HexadecimalConstant 
-	| @category="constant" IntegerConstant 
-	| @category="constant" CharacterConstant 
-	| @category="constant" FloatingPointConstant 
-	| @category="constant" StringConstant 
+	| @category="number" HexadecimalConstant 
+	| @category="number" IntegerConstant 
+	| @category="string" CharacterConstant 
+	| @category="number" FloatingPointConstant 
+	| @category="string" StringConstant 
 	| Expression "[" Expression "]" 
 	| Expression "(" {NonCommaExpression ","}* ")" 
 	| "sizeof" "(" TypeName ")" 

--- a/src/org/rascalmpl/library/lang/dot/syntax/Dot.rsc
+++ b/src/org/rascalmpl/library/lang/dot/syntax/Dot.rsc
@@ -94,5 +94,5 @@ layout LAYOUTLIST = LAYOUT* !>> [\ \t\n\r] !>> "//" !>> "/*"
                    
 
 lexical LAYOUT = Whitespace: [\ \t\n\r] 
-               | @category="Comment" Comment
+               | @category="comment" Comment
                ;

--- a/src/org/rascalmpl/library/lang/javascript/saner/Syntax.rsc
+++ b/src/org/rascalmpl/library/lang/javascript/saner/Syntax.rsc
@@ -312,8 +312,8 @@ lexical Whitespace
   ;
 
 lexical Comment
-  = @category="Comment" "/*" CommentChar* "*/"
-  | @category="Comment" "//" ![\n]*  $
+  = @category="comment" "/*" CommentChar* "*/"
+  | @category="comment" "//" ![\n]*  $
   ;
 
 lexical CommentChar

--- a/src/org/rascalmpl/library/lang/pico/syntax/Main.rsc
+++ b/src/org/rascalmpl/library/lang/pico/syntax/Main.rsc
@@ -53,8 +53,8 @@ layout Layout = WhitespaceAndComment* !>> [\ \t\n\r%];
 
 lexical WhitespaceAndComment 
    = [\ \t\n\r]
-   | @category="Comment" "%" ![%]+ "%"
-   | @category="Comment" "%%" ![\n]* $
+   | @category="comment" "%" ![%]+ "%"
+   | @category="comment" "%%" ![\n]* $
    ;
 
 public start[Program] program(str s) {

--- a/src/org/rascalmpl/library/lang/sdf2/syntax/Sdf2.rsc
+++ b/src/org/rascalmpl/library/lang/sdf2/syntax/Sdf2.rsc
@@ -135,8 +135,8 @@ layout LAYOUTLIST = LAYOUT* !>> [\ \t\n\r%]
                     ;
 
 lexical LAYOUT = Whitespace: [\ \t\n\r] |
-                 @category="Comment" Line: "%%" ![\n]* [\n] |
-                 @category="Comment" Nested: "%" ![%\n] "%"
+                 @category="comment" Line: "%%" ![\n]* [\n] |
+                 @category="comment" Nested: "%" ![%\n] "%"
                 ;
 
 syntax Alias = Alias: Sym "-\>" Sym

--- a/src/org/rascalmpl/library/lang/std/Comment.rsc
+++ b/src/org/rascalmpl/library/lang/std/Comment.rsc
@@ -8,4 +8,4 @@
 @contributor{Jurgen J. Vinju - Jurgen.Vinju@cwi.nl - CWI}
 module lang::std::Comment
 
-lexical Comment = @lineComment @category="Comment" "//" ![\n]* $;
+lexical Comment = @lineComment @category="comment" "//" ![\n]* $;


### PR DESCRIPTION
In #2198 the standard library was updated to expect certain categories on grammar productions. This PR updates the grammars in the standard library to match this.