### PR TITLE
Refactored error recovery tests so Rascal and Pico syntax are no longer visible in the same module

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/BasicRecoveryTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/BasicRecoveryTests.rsc
@@ -14,10 +14,7 @@
 
 module lang::rascal::tests::concrete::recovery::BasicRecoveryTests
 
-import ParseTree;
-import util::ParseErrorRecovery;
-
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 layout Layout = [\ ]* !>> [\ ];
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ListRecoveryTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ListRecoveryTests.rsc
@@ -17,7 +17,7 @@ module lang::rascal::tests::concrete::recovery::ListRecoveryTests
 import ParseTree;
 import util::ParseErrorRecovery;
 
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 layout Layout = [\ ]* !>> [\ ];
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/NestedRecoveryTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/NestedRecoveryTests.rsc
@@ -14,7 +14,7 @@
 
 module lang::rascal::tests::concrete::recovery::NestedRecoveryTests
 
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 layout Layout = [\ ]* !>> [\ ];
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/NonAsciiTest.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/NonAsciiTest.rsc
@@ -14,7 +14,7 @@
 
 module lang::rascal::tests::concrete::recovery::NonAsciiTest
 
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 
 syntax S = T;

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/PicoRecoveryTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/PicoRecoveryTests.rsc
@@ -18,7 +18,7 @@ import lang::pico::\syntax::Main;
 
 import ParseTree;
 import util::ParseErrorRecovery;
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 Tree parsePico(str input, bool visualize=false) 
     = parser(#Program, allowRecovery=true, allowAmbiguity=true)(input, |unknown:///?visualize=<"<visualize>">|);

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/PrefixSharingTest.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/PrefixSharingTest.rsc
@@ -8,7 +8,7 @@ syntax N = [0-9];
 
 import ParseTree;
 import util::ParseErrorRecovery;
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 import vis::Text;
 import IO;
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/RascalRecoveryTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/RascalRecoveryTests.rsc
@@ -16,7 +16,7 @@ module lang::rascal::tests::concrete::recovery::RascalRecoveryTests
 
 import lang::rascal::\syntax::Rascal;
 
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 bool debugging = false;
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/RecoveryCheckSupport.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/RecoveryCheckSupport.rsc
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2024-2025, NWO-I Centrum Wiskunde & Informatica (CWI)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+module lang::rascal::tests::concrete::recovery::RecoveryCheckSupport
+
+import ParseTree;
+import util::ParseErrorRecovery;
+import String;
+import IO;
+import Grammar;
+import analysis::statistics::Descriptive;
+import util::Math;
+import Set;
+import List;
+import vis::Text;
+
+import lang::rascal::grammar::definition::Modules;
+
+bool checkRecovery(type[&T<:Tree] begin, str input, list[str] expectedErrors, bool visualize=false) {
+    Tree t = parser(begin, allowRecovery=true, allowAmbiguity=true)(input, |unknown:///?visualize=<"<visualize>">|);
+    return checkErrors(t, expectedErrors);
+}
+
+// Print a list of errors
+void printErrors(list[Tree] errors) {
+    for (Tree error <- errors) {
+        println("\'<getErrorText(error)>\'");
+    }
+}
+
+// Check a tree contains exactly the expected error
+bool checkError(Tree t, str expectedError) = checkErrors(t, [expectedError]);
+
+// Check if a tree contains exactly the expected errors
+bool checkErrors(Tree t, list[str] expectedErrors) {
+    list[Tree] errors = findBestParseErrors(t);
+    if (size(errors) != size(expectedErrors)) {
+        println("Expected <size(expectedErrors)> errors, found <size(errors)>");
+        printErrors(errors);
+        return false;
+    }
+
+    for (error <- errors) {
+        str errorText = getErrorText(error);
+        if (errorText notin expectedErrors) {
+            println("Unexpected error: \'<errorText>\'");
+            println("All errors found:");
+            printErrors(errors);
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/RecoveryTestSupport.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/RecoveryTestSupport.rsc
@@ -567,43 +567,6 @@ TestStats runBatchRecoveryTest(RecoveryTestConfig config, TestStats cumulativeSt
     return cumulativeStats;
 }
 
-bool checkRecovery(type[&T<:Tree] begin, str input, list[str] expectedErrors, bool visualize=false) {
-    Tree t = parser(begin, allowRecovery=true, allowAmbiguity=true)(input, |unknown:///?visualize=<"<visualize>">|);
-    return checkErrors(t, expectedErrors);
-}
-
-// Print a list of errors
-void printErrors(list[Tree] errors) {
-    for (Tree error <- errors) {
-        println("\'<getErrorText(error)>\'");
-    }
-}
-
-// Check a tree contains exactly the expected error
-bool checkError(Tree t, str expectedError) = checkErrors(t, [expectedError]);
-
-// Check if a tree contains exactly the expected errors
-bool checkErrors(Tree t, list[str] expectedErrors) {
-    list[Tree] errors = findBestParseErrors(t);
-    if (size(errors) != size(expectedErrors)) {
-        println("Expected <size(expectedErrors)> errors, found <size(errors)>");
-        printErrors(errors);
-        return false;
-    }
-
-    for (error <- errors) {
-        str errorText = getErrorText(error);
-        if (errorText notin expectedErrors) {
-            println("Unexpected error: \'<errorText>\'");
-            println("All errors found:");
-            printErrors(errors);
-            return false;
-        }
-    }
-
-    return true;
-}
-
 str getTestInput(loc testUri) {
     str query = testUri.query;
     loc file = testUri[query = ""];

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ToyRascalRecoveryTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ToyRascalRecoveryTests.rsc
@@ -19,9 +19,8 @@ import lang::rascal::tests::concrete::recovery::ToyRascal;
 import ParseTree;
 import util::ParseErrorRecovery;
 import IO;
-import util::Maybe;
 
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 Tree parseToyRascal(str input, bool visualize=false) {
     Tree result = parser(#start[FunctionDeclaration], allowRecovery=true, allowAmbiguity=true)(input, |unknown:///?visualize=<"<visualize>">|);

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/FlowGraphOutOfMemoryBug.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/FlowGraphOutOfMemoryBug.rsc
@@ -1,10 +1,10 @@
 module lang::rascal::tests::concrete::recovery::bugs::FlowGraphOutOfMemoryBug
 
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
 import lang::rascal::\syntax::Rascal;
 import ParseTree;
 import IO;
-import util::Benchmark;
 import util::ParseErrorRecovery;
 import String;
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/InfiniteLoopBug.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/InfiniteLoopBug.rsc
@@ -12,7 +12,7 @@
 **/
 module lang::rascal::tests::concrete::recovery::bugs::InfiniteLoopBug
 
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 import lang::rascal::\syntax::Rascal;
 import ParseTree;
 import IO;

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/MinimalMultiError.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/MinimalMultiError.rsc
@@ -12,7 +12,7 @@
 **/
 module lang::rascal::tests::concrete::recovery::bugs::MinimalMultiError
 
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 layout Layout = [\ ]* !>> [\ ];
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/MultiErrorPico.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/MultiErrorPico.rsc
@@ -13,7 +13,7 @@
 module lang::rascal::tests::concrete::recovery::bugs::MultiErrorPico
 
 import lang::pico::\syntax::Main;
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 bool multiErrorPico() {
     return checkRecovery(#start[Program], "begin

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/MultiProdRecovery.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/MultiProdRecovery.rsc
@@ -12,7 +12,7 @@
 **/
 module lang::rascal::tests::concrete::recovery::bugs::MultiProdRecovery
 
-import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 
 layout Layout = [\ ]* !>> [\ ];
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/OvertakenNullableBug.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/bugs/OvertakenNullableBug.rsc
@@ -13,6 +13,7 @@
 module lang::rascal::tests::concrete::recovery::bugs::OvertakenNullableBug
 
 
+import lang::rascal::tests::concrete::recovery::RecoveryCheckSupport;
 import lang::rascal::tests::concrete::recovery::RecoveryTestSupport;
 import lang::rascal::\syntax::Rascal;
 import ParseTree;


### PR DESCRIPTION
Both the Pico and Rascal syntax where indirectly imported in the same module.
This refactoring fixes that.