### PR TITLE
IO capabilities provide information about the file IO features implemented for a specific scheme

### DIFF
--- a/src/org/rascalmpl/library/IO.rsc
+++ b/src/org/rascalmpl/library/IO.rsc
@@ -757,3 +757,42 @@ java void watch(loc src, bool recursive, void (LocationChangeEvent event) watche
 
 @javaClass{org.rascalmpl.library.Prelude}
 java void unwatch(loc src, bool recursive, void (LocationChangeEvent event) watcher);
+
+@synopsis{Categories of IO capabilities for loc schemes}
+@description{
+* `read` includes at least these functions:
+   * ((readFile))
+   * ((lastModified)) and ((created))
+   * ((exists))
+   * ((isFile)) and ((isDirectory))
+   * `loc.ls`, and ((listEntries)) 
+* `write` includes at least these functions:
+   * ((writeFile))
+   * ((mkDirectory))
+   * ((remove))
+   * ((rename))
+* `classloader` means that for this scheme a specialized/optimized ClassLoader can be produced at run-time. By
+default an abstract (slower) ClassLoader can be built using `read` capabilities on `.class` files.
+* `watch` means that for this scheme a native file watcher can be instantiated. By default 
+a slower more generic file watcher is created based on capturing `write` actions.
+   * ((logical)) schemes provide a transparent facade for more abstract URIs. The abstract URI is 
+rewritten to a more concrete URI on-demand. Logical URIs can be nested arbitrarily.
+
+These capabilities extend naturally to other IO functions that use the internal versions of the above functionality, 
+such as used in ((ValueIO)) and ((lang::json::IO)), etc.
+}
+@pitfalls{
+* IO capabilities are not to be confused with file _permissions_. It is still possible that a file
+has write capabilities, but writing is denied by the OS due to a lack of permissions.
+}
+data IOCapability
+  = read()
+  | write()
+  | classloader()
+  | logical()
+  | watch()
+  ;
+
+@javaClass{org.rascalmpl.library.Prelude}
+@synopsis{List the IO capabilities of a loc (URI) scheme}
+java set[IOCapability] capabilities(loc location);

--- a/src/org/rascalmpl/library/IO.rsc
+++ b/src/org/rascalmpl/library/IO.rsc
@@ -786,11 +786,11 @@ such as used in ((ValueIO)) and ((lang::json::IO)), etc.
 has write capabilities, but writing is denied by the OS due to a lack of permissions.
 }
 data IOCapability
-  = read()
-  | write()
-  | classloader()
-  | logical()
-  | watch()
+  = reading()
+  | writing()
+  | classloading()
+  | resolving()
+  | watching()
   ;
 
 @javaClass{org.rascalmpl.library.Prelude}

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -3710,6 +3710,10 @@ public class Prelude {
 		return URIUtil.relativize(outside, inside);
 	}
 
+	public ISet capabilities(ISourceLocation loc) {
+		return URIResolverRegistry.getInstance().capabilities(loc);
+	}
+
 	public IValue readBinaryValueFile(IValue type, ISourceLocation loc){
 		if(trackIO) System.err.println("readBinaryValueFile: " + loc);
 

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -1098,11 +1098,11 @@ public class URIResolverRegistry {
 	private final TypeFactory tf = TypeFactory.getInstance();
 	private final TypeStore capabilitiesStore = new TypeStore();
 	private final Type IOcapability = tf.abstractDataType(capabilitiesStore, "IOCapability");
-	private final Type readCap = tf.constructor(capabilitiesStore, IOcapability, "read");
-	private final Type writeCap = tf.constructor(capabilitiesStore, IOcapability, "write");
-	private final Type loadCap = tf.constructor(capabilitiesStore, IOcapability, "classloader");
-	private final Type logicalCap = tf.constructor(capabilitiesStore, IOcapability, "logical");
-	private final Type watchCap = tf.constructor(capabilitiesStore, IOcapability, "watch");
+	private final Type readCap = tf.constructor(capabilitiesStore, IOcapability, "reading");
+	private final Type writeCap = tf.constructor(capabilitiesStore, IOcapability, "writing");
+	private final Type loadCap = tf.constructor(capabilitiesStore, IOcapability, "classloading");
+	private final Type logicalCap = tf.constructor(capabilitiesStore, IOcapability, "resolving");
+	private final Type watchCap = tf.constructor(capabilitiesStore, IOcapability, "watching");
 
 	public ISet capabilities(ISourceLocation loc) {
 		var vf = IRascalValueFactory.getInstance();

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -46,10 +46,16 @@ import org.rascalmpl.unicode.UnicodeOffsetLengthReader;
 import org.rascalmpl.unicode.UnicodeOutputStreamWriter;
 import org.rascalmpl.uri.ISourceLocationWatcher.ISourceLocationChanged;
 import org.rascalmpl.uri.classloaders.IClassloaderLocationResolver;
+import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
 
+import io.usethesource.vallang.ISet;
+import io.usethesource.vallang.ISetWriter;
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IValueFactory;
+import io.usethesource.vallang.type.Type;
+import io.usethesource.vallang.type.TypeFactory;
+import io.usethesource.vallang.type.TypeStore;
 
 public class URIResolverRegistry {
 	private static final int FILE_BUFFER_SIZE = 8 * 1024;
@@ -1086,6 +1092,49 @@ public class URIResolverRegistry {
 			}
 		}
 
+	}
+
+	// these types must align with their correspondig types in IO.rsc
+	private final TypeFactory tf = TypeFactory.getInstance();
+	private final TypeStore capabilitiesStore = new TypeStore();
+	private final Type IOcapability = tf.abstractDataType(capabilitiesStore, "IOCapability");
+	private final Type readCap = tf.constructor(capabilitiesStore, IOcapability, "read");
+	private final Type writeCap = tf.constructor(capabilitiesStore, IOcapability, "write");
+	private final Type loadCap = tf.constructor(capabilitiesStore, IOcapability, "classloader");
+	private final Type logicalCap = tf.constructor(capabilitiesStore, IOcapability, "logical");
+	private final Type watchCap = tf.constructor(capabilitiesStore, IOcapability, "watch");
+
+	public ISet capabilities(ISourceLocation loc) {
+		var vf = IRascalValueFactory.getInstance();
+		var scheme = loc.getScheme();
+		ISetWriter result = vf.setWriter();
+
+		if (logicalResolvers.containsKey(scheme)) {
+			result.insert(vf.constructor(logicalCap));
+			var resolved = safeResolve(loc);
+
+			if (resolved != loc) {
+				result.insertAll(capabilities(resolved));
+			}
+		}
+
+		if (inputResolvers.containsKey(scheme)) {
+			result.insert(vf.constructor(readCap));
+		}
+
+		if (outputResolvers.containsKey(scheme)) {
+			result.insert(vf.constructor(writeCap));
+		}
+
+		if (classloaderResolvers.containsKey(scheme)) {
+			result.insert(vf.constructor(loadCap));
+		}
+
+		if (watchers.containsKey(scheme)) {
+			result.insert(vf.constructor(watchCap));
+		}
+	
+		return result.done();
 	}
 
 }

--- a/src/org/rascalmpl/uri/jar/JarFileResolver.java
+++ b/src/org/rascalmpl/uri/jar/JarFileResolver.java
@@ -84,11 +84,7 @@ public class JarFileResolver  {
         if (!path.endsWith("/") && !path.isEmpty()) {
             path = path + "/";
         }
-        try {
-            return getFileHierchyCache(jar).directChildren(path);
-        }
-        catch (IOException e) {
-            return new String[0];
-        }
+        
+        return getFileHierchyCache(jar).directChildren(path);
     }
 }


### PR DESCRIPTION
This implements and documents the following function in IO.rsc:

```rascal
data IOCapability
  = reading()
  | writing()
  | classloading()
  | resolving()
  | watching()
  ;

@javaClass{org.rascalmpl.library.Prelude}
java set[IOCapability] capabilities(loc location);
```

Note that this does not provide insight into "file permissions". A location may have the capability of being written to, while it can still receive a PermissionDenied exception when written to. 

The "permissions" feature would be a yet another extention to the capabilities of the URIResolverRegistry.

It is not possible to implement this feature fully on only the _scheme_ information of a `loc`. The reason is that some (many) logical resolvers need actual `authority` and `path` information to be rewritten to a physical location, and this can result in different capabilities per unique path.