### PR TITLE
feat/bootstrap using main functions

### DIFF
--- a/.github/ISSUE_TEMPLATE/stable-release-manual-testing-template.md
+++ b/.github/ISSUE_TEMPLATE/stable-release-manual-testing-template.md
@@ -51,7 +51,7 @@ First a "pre-release" of the supporting compiler/typechecker tools must be done,
 - [ ] jump-to-definition also works to library modules and inside library modules
 - [ ] clicking in outline jumps to editor to right position
 - [ ] syntax highlighting in editor works
-- [ ] add dependency on another project by editing `RASCAL.MF`: `Required-Libraries: |lib://otherProject|`, import a module and test the type-checker as well as the interpreter for correct resolution
+- [ ] add dependency on another project by editing `pom.xml` `<dependencies> tag, import a module and test the type-checker as well as the interpreter for correct resolution
 - [ ] `import demo::lang::Pico::Plugin; registerPico();` and test the editor of the example pico files (syntax highlighting, menu options)
 - [ ] `import demo::lang::Pico::Plugin; rascal>:edit  demo::lang::Pico::Plugin`
 - [ ] use util::IDEServices:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
           cache: 'maven'
 
       - name: Run Tests
-        run: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Drascal.compile.skip -Drascal.tutor.skip -Drascal.test.memory=14 test
+        run: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Drascal.compile.skip -Drascal.tutor.skip -Drascal.test.memory=2 -Dsurefire.rerunFailingTestsCount=3 test
 
       - uses: codecov/codecov-action@v4
         continue-on-error: true # sometimes this one fails, that shouldn't stop a build
@@ -71,7 +71,7 @@ jobs:
 
       - name: Test if release # just to be extra sure for a release
         if: startsWith(github.ref, 'refs/tags/v')
-        run: mvn -Drascal.test.memory=10 -Drascal.compile.skip -Drascal.tutor.skip test 
+        run: mvn -Dsurefire.rerunFailingTestsCount=3 -Drascal.test.memory=2 -Drascal.compile.skip -Drascal.tutor.skip test 
 
       - name: Attach artifact 
         id: build-artifact
@@ -151,7 +151,7 @@ jobs:
 
       - name: Run Tests
         # single quotes to help windows deal with argument splitting
-        run: mvn -B '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn' '-Drascal.compile.skip' '-Drascal.tutor.skip' '-Drascal.test.memory=2' test
+        run: mvn -B '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn' '-Drascal.compile.skip' '-Drascal.tutor.skip' '-Dsurefire.rerunFailingTestsCount=3' '-Drascal.test.memory=2' test
 
       - uses: codecov/codecov-action@v4
         continue-on-error: true # sometimes this one fails, that shouldn't stop a build
@@ -181,7 +181,7 @@ jobs:
         run: bash src/org/rascalmpl/compiler/lang/rascalcore/check/tests/download-test-jars.sh
 
       - name: Run Tests
-        run: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pcompiler-tests -Drascal.compile.skip -Drascal.tutor.skip -Drascal.test.memory=7 test
+        run: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pcompiler-tests -Drascal.compile.skip -Drascal.tutor.skip -Drascal.test.memory=2 -Dsurefire.rerunFailingTestsCount=3 test
 
       - uses: codecov/codecov-action@v4
         continue-on-error: true # sometimes this one fails, that shouldn't stop a build

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC25</version>
+    <version>0.41.0-RC26-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC25</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>3</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
-        <rascal-maven.version>0.30.0-RC7</rascal-maven.version>
+        <rascal-maven.version>0.30.0-RC8</rascal-maven.version>
         <jline.version>3.27.0</jline.version>
     </properties>
 
@@ -132,6 +132,10 @@
                 <version>${rascal-maven.version}</version>
                 <configuration>
                     <bootstrapRascalVersion>0.41.0-RC24</bootstrapRascalVersion>
+                    <parallel>true</parallel>
+                    <parallelPreChecks>
+                        <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>
+                    </parallelPreChecks>
                 </configuration>
                 <executions>
                     <execution>
@@ -141,6 +145,10 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
+                            <parallel>true</parallel>
+                            <parallelPreChecks>
+                               <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>
+                            </parallelPreChecks>
                             <errorsAsWarnings>false</errorsAsWarnings> 
                             <bin>${project.build.outputDirectory}</bin>
                             <srcs>
@@ -149,7 +157,6 @@
                             <libs>
                             </libs>
                             <srcIgnores>
-                                <ignore>${project.basedir}/src/org/rascalmpl/tutor/lang/rascal/tutor/examples/</ignore>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/experiments</ignore>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/resource</ignore>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/tests</ignore>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC24-SNAPSHOT</version>
+    <version>0.41.0-RC24</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v0.41.0-RC24</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC29-SNAPSHOT</version>
+    <version>0.41.0-RC29</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC26</tag>
+        <tag>v0.41.0-RC29</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -131,52 +131,37 @@
                 <artifactId>rascal-maven-plugin</artifactId>
                 <version>${rascal-maven.version}</version>
                 <configuration>
-                    <rascalBootstrapVersion>0.41.0-RC21</rascalBootstrapVersion>
-                    <errorsAsWarnings>false</errorsAsWarnings> <!-- only allowed during intermediate bootstrap cycles -->
-                    <bin>${project.build.outputDirectory}</bin>
-                    <srcs>
-                        <src>${project.basedir}/src/org/rascalmpl/library</src>
-                        <!-- do not typecheck the checker or the tutor yet 
-                        <src>${project.basedir}/src/org/rascalmpl/tutor</src>
-                        <src>${project.basedir}/src/org/rascalmpl/compiler</src>
-                        -->
-                    </srcs>
-                    <sourceLookup>|std:///|</sourceLookup>
-                    <funding>${project.basedir}/FUNDING</funding>
-                    <citation>${project.basedir}/CITATION.md</citation>
-                    <issues>|https://github.com/usethesource/rascal/issues|</issues>
-                    <srcIgnores>
-                        <ignore>${project.basedir}/src/org/rascalmpl/tutor/lang/rascal/tutor/examples/</ignore>
-                        <ignore>${project.basedir}/src/org/rascalmpl/library/experiments</ignore>
-                        <ignore>${project.basedir}/src/org/rascalmpl/library/resource</ignore>
-                        <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/tests</ignore>
-                        <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/grammar/tests</ignore>
-                        <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/syntax/tests</ignore>
-                    </srcIgnores>
-                    <enableStandardLibrary>false</enableStandardLibrary>
-                    <parallel>true</parallel>
-                    <parallelPreChecks>
-                        <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>
-                    </parallelPreChecks>
+                    <bootstrapRascalVersion>0.41.0-RC22</bootstrapRascalVersion>
                 </configuration>
                 <executions>
-                    <!-- commented out for bootstrap purposes
                     <execution>
                         <id>it-compile</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                            <!-- only allowed during intermediate bootstrap cycles -->
+                            <errorsAsWarnings>false</errorsAsWarnings> 
+                            <bin>${project.build.outputDirectory}</bin>
+                            <srcs>
+                                <src>${project.basedir}/src/org/rascalmpl/library</src>
+                            </srcs>
+                            <srcIgnores>
+                                <ignore>${project.basedir}/src/org/rascalmpl/tutor/lang/rascal/tutor/examples/</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/experiments</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/resource</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/tests</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/grammar/tests</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/syntax/tests</ignore>
+                            </srcIgnores>
+                            <enableStandardLibrary>false</enableStandardLibrary>
+                            <parallel>true</parallel>
+                            <parallelPreChecks>
+                                <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>
+                            </parallelPreChecks>
+                        </configuration>
                     </execution>
-                    <execution>
-                        <id>it-package</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                    </execution> -->
-
-		    <!-- commented out while bootstrapping the tutor
                     <execution>
                         <id>default-cli</id>
                         <phase>compile</phase>
@@ -188,6 +173,8 @@
                             <enableStandardLibrary>false</enableStandardLibrary>
                             <errorsAsWarnings>false</errorsAsWarnings>
                             <bin>${project.build.outputDirectory}</bin>
+                            <funding>${project.basedir}/FUNDING</funding>
+                            <citation>${project.basedir}/CITATION.md</citation>
                             <license>${project.basedir}/LICENSE</license>
                             <sources>|http://github.com/usethesource/rascal/blob/main|</sources>
                             <issues>|http://github.com/usethesource/rascal/issues|</issues>
@@ -198,8 +185,17 @@
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal</ignore>
                             </ignores>
                         </configuration>
-                        </execution>
-		    -->
+                    </execution>
+                    <execution>
+                        <id>it-package</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <sourceLookup>|std:///|</sourceLookup>
+                        </configuration>
+                    </execution> 
                 </executions>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC24</version>
+    <version>0.41.0-RC25-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC24</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,11 @@
                             </srcs>
                             <srcIgnores>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/experiments</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/resource</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/tests</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/grammar/tests</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/syntax/tests</ignore>
                             </srcIgnores>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC28-SNAPSHOT</version>
+    <version>0.41.0-RC28</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC26</tag>
+        <tag>v0.41.0-RC28</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC26-SNAPSHOT</version>
+    <version>0.41.0-RC26</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v0.41.0-RC26</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
                     <bootstrapRascalVersion>0.41.0-RC23</bootstrapRascalVersion>
                 </configuration>
                 <executions>
+                    <!--
                     <execution>
                         <id>it-compile</id>
                         <phase>compile</phase>
@@ -141,12 +142,13 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <!-- only allowed during intermediate bootstrap cycles -->
                             <errorsAsWarnings>false</errorsAsWarnings> 
                             <bin>${project.build.outputDirectory}</bin>
                             <srcs>
                                 <src>${project.basedir}/src/org/rascalmpl/library</src>
                             </srcs>
+                            <libs>
+                            </libs>
                             <srcIgnores>
                                 <ignore>${project.basedir}/src/org/rascalmpl/tutor/lang/rascal/tutor/examples/</ignore>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/experiments</ignore>
@@ -155,11 +157,6 @@
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/grammar/tests</ignore>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/syntax/tests</ignore>
                             </srcIgnores>
-                            <enableStandardLibrary>false</enableStandardLibrary>
-                            <parallel>true</parallel>
-                            <parallelPreChecks>
-                                <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>
-                            </parallelPreChecks>
                         </configuration>
                     </execution>
                     <execution>
@@ -195,7 +192,8 @@
                         <configuration>
                             <sourceLookup>|std:///|</sourceLookup>
                         </configuration>
-                    </execution> 
+                        </execution> 
+                    -->
                 </executions>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -131,13 +131,12 @@
                 <artifactId>rascal-maven-plugin</artifactId>
                 <version>${rascal-maven.version}</version>
                 <configuration>
-                    <bootstrapRascalVersion>0.41.0-RC24</bootstrapRascalVersion>
+                    <bootstrapRascalVersion>0.41.0-RC25</bootstrapRascalVersion>
                     <parallel>true</parallel>
                     <parallelPreChecks>
                         <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>
                     </parallelPreChecks>
                 </configuration>
-                <!--
                 <executions>
                     <execution>
                         <id>it-compile</id>
@@ -206,7 +205,6 @@
                         </configuration>
                         </execution> 
                     </executions>
-                -->
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>3</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
-        <rascal-maven.version>0.30.0-RC10</rascal-maven.version>
+        <rascal-maven.version>0.30.0-RC11</rascal-maven.version>
         <jline.version>3.27.0</jline.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -621,6 +621,7 @@
                                 <include>**/org/rascalmpl/compiler/**/*Tests.java</include>
                                 <include>**/org/rascalmpl/compiler/**/*Test.java</include>
                             </includes>
+
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC23-SNAPSHOT</version>
+    <version>0.41.0-RC24-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC22</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->
@@ -32,7 +32,7 @@
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>3</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
-        <rascal-maven.version>0.30.0-RC5</rascal-maven.version>
+        <rascal-maven.version>0.30.0-RC7</rascal-maven.version>
         <jline.version>3.27.0</jline.version>
     </properties>
 
@@ -131,7 +131,7 @@
                 <artifactId>rascal-maven-plugin</artifactId>
                 <version>${rascal-maven.version}</version>
                 <configuration>
-                    <bootstrapRascalVersion>0.41.0-RC22</bootstrapRascalVersion>
+                    <bootstrapRascalVersion>0.41.0-RC23</bootstrapRascalVersion>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC25-SNAPSHOT</version>
+    <version>0.41.0-RC25</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v0.41.0-RC25</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->
@@ -137,6 +137,7 @@
                         <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>
                     </parallelPreChecks>
                 </configuration>
+                <!--
                 <executions>
                     <execution>
                         <id>it-compile</id>
@@ -204,7 +205,8 @@
                             <sourceLookup>|std:///|</sourceLookup>
                         </configuration>
                         </execution> 
-                </executions>
+                    </executions>
+                -->
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC28</version>
+    <version>0.41.0-RC29-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC28</tag>
+        <tag>v0.41.0-RC26</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC29</version>
+    <version>0.41.0-RC30-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC29</tag>
+        <tag>v0.41.0-RC26</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>3</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
-        <rascal-maven.version>0.30.0-RC11</rascal-maven.version>
+        <rascal-maven.version>0.30.0-RC13-SNAPSHOT</rascal-maven.version>
         <jline.version>3.27.0</jline.version>
     </properties>
 
@@ -131,12 +131,12 @@
                 <artifactId>rascal-maven-plugin</artifactId>
                 <version>${rascal-maven.version}</version>
                 <configuration>
-                    <bootstrapRascalVersion>0.41.0-RC25</bootstrapRascalVersion>
+                    <bootstrapRascalVersion>0.41.0-RC29</bootstrapRascalVersion>
                     <parallel>true</parallel>
                     <parallelPreChecks>
                         <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>
                     </parallelPreChecks>
-                    </configuration> <!--
+                    </configuration> 
                 <executions>
                     <execution>
                         <id>it-compile</id>
@@ -203,7 +203,7 @@
                             <sourceLookup>|std:///|</sourceLookup>
                         </configuration>
                         </execution> 
-                    </executions>-->
+                    </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC26</version>
+    <version>0.41.0-RC27-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC27</version>
+    <version>0.41.0-RC28-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC27</tag>
+        <tag>v0.41.0-RC26</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>3</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
-        <rascal-maven.version>0.30.0-RC9-SNAPSHOT</rascal-maven.version>
+        <rascal-maven.version>0.30.0-RC9</rascal-maven.version>
         <jline.version>3.27.0</jline.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,10 +131,9 @@
                 <artifactId>rascal-maven-plugin</artifactId>
                 <version>${rascal-maven.version}</version>
                 <configuration>
-                    <bootstrapRascalVersion>0.41.0-RC23</bootstrapRascalVersion>
+                    <bootstrapRascalVersion>0.41.0-RC24</bootstrapRascalVersion>
                 </configuration>
                 <executions>
-                    <!--
                     <execution>
                         <id>it-compile</id>
                         <phase>compile</phase>
@@ -193,7 +192,6 @@
                             <sourceLookup>|std:///|</sourceLookup>
                         </configuration>
                         </execution> 
-                    -->
                 </executions>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC25</version>
+    <version>0.41.0-RC25-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC25</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>3</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
-        <rascal-maven.version>0.30.0-RC8</rascal-maven.version>
+        <rascal-maven.version>0.30.0-RC9-SNAPSHOT</rascal-maven.version>
         <jline.version>3.27.0</jline.version>
     </properties>
 
@@ -184,9 +184,9 @@
                             <srcs>
                                 <src>${project.basedir}/src/org/rascalmpl/library</src>
                             </srcs>
-                            <ignores>
+                            <srcIgnores>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal</ignore>
-                            </ignores>
+                            </srcIgnores>
                         </configuration>
                     </execution>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>3</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
-        <rascal-maven.version>0.30.0-RC9</rascal-maven.version>
+        <rascal-maven.version>0.30.0-RC10</rascal-maven.version>
         <jline.version>3.27.0</jline.version>
     </properties>
 
@@ -136,7 +136,7 @@
                     <parallelPreChecks>
                         <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>
                     </parallelPreChecks>
-                </configuration>
+                    </configuration> <!--
                 <executions>
                     <execution>
                         <id>it-compile</id>
@@ -173,7 +173,6 @@
                         </goals>
                         <configuration>
                             <isPackageCourse>false</isPackageCourse>
-                            <enableStandardLibrary>false</enableStandardLibrary>
                             <errorsAsWarnings>false</errorsAsWarnings>
                             <bin>${project.build.outputDirectory}</bin>
                             <funding>${project.basedir}/FUNDING</funding>
@@ -204,7 +203,7 @@
                             <sourceLookup>|std:///|</sourceLookup>
                         </configuration>
                         </execution> 
-                    </executions>
+                    </executions>-->
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC25-SNAPSHOT</version>
+    <version>0.41.0-RC25</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v0.41.0-RC25</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>rascal</artifactId>
-    <version>0.41.0-RC27-SNAPSHOT</version>
+    <version>0.41.0-RC27</version>
     <packaging>jar</packaging>
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/rascal.git</developerConnection>
-        <tag>v0.41.0-RC26</tag>
+        <tag>v0.41.0-RC27</tag>
     </scm>
 
     <!-- dependency resolution configuration (usethesource) -->

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
@@ -132,7 +132,7 @@ ModuleStatus rascalTModelForLocs(
     list[Message](str qualifiedModuleName, lang::rascal::\syntax::Rascal::Module M, map[str,TModel] transient_tms, ModuleStatus ms, RascalCompilerConfig compilerConfig) codgen
 ){
     pcfg = compilerConfig.typepalPathConfig;
-   
+    
     if(compilerConfig.logPathConfig) { iprintln(pcfg); }
 
     set[Message] msgs = validatePathConfigForChecker(pcfg, mlocs[0]);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
@@ -31,8 +31,13 @@ import IO;
 import ValueIO;
 import ParseTree;
 import Location;
+import util::Reflective;
 
-void main(PathConfig pcfg = getProjectPathConfig(|cwd:///|), loc sourceLookup = "") {
+void main(PathConfig pcfg = getProjectPathConfig(|cwd:///|), loc sourceLookup = |unknown:///|) {
+    if (!(sourceLookup?)) {
+      throw "sourceLookup is not an optional parameter. The packager needs something like `|mvn://groupId--artifactId--version|`";
+    }
+
     package(pcfg.srcs, pcfg.bin, sourceLookup);
 }
 
@@ -43,7 +48,7 @@ void package(list[loc] srcs, loc bin, loc sourceLookup) {
 
 void packageSourceFiles(list[loc] srcs, loc bin) {
     for (folder <- srcs, file <- find(folder, "rsc")) {
-      copyFile(file, bin + relativize(folder, file).path);
+      copy(file, bin + relativize(folder, file).path);
     }
 }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
@@ -31,7 +31,7 @@ import IO;
 import ValueIO;
 import ParseTree;
 
-int main(PathConfig pcfg = getProjectPathConfig(|cwd:///|), str sourceLookup = "") {
+void main(PathConfig pcfg = getProjectPathConfig(|cwd:///|), str sourceLookup = "") {
   loc lookupTarget = readTextValueString(#loc, sourceLookup);
   package(pcfg.srcs, pcfg.bin, lookupTarget);
 }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
@@ -30,62 +30,55 @@ import util::FileSystem;
 import IO;
 import ValueIO;
 import ParseTree;
+import Location;
 
-void main(PathConfig pcfg = getProjectPathConfig(|cwd:///|), str sourceLookup = "") {
-  loc lookupTarget = readTextValueString(#loc, sourceLookup);
-  package(pcfg.srcs, pcfg.bin, lookupTarget);
+void main(PathConfig pcfg = getProjectPathConfig(|cwd:///|), loc sourceLookup = "") {
+    package(pcfg.srcs, pcfg.bin, sourceLookup);
 }
 
 void package(list[loc] srcs, loc bin, loc sourceLookup) {
-  packageSourceFiles(srcs, bin);  
-  rewriteTypeFiles(srcs, bin, sourceLookup);
+    packageSourceFiles(srcs, bin);  
+    rewriteTypeFiles(srcs, bin, sourceLookup);
 }
 
 void packageSourceFiles(list[loc] srcs, loc bin) {
-  for (folder <- srcs, file <- find(folder, "rsc")) {
-    copyFile(file, bin + relativize(folder, file));
-  }
+    for (folder <- srcs, file <- find(folder, "rsc")) {
+      copyFile(file, bin + relativize(folder, file).path);
+    }
 }
 
 void rewriteTypeFiles(list[loc] srcs, loc bin, loc sourceLookup) {
-  for (file <- find(bin, "tpl")) {
-     model = readBinaryValueFile(file);
-     model = rewriteTypeModel(model, paths(srcs), sourceLookup);
-     writeBinaryValueFile(file, model);
-  }
+    for (file <- find(bin, "tpl")) {
+        model = readBinaryValueFile(file);
+        model = rewriteTypeModel(model, paths(srcs), sourceLookup);
+        writeBinaryValueFile(file, model);
+    }
 }
 
 // map all files to their relative path within their respective source folder 
 map[loc, str] paths(list[loc] srcs) 
-  = (l:relativize(src, l) | src <- srcs, /file(loc l) <- crawl(src));
+    = (l:relativize(src, l).path | src <- srcs, /file(loc l) <- crawl(src));
 
 // we do not insist on a specific type here for forward/backward compatibility's sake
 value rewriteTypeModel(value model, map[loc,str] paths, loc sourceLookup) 
-  = visit(model) {
-      // any location in the wild:
-      case loc l => inheritPosition(sourceLookup + paths[l.top], l)
-        when l.top in paths
-        
-      // \loc annotations on Trees are not visited by `visit` automatically
-      case Tree t => t[@\loc = inheritPosition(sourceLookup + paths[Top], t@\loc)]
-        when t@\loc?, loc Top := t@\loc.top, Top in paths
-  };
-
-// compute a relative path of a file for a given base folder, if the file is indeed nested inside the given folder
-str relativize(loc folder, loc file) = relativize(folder.path, file.path) 
-  when folder.scheme == file.scheme,
-       folder.authority == file.authority;
-        
-str relativize(str folder, /^<folder><path:.*>$/) = path;
+    = visit(model) {
+          // any location in the wild:
+          case loc l => inheritPosition(sourceLookup + paths[l.top], l)
+               l.top in paths
+            
+          // \loc annotations on Trees are not visited by `visit` automatically
+          case Tree t => t[@\loc = inheritPosition(sourceLookup + paths[Top], t@\loc)]
+              when t@\loc?, loc Top := t@\loc.top, Top in paths
+    };
 
 loc inheritPosition(loc new, loc original) {
-  if (original.begin?) {
-     return new(original.offset, original.length, original.begin, original.end);
-  }
-  else if (original.offset?) {
-     return new(original.offset, original.length);
-  }
-  else {
-     return new;
-  }
+    if (original.begin?) {
+        return new(original.offset, original.length, original.begin, original.end);
+    }
+    else if (original.offset?) {
+        return new(original.offset, original.length);
+    }
+    else {
+        return new;
+    }
 }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
@@ -64,7 +64,7 @@ value rewriteTypeModel(value model, map[loc,str] paths, loc sourceLookup)
     = visit(model) {
           // any location in the wild:
           case loc l => inheritPosition(sourceLookup + paths[l.top], l)
-               l.top in paths
+              when l.top in paths
             
           // \loc annotations on Trees are not visited by `visit` automatically
           case Tree t => t[@\loc = inheritPosition(sourceLookup + paths[Top], t@\loc)]

--- a/src/org/rascalmpl/interpreter/Evaluator.java
+++ b/src/org/rascalmpl/interpreter/Evaluator.java
@@ -736,7 +736,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
             }
         }
 
-        if (params.get("project") != null) {
+        if (params.get("project") != null && pathConfigName != null) {
             // we have a project that can use automatic detection of PathConfig parameters.
             var pcfg = PathConfig.fromSourceProjectRascalManifest((ISourceLocation) params.get("project"), RascalConfigMode.INTERPRETER, true);
             var cons = pcfg.asConstructor();
@@ -761,6 +761,8 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
                     }
                 }
             }
+
+            params.put(pathConfigName, cons);
         }
         else if (pathConfigName != null) {
             // Fold back the PathConfig-specific parameters,

--- a/src/org/rascalmpl/library/IO.rsc
+++ b/src/org/rascalmpl/library/IO.rsc
@@ -775,7 +775,7 @@ java void unwatch(loc src, bool recursive, void (LocationChangeEvent event) watc
 default an abstract (slower) ClassLoader can be built using `read` capabilities on `.class` files.
 * `watch` means that for this scheme a native file watcher can be instantiated. By default 
 a slower more generic file watcher is created based on capturing `write` actions.
-   * ((logical)) schemes provide a transparent facade for more abstract URIs. The abstract URI is 
+   * ((resolving)) schemes provide a transparent facade for more abstract URIs. The abstract URI is 
 rewritten to a more concrete URI on-demand. Logical URIs can be nested arbitrarily.
 
 These capabilities extend naturally to other IO functions that use the internal versions of the above functionality, 

--- a/src/org/rascalmpl/library/ParseTree.rsc
+++ b/src/org/rascalmpl/library/ParseTree.rsc
@@ -387,7 +387,6 @@ syntax Exp
     = Number
     | left Exp "+" Exp
     ;
-
 import ParseTree;
 ```
 Seeing that `parse` returns a parse tree:

--- a/src/org/rascalmpl/library/analysis/m3/Core.rsc
+++ b/src/org/rascalmpl/library/analysis/m3/Core.rsc
@@ -9,7 +9,7 @@ The M3 ((Library:analysis::m3::Core)) defines basic concepts such as:
 *  uses: where declared artifacts are used
 *  types: which artifacts has which types
 
-From this ((Library:analysis::m3::Core)) is supposed to be extended with features specific for a programming language. See for example [Java M3]((lang::java::m3::Core)).
+From this ((Library:analysis::m3::Core)) is supposed to be extended with features specific for a programming language. 
 }
 @benefits{
 *  Qualified names in the shape of a location are a uniform and generic way of identifying source code artifacts, that can be extended across languages, projects, and versions.

--- a/src/org/rascalmpl/library/analysis/m3/TypeSymbol.rsc
+++ b/src/org/rascalmpl/library/analysis/m3/TypeSymbol.rsc
@@ -9,8 +9,6 @@ class and interface definitions which coincide with types, another may have high
 As a basic principle, the symbols for declared types always link to their definition in the source code using a location value, while other implicit types do not have such a link (i.e. `int` and `void`).
 
 We cater for languages to have a subtype relation to be defined, and a least upper bound computation. 
-
-You will find an interesting examples in ((lang::java::m3::TypeSymbol)).
 }
 @benefits{
 * symbolic types can be analyzed and manipulated symbolically, i.e. to instatiate parametrized types.

--- a/src/org/rascalmpl/library/lang/csv/IO.rsc
+++ b/src/org/rascalmpl/library/lang/csv/IO.rsc
@@ -77,14 +77,14 @@ Reading the values in fields is straightforward, except for the case that the te
 Given is the follwing file `ex1.csv`:
 
 ```rascal
-((|lib://rascal/org/rascalmpl/library/lang/csv/examples/ex1.csv|))
+((|project://rascal/src/org/rascalmpl/library/lang/csv/examples/ex1.csv|))
 ```
 
 We can read it in various ways:
 
 ```rascal-shell
 import lang::csv::IO;
-R1 = readCSV(#rel[int position, str artist, str title, int year],  |lib://rascal/org/rascalmpl/library/lang/csv/examples/ex1.csv|, separator = ";");
+R1 = readCSV(#rel[int position, str artist, str title, int year],  |project://rascal/src/org/rascalmpl/library/lang/csv/examples/ex1.csv|, separator = ";");
 ```
 Now we can, for instance, select one of the fields of `R1`:
 
@@ -94,7 +94,7 @@ R1.artist;
 It is also possible to infer the type:
 
 ```rascal-shell,continue
-R1 = readCSV(|lib://rascal/org/rascalmpl/library/lang/csv/examples/ex1.csv|, separator = ";");
+R1 = readCSV(|project://rascal/src/org/rascalmpl/library/lang/csv/examples/ex1.csv|, separator = ";");
 ```
 }
 @javaClass{org.rascalmpl.library.lang.csv.IO}

--- a/src/org/rascalmpl/library/lang/csv/IO.rsc
+++ b/src/org/rascalmpl/library/lang/csv/IO.rsc
@@ -132,7 +132,6 @@ rel[int position, str artist, str title, int year] R1 = {
 };
 // we can write the CSV with a header row:
 writeCSV(#rel[int position, str artist, str title, int year], R1, |tmp:///ex1a.csv|);
-
 // or write it without the header row:
 writeCSV(#rel[int, str, str, int], R1, |tmp:///ex1b.csv|, header = false, separator = ";");
 ```

--- a/src/org/rascalmpl/library/lang/json/IO.rsc
+++ b/src/org/rascalmpl/library/lang/json/IO.rsc
@@ -53,8 +53,7 @@ This example demonstrates serializing:
 ```rascal-shell
 import lang::json::IO;
 data Size = xxs() | xs() | s() | m() | l() | xl() | xxl();
-data Person
-  = person(str firstName, str lastName, datetime birth, int height=0, Size size = m());
+data Person = person(str firstName, str lastName, datetime birth=$1977-05-17T06:00:00.000+00:00$;, int height=0, Size size = m());
 example = person("Santa", "Class", height=175, size=xxl());
 asJSON(example, dateTimeFormat="YYYY-MM-DD");
 ```

--- a/src/org/rascalmpl/library/lang/xml/DOM.rsc
+++ b/src/org/rascalmpl/library/lang/xml/DOM.rsc
@@ -79,15 +79,12 @@ public Node element(str name, list[Node] kids) = element(none(), name, kids);
 
 
 @synopsis{Parse an XML document and return a DOM instance.}
-@description{
-
-}
 @examples{
 Read the sample note file, parse it, and construct a DOM instance.
 ```rascal-shell
 import IO;
 import lang::xml::DOM;
-N = readFile(|lib://rascal/org/rascalmpl/library/lang/xml/examples/note.xml|);
+N = readFile(|project://rascal/src/org/rascalmpl/library/lang/xml/examples/note.xml|);
 parseXMLDOM(N);
 ```
 
@@ -105,7 +102,7 @@ Read the sample note file, parse it, and construct a DOM instance (using `parseX
 ```rascal-shell
 import IO;
 import lang::xml::DOM;
-N = readFile(|lib://rascal/org/rascalmpl/library/lang/xml/examples/note.xml|);
+N = readFile(|project://rascal/src/org/rascalmpl/library/lang/xml/examples/note.xml|);
 parseXMLDOMTrim(N);
 ```
 All whitespace characters have been removed and do not occur in the trimmed DOM instance.
@@ -121,7 +118,7 @@ Read the sample note file, parse it, construct a DOM instance, and convert it to
 ```rascal-shell
 import IO;
 import lang::xml::DOM;
-F = readFile(|lib://rascal/org/rascalmpl/library/lang/xml/examples/note.xml|);
+F = readFile(|project://rascal/src/org/rascalmpl/library/lang/xml/examples/note.xml|);
 println(F);
 S = xmlRaw(parseXMLDOM(F));
 println(S);
@@ -138,7 +135,7 @@ Read the sample note file, parse it, construct a DOM instance, and convert it to
 ```rascal-shell
 import IO;
 import lang::xml::DOM;
-F = readFile(|lib://rascal/org/rascalmpl/library/lang/xml/examples/note.xml|);
+F = readFile(|project://rascal/src/org/rascalmpl/library/lang/xml/examples/note.xml|);
 println(F);
 S = xmlCompact(parseXMLDOM(F));
 println(S);
@@ -156,7 +153,7 @@ Read the sample note file, parse it, construct a DOM instance, and convert it to
 ```rascal-shell
 import IO;
 import lang::xml::DOM;
-F = readFile(|lib://rascal/org/rascalmpl/library/lang/xml/examples/note.xml|);
+F = readFile(|project://rascal/src/org/rascalmpl/library/lang/xml/examples/note.xml|);
 println(F);
 S = xmlPretty(parseXMLDOM(F));
 println(S);

--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -312,7 +312,7 @@ public class PathConfig {
      * are, which libraries to reference and which classpath entries to add. If this PathConfig is
      * for the interpreter it adds more folders to the source path than if its for the compiler.
      * 
-     * If library dependencies exist for open projects in the same IDE, via the lib://libName, project://libName
+     * If library dependencies exist for open projects in the same IDE, via the pom artifactId == libName and project://libName
      * correspondence, then the target and source folders of the projects are added rather then
      * the jar files. For compiler configs this works differently than for interpreter configs.
      * The latter adds source folders to the sources while the former adds target folders to the libraries.

--- a/src/org/rascalmpl/library/vis/Graphs.rsc
+++ b/src/org/rascalmpl/library/vis/Graphs.rsc
@@ -100,7 +100,7 @@ styles += [
     )
 ];
 // and draw again (while adding the grandparent edges too)
-graph(g + (g o g), cytoGraphConfig(nodeClassifier=nodeClassifier, edgeClassifier=edgeClassifier, styles=styles, \layout=lyt))
+graph(g + (g o g), cfg=cytoGraphConfig(nodeClassifier=nodeClassifier, edgeClassifier=edgeClassifier, styles=styles, \layout=lyt))
 ```    
 }
 data CytoGraphConfig = cytoGraphConfig(

--- a/src/org/rascalmpl/shell/AbstractCommandlineTool.java
+++ b/src/org/rascalmpl/shell/AbstractCommandlineTool.java
@@ -55,7 +55,11 @@ public abstract class AbstractCommandlineTool {
                 
                 IValue result = eval.main(monitor, mainModule, "main", args);
                 
-                if (result.getType().isInteger()) {
+                if (result == null) {
+                    // void main
+                    System.exit(0);
+                }
+                else if (result.getType().isInteger()) {
                     System.exit(((IInteger) result).intValue());
                 }
                 else {

--- a/src/org/rascalmpl/shell/RascalPackage.java
+++ b/src/org/rascalmpl/shell/RascalPackage.java
@@ -2,6 +2,6 @@ package org.rascalmpl.shell;
 
 public class RascalPackage extends AbstractCommandlineTool {
     public static void main(String[] args) {
-        main("lang::rascalcore::package::Packager", new String[] { }, args);
+        main("lang::rascalcore::package::Packager", new String[] {"org/rascalmpl/compiler"}, args);
     }
 }

--- a/src/org/rascalmpl/tutor/lang/rascal/tutor/Compiler.rsc
+++ b/src/org/rascalmpl/tutor/lang/rascal/tutor/Compiler.rsc
@@ -67,13 +67,21 @@ public void defaultCompile(bool clean=false) {
 }
 
 int main(PathConfig pcfg = getProjectPathConfig(|cwd:///|), 
-  loc license=|unknown:///|, loc citation = |unknown:///|, loc funding=|unknown:///|, loc releaseNotes=|unknown:///|,
-  bool errorsAsWarnings=false, bool warningsAsErrors=false) {
+  loc license=|unknown:///|, 
+  loc citation = |unknown:///|, 
+  loc funding=|unknown:///|, 
+  loc releaseNotes=|unknown:///|,
+  bool errorsAsWarnings=false, 
+  bool warningsAsErrors=false, 
+  bool isPackageCourse=true, 
+  str packageName="noPackageName") {
 
   if (license?) pcfg.license = license;
   if (citation?) pcfg.citation = citation;
   if (funding?) pcfg.funding = funding;
   if (releaseNotes?) pcfg.releaseNotes = releaseNotes;
+  if (isPackageCourse?) pcfg.isPackageCourse = isPackageCourse;
+  if (packageName?) pcfg.packageName = packageName;
 
   messages = compile(pcfg);
   
@@ -241,19 +249,6 @@ void generatePackageIndex(PathConfig pcfg) {
     '    \</dependency\>
     '\</dependencies\> 
     '```
-    '**and** change the `Require-Libraries` field in `/path/to/yourProjectName/META-INF/RASCAL.MF` like so:
-    '
-    '```MF
-    'Manifest-Version: 0.0.1
-    'Project-Name: yourProjectName
-    'Source: path/to/src
-    'Require-Libraries: |lib://<pcfg.packageName>|
-    '
-    '
-    '```
-    ':::info
-    'dot.MF files _must_ end with an empty line.
-    ':::
     ");
 }
 


### PR DESCRIPTION
- **configured each stage separately: compile, tutor, package, and bumped the bootstrap version**
- **bumped bootstrap version and mvn plugin version**
- **turned off compilation to get a clean bootstrap version of the interpreter and the main functions**
- **finished the main:PathConfig feature**
- **finished special -project parameter**
- **[maven-release-plugin] prepare release v0.41.0-RC24**
- **[maven-release-plugin] prepare for next development iteration**
- **enabled bootstrap again and now booting from 0.41.0-RC24**
- **bumped maven plugin to 0.30.0-RC8**
- **configuration of ignores improved**
- **fixed some documentation errors**
- **squashed a number of documentation errors**
- **fixed more doc stuff**
- **set maven-plugin version to 0.30.0-RC9**
- **str to loc parameter and re-indented the packager**
- **added missing library location for the packager**
- **disabled bootstrap again**
- **fixed version**
- **[maven-release-plugin] prepare release v0.41.0-RC25**
- **[maven-release-plugin] prepare for next development iteration**
- **allocate 2Gb to all test runners again, since experimenting with more memory did not help. Set surefire failed test rerun tries to 3 to avoid having to click rerun ourselves all the time.**
- **bumped bootstrap version to 0.41.0-RC25 and reactived bootstrap**
- **turned off bootstrap again for first boot step**
- **fixed minor issues in tutor and added isPackageCourse and packageName parameters**
- **bumped to maven-plugin 0.30.0-RC11**
- **[maven-release-plugin] prepare release v0.41.0-RC26**
- **[maven-release-plugin] prepare for next development iteration**
- **fixed typo**
- **[maven-release-plugin] prepare release v0.41.0-RC27**
- **[maven-release-plugin] prepare for next development iteration**
- **more fixes**
- **[maven-release-plugin] prepare release v0.41.0-RC28**
- **[maven-release-plugin] prepare for next development iteration**
- **fixed support for void return of main functions**
- **[maven-release-plugin] prepare release v0.41.0-RC29**
- **[maven-release-plugin] prepare for next development iteration**
- **reactivated bootstrap and depending on 0.41.0-RC29**
