### PR TITLE
Throw exception when needle cannot be found in haystack.

### DIFF
--- a/src/org/rascalmpl/library/Location.rsc
+++ b/src/org/rascalmpl/library/Location.rsc
@@ -37,9 +37,7 @@ loc relativize(list[loc] haystack, loc needle) {
     if (h <- haystack, loc r := relativize(h, needle), r != needle) {
         return r;
     }
-    else {
-        fail relativize;
-    }
+    throw PathNotFound(needle);
 }
 
 @synopsis{Shortens an absolute path to a jar inside the local maven repository.}


### PR DESCRIPTION
`relativize(list[loc] haystack, loc needle)` currently fails when the needle cannot be found in the haystack. That makes it hard to work with failures. Instead, it now throws an exception.