### PR TITLE
Rewrote ParserTest to work with junit runner

### DIFF
--- a/src/org/rascalmpl/test/infrastructure/RecursiveTestSuite.java
+++ b/src/org/rascalmpl/test/infrastructure/RecursiveTestSuite.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runners.Suite;
 import org.junit.runners.model.InitializationError;
 
+import junit.framework.TestCase;
+
 public class RecursiveTestSuite extends Suite {
 
 	public RecursiveTestSuite(Class<?> setupClass)
@@ -67,6 +69,9 @@ public class RecursiveTestSuite extends Suite {
 					    if (includeRascalTests) {
 					        result.add(currentClass);
 					    }
+					}
+					else if (TestCase.class.isAssignableFrom(currentClass)) {
+						result.add(currentClass);
 					}
 					else {
 						for (Method m: currentClass.getMethods()) {

--- a/src/org/rascalmpl/test/infrastructure/RecursiveTestSuite.java
+++ b/src/org/rascalmpl/test/infrastructure/RecursiveTestSuite.java
@@ -20,8 +20,6 @@ import org.junit.Test;
 import org.junit.runners.Suite;
 import org.junit.runners.model.InitializationError;
 
-import junit.framework.TestCase;
-
 public class RecursiveTestSuite extends Suite {
 
 	public RecursiveTestSuite(Class<?> setupClass)
@@ -69,9 +67,6 @@ public class RecursiveTestSuite extends Suite {
 					    if (includeRascalTests) {
 					        result.add(currentClass);
 					    }
-					}
-					else if (TestCase.class.isAssignableFrom(currentClass)) {
-						result.add(currentClass);
 					}
 					else {
 						for (Method m: currentClass.getMethods()) {

--- a/test/org/rascalmpl/test/parser/ParserTest.java
+++ b/test/org/rascalmpl/test/parser/ParserTest.java
@@ -14,6 +14,7 @@ package org.rascalmpl.test.parser;
 import java.io.IOException;
 
 import org.junit.Assert;
+import org.junit.Test;
 import org.rascalmpl.parser.gtd.exception.ParseError;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IString;
@@ -22,15 +23,10 @@ import io.usethesource.vallang.IValueFactory;
 import io.usethesource.vallang.type.TypeFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
 
-import junit.framework.TestCase;
-
-public class ParserTest extends TestCase{
-	private final static TypeFactory tf = TypeFactory.getInstance();
-	private final static IValueFactory vf = ValueFactoryFactory.getValueFactory();
+public class ParserTest {
+	private static final TypeFactory tf = TypeFactory.getInstance();
+	private static final IValueFactory vf = ValueFactoryFactory.getValueFactory();
 	
-	public ParserTest() {
-		super();
-	}
 	
 	public void executeParser(IParserTest parser){
 		try {
@@ -57,6 +53,7 @@ public class ParserTest extends TestCase{
 		}
 	}
 	
+	@Test
 	public void testBasic(){
 		executeParser(new Simple1());
 		executeParser(new Simple2());
@@ -67,6 +64,7 @@ public class ParserTest extends TestCase{
 		executeParser(new Epsilon());
 	}
 	
+	@Test
 	public void testAmbiguitiesBasic(){
 		executeParser(new Ambiguous1());
 		executeParser(new Ambiguous2());
@@ -79,12 +77,14 @@ public class ParserTest extends TestCase{
 		executeParser(new Ambiguous9());
 	}
 	
+	@Test
 	public void testSplitAndMerge(){
 		executeParser(new SplitAndMerge1());
 		executeParser(new SplitAndMerge2());
 		executeParser(new SplitAndMerge3());
 	}
 	
+	@Test
 	public void testList(){
 		executeParser(new CharPlusList());
 		executeParser(new CharStarList());
@@ -93,32 +93,38 @@ public class ParserTest extends TestCase{
 		executeParser(new NonTerminalStarList());
 	}
 	
+	@Test
 	public void testSeparatedList(){
 		executeParser(new SeparatedPlusList());
 		executeParser(new SeparatedStarList());
 	}
 	
+	@Test
 	public void testOptional(){
 		executeParser(new Optional1());
 		executeParser(new Optional2());
 		executeParser(new Optional3());
 	}
 	
+	@Test
 	public void testSequence(){
 		executeParser(new Sequence1());
 		executeParser(new Sequence2());
 	}
 	
+	@Test
 	public void testAlternative(){
 		executeParser(new Alternative1());
 	}
 	
+	@Test
 	public void testAmbiguousList(){
 		executeParser(new AmbiguousNonTerminalPlusList1());
 		executeParser(new AmbiguousNonTerminalPlusList2());
 		executeParser(new AmbiguousNestedPlusList());
 	}
 	
+	@Test
 	public void testRecursion(){
 		executeParser(new RightRecursion());
 		executeParser(new LeftRecursion());
@@ -128,11 +134,13 @@ public class ParserTest extends TestCase{
 		executeParser(new NullableSharing());
 	}
 	
+	@Test
 	public void testAmbiguousRecursion(){
 		executeParser(new AmbiguousRecursive());
 		executeParser(new AmbiguousRecursivePrefixShared());
 	}
 	
+	@Test
 	public void testCycle(){
 		executeParser(new NotAUselessSelfLoop());
 		executeParser(new UselessSelfLoop());
@@ -140,24 +148,29 @@ public class ParserTest extends TestCase{
 		executeParser(new CycleEpsilon());
 	}
 	
+	@Test
 	public void testListCycle(){
 		executeParser(new EpsilonList());
 		executeParser(new AmbiguousEpsilonList());
 		executeParser(new AmbiguousSeparatedEpsilonList());
 	}
 	
+	@Test
 	public void testListSharing(){
 		executeParser(new ListOverlap());
 	}
 
+	@Test
 	public void testDoubleLeftNullable() {
 		executeParser(new DoubleLeftNullable());
 	}
 
+	@Test
 	public void testDoubleRightNullable() {
 		executeParser(new DoubleRightNullableWithPrefixSharing());
 	}
 
+	@Test
 	public void testPrefixSharedExcept() {
 		executeParser(new PrefixSharedExcept());
 	}


### PR DESCRIPTION
Fixes issue found in: https://github.com/usethesource/rascal/pull/2267#issuecomment-2894200499

In the end `TestCase` was not compatible with junit `Suite` so I just rewrote the `TestParser` class.