### PR TITLE
Fix cleared typestore losing constructors

### DIFF
--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -3949,13 +3949,20 @@ public class Prelude {
 
 		private final IValueFactory values;
 
-		private static final Type deleted;
-		private static final Type created;
-		private static final Type modified;
-		private static final Type file;
-		private static final Type directory;
-		private static final Type changeEvent;
-		static {
+		private final Type deleted;
+		private final Type created;
+		private final Type modified;
+		private final Type file;
+		private final Type directory;
+		private final Type changeEvent;
+
+		public ReleasableCallback(ISourceLocation src, boolean recursive, IFunction target, IValueFactory values) {
+			this.src = src;
+			this.recursive = recursive;
+			this.target = new WeakReference<>(target);
+			this.hash = src.hashCode() + 7 * target.hashCode();
+			this.values = values;
+
 			var store = new TypeStore();
 			var tf = TypeFactory.getInstance();
 
@@ -3971,16 +3978,6 @@ public class Prelude {
 			var changeEventType = tf.abstractDataType(store, "LocationChangeEvent");
 			changeEvent = tf.constructor(store, changeEventType, "changeEvent", 
 				tf.sourceLocationType(), "src", locationChangeType, "changeType", locationType, "type");
-		}
-
-
-
-		public ReleasableCallback(ISourceLocation src, boolean recursive, IFunction target, IValueFactory values) {
-			this.src = src;
-			this.recursive = recursive;
-			this.target = new WeakReference<>(target);
-			this.hash = src.hashCode() + 7 * target.hashCode();
-			this.values = values;
 		}
 
 		@Override
@@ -4001,8 +3998,6 @@ public class Prelude {
 		}
 
 		private IValue convertChangeEvent(ISourceLocationChanged e) {
-			
-			
 			return values.constructor(changeEvent, 
 				e.getLocation(),
 				convertChangeType(e.getChangeType()),
@@ -4011,14 +4006,12 @@ public class Prelude {
 		}
 
 		private IValue convertFileType(ISourceLocationType type) {
-			
 			switch (type) {
 				case FILE:
 					return values.constructor(file);
 				case DIRECTORY:
 					return values.constructor(directory);
 			}
-
 			throw RuntimeExceptionFactory.illegalArgument();
 		}
 

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -3948,7 +3948,13 @@ public class Prelude {
 		private final int hash;
 
 		private final IValueFactory values;
-		private final TypeStore store;
+		private final Type deleted;
+		private final Type created;
+		private final Type modified;
+		private final Type file;
+		private final Type directory;
+		private final Type changeEvent;
+
 
 		public ReleasableCallback(ISourceLocation src, boolean recursive, IFunction target, IValueFactory values, TypeStore store) {
 			this.src = src;
@@ -3956,7 +3962,16 @@ public class Prelude {
 			this.target = new WeakReference<>(target);
 			this.hash = src.hashCode() + 7 * target.hashCode();
 			this.values = values;
-			this.store = store;
+			this.deleted = getFirstConstructor(store, "deleted");
+			this.created = getFirstConstructor(store, "created");
+			this.modified = getFirstConstructor(store, "modified");
+			this.file = getFirstConstructor(store, "file");
+			this.directory = getFirstConstructor(store, "directory");
+			this.changeEvent = getFirstConstructor(store, "changeEvent");
+		}
+
+		private static Type getFirstConstructor(TypeStore store, String name) {
+			return store.lookupConstructors(name).iterator().next();
 		}
 
 		@Override
@@ -3977,7 +3992,6 @@ public class Prelude {
 		}
 
 		private IValue convertChangeEvent(ISourceLocationChanged e) {
-			Type changeEvent = store.lookupConstructors("changeEvent").iterator().next();
 			
 			
 			return values.constructor(changeEvent, 
@@ -3988,8 +4002,6 @@ public class Prelude {
 		}
 
 		private IValue convertFileType(ISourceLocationType type) {
-			Type file = store.lookupConstructors("file").iterator().next();
-			Type directory = store.lookupConstructors("directory").iterator().next();
 			
 			switch (type) {
 				case FILE:
@@ -4002,9 +4014,6 @@ public class Prelude {
 		}
 
 		private IValue convertChangeType(ISourceLocationChangeType changeType) {
-			Type deleted = store.lookupConstructors("deleted").iterator().next();
-			Type created = store.lookupConstructors("created").iterator().next();
-			Type modified = store.lookupConstructors("modified").iterator().next();
 
 			switch (changeType) {
 				case DELETED:

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -147,16 +147,14 @@ public class Prelude {
 	
 	private final boolean trackIO = System.getenv("TRACKIO") != null;
     private final PrintWriter out;
-	private final TypeStore store;
 	private final IRascalMonitor monitor;
 	private final IResourceLocationProvider resourceProvider;
 	
-	public Prelude(IValueFactory values, IRascalValueFactory rascalValues, PrintWriter out, TypeStore store, IRascalMonitor monitor, IResourceLocationProvider resourceProvider) {
+	public Prelude(IValueFactory values, IRascalValueFactory rascalValues, PrintWriter out, IRascalMonitor monitor, IResourceLocationProvider resourceProvider) {
 		super();
 		
 		this.values = values;
 		this.rascalValues = rascalValues;
-		this.store = store;
 		this.out = out;
 		this.tr = new TypeReifier(values);
 		this.monitor = monitor;


### PR DESCRIPTION
This would cause some file watch events to get dropped.

Sometimes the `store` would not contain the expected constructors anymore (I think it's because of an unimport that happens). And then the file monitor thread would report exceptions on every run.

This solves that (note, what it means to call this function where the typestore is corrupted I have no idea, but at least it won't crash in this place anymore).