### PR TITLE
Support module reloading in the rascal repl (ported from the VS Code repl implementation)

### DIFF
--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -82,7 +82,7 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
     protected Evaluator eval;
     protected final Set<String> dirtyModules = ConcurrentHashMap.newKeySet();
 
-    URIResolverRegistry reg = URIResolverRegistry.getInstance();
+    private final URIResolverRegistry reg = URIResolverRegistry.getInstance();
     
     private final RascalValuePrinter printer;
 

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -157,15 +157,7 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
     }
 
     private boolean isWatchable(ISourceLocation loc) {
-        for (var capability : reg.capabilities(loc)) {
-            // see the `IOCapability` ADT in `IO.rsc`
-            switch (((IConstructor)capability).getName()) {
-                case "watching":
-                case "writing":
-                    return true;
-            }
-        }
-        return false;
+        return reg.isNativelyWatchable(loc) || reg.isWritable(loc);
     }
 
     @Override

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -157,7 +157,7 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
     }
 
     private boolean isWatchable(ISourceLocation loc) {
-        return reg.isSchemeNativelyWatchable(loc) || reg.isSchemeWritable(loc);
+        return reg.hasNativelyWatchableScheme(loc) || reg.hasWritableScheme(loc);
     }
 
     @Override

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -171,12 +171,11 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
     public ICommandOutput handleInput(String command) throws InterruptedException, ParseError, StopREPLException {
         Objects.requireNonNull(eval, "Not initialized yet");
         synchronized(eval) {
-            Set<String> changes = new HashSet<>();
-            changes.addAll(dirtyModules);
-            dirtyModules.removeAll(changes);
-            eval.reloadModules(eval.getMonitor(), changes, URIUtil.rootLocation("reloader"));
-            
             try {
+                Set<String> changes = new HashSet<>();
+                changes.addAll(dirtyModules);
+                dirtyModules.removeAll(changes);
+                eval.reloadModules(eval.getMonitor(), changes, URIUtil.rootLocation("reloader"));
                 return printer.outputResult(eval.eval(eval.getMonitor(), command, PROMPT_LOCATION));
             }
             catch (InterruptException ex) {

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -80,7 +80,7 @@ import io.usethesource.vallang.IValueFactory;
 public class RascalInterpreterREPL implements IRascalLanguageProtocol {
     protected IDEServices services;
     protected Evaluator eval;
-    protected Set<String> dirtyModules = ConcurrentHashMap.newKeySet();
+    protected final Set<String> dirtyModules = ConcurrentHashMap.newKeySet();
 
     URIResolverRegistry reg = URIResolverRegistry.getInstance();
     

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -157,7 +157,7 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
     }
 
     private boolean isWatchable(ISourceLocation loc) {
-        return reg.hasNativelyWatchableScheme(loc) || reg.hasWritableScheme(loc);
+        return reg.hasNativelyWatchableResolver(loc) || reg.hasWritableResolver(loc);
     }
 
     @Override

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -149,6 +149,7 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
                 reg.watch(p, true, d -> sourceLocationChanged(p, d));
             }
             catch (IOException e) {
+                stderr.println("Failed to register watch for " + p);
                 e.printStackTrace(stderr);
             }
         });

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -157,7 +157,7 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
     }
 
     private boolean isWatchable(ISourceLocation loc) {
-        return reg.isNativelyWatchable(loc) || reg.isWritable(loc);
+        return reg.isSchemeNativelyWatchable(loc) || reg.isSchemeWritable(loc);
     }
 
     @Override

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -1137,4 +1137,24 @@ public class URIResolverRegistry {
 		return result.done();
 	}
 
+	public boolean isReadable(ISourceLocation loc) {
+		return inputResolvers.containsKey(loc.getScheme());
+	}
+
+	public boolean isWritable(ISourceLocation loc) {
+		return outputResolvers.containsKey(loc.getScheme());
+	}
+
+	public boolean isEfficientlyClassloadable(ISourceLocation loc) {
+		return classloaderResolvers.containsKey(loc.getScheme());
+	}
+
+	public boolean isLogical(ISourceLocation loc) {
+		return logicalResolvers.containsKey(loc.getScheme());
+	}
+
+	public boolean isNativelyWatchable(ISourceLocation loc) {
+		return watchers.containsKey(loc.getScheme());
+	}
+
 }

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -1137,23 +1137,23 @@ public class URIResolverRegistry {
 		return result.done();
 	}
 
-	public boolean isSchemeReadable(ISourceLocation loc) {
+	public boolean hasReadableScheme(ISourceLocation loc) {
 		return inputResolvers.containsKey(loc.getScheme()) || inputResolvers.containsKey(safeResolve(loc).getScheme());
 	}
 
-	public boolean isSchemeWritable(ISourceLocation loc) {
+	public boolean hasWritableScheme(ISourceLocation loc) {
 		return outputResolvers.containsKey(loc.getScheme()) || outputResolvers.containsKey(safeResolve(loc).getScheme());
 	}
 
-	public boolean isSchemeEfficientlyClassloadable(ISourceLocation loc) {
+	public boolean hasEfficientlyClassloadableScheme(ISourceLocation loc) {
 		return classloaderResolvers.containsKey(loc.getScheme()) || classloaderResolvers.containsKey(safeResolve(loc).getScheme());
 	}
 
-	public boolean isSchemeLogical(ISourceLocation loc) {
+	public boolean hasLogicalScheme(ISourceLocation loc) {
 		return logicalResolvers.containsKey(loc.getScheme());
 	}
 
-	public boolean isSchemeNativelyWatchable(ISourceLocation loc) {
+	public boolean hasNativelyWatchableScheme(ISourceLocation loc) {
 		return watchers.containsKey(loc.getScheme()) || watchers.containsKey(safeResolve(loc).getScheme());
 	}
 

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -1137,24 +1137,24 @@ public class URIResolverRegistry {
 		return result.done();
 	}
 
-	public boolean isReadable(ISourceLocation loc) {
-		return inputResolvers.containsKey(loc.getScheme());
+	public boolean isSchemeReadable(ISourceLocation loc) {
+		return inputResolvers.containsKey(loc.getScheme()) || inputResolvers.containsKey(safeResolve(loc).getScheme());
 	}
 
-	public boolean isWritable(ISourceLocation loc) {
-		return outputResolvers.containsKey(loc.getScheme());
+	public boolean isSchemeWritable(ISourceLocation loc) {
+		return outputResolvers.containsKey(loc.getScheme()) || outputResolvers.containsKey(safeResolve(loc).getScheme());
 	}
 
-	public boolean isEfficientlyClassloadable(ISourceLocation loc) {
-		return classloaderResolvers.containsKey(loc.getScheme());
+	public boolean isSchemeEfficientlyClassloadable(ISourceLocation loc) {
+		return classloaderResolvers.containsKey(loc.getScheme()) || classloaderResolvers.containsKey(safeResolve(loc).getScheme());
 	}
 
-	public boolean isLogical(ISourceLocation loc) {
+	public boolean isSchemeLogical(ISourceLocation loc) {
 		return logicalResolvers.containsKey(loc.getScheme());
 	}
 
-	public boolean isNativelyWatchable(ISourceLocation loc) {
-		return watchers.containsKey(loc.getScheme());
+	public boolean isSchemeNativelyWatchable(ISourceLocation loc) {
+		return watchers.containsKey(loc.getScheme()) || watchers.containsKey(safeResolve(loc).getScheme());
 	}
 
 }

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -1137,23 +1137,23 @@ public class URIResolverRegistry {
 		return result.done();
 	}
 
-	public boolean hasReadableScheme(ISourceLocation loc) {
+	public boolean hasReadableResolver(ISourceLocation loc) {
 		return inputResolvers.containsKey(loc.getScheme()) || inputResolvers.containsKey(safeResolve(loc).getScheme());
 	}
 
-	public boolean hasWritableScheme(ISourceLocation loc) {
+	public boolean hasWritableResolver(ISourceLocation loc) {
 		return outputResolvers.containsKey(loc.getScheme()) || outputResolvers.containsKey(safeResolve(loc).getScheme());
 	}
 
-	public boolean hasEfficientlyClassloadableScheme(ISourceLocation loc) {
+	public boolean hasEfficientlyClassloadableResolver(ISourceLocation loc) {
 		return classloaderResolvers.containsKey(loc.getScheme()) || classloaderResolvers.containsKey(safeResolve(loc).getScheme());
 	}
 
-	public boolean hasLogicalScheme(ISourceLocation loc) {
+	public boolean hasLogicalResolver(ISourceLocation loc) {
 		return logicalResolvers.containsKey(loc.getScheme());
 	}
 
-	public boolean hasNativelyWatchableScheme(ISourceLocation loc) {
+	public boolean hasNativelyWatchableResolver(ISourceLocation loc) {
 		return watchers.containsKey(loc.getScheme()) || watchers.containsKey(safeResolve(loc).getScheme());
 	}
 


### PR DESCRIPTION
This PR adds automatic module reloading for Rascal interpreter REPLs. Previously, this was only supported in VS Code REPLs.