### PR TITLE
Fixed Evaluator creation for Rascal itself

### DIFF
--- a/src/org/rascalmpl/library/util/Eval.java
+++ b/src/org/rascalmpl/library/util/Eval.java
@@ -207,7 +207,7 @@ public class Eval {
 		private int duration = -1;
 		
 		public RascalRuntime(PathConfig pcfg, Reader input, PrintWriter stderr, PrintWriter stdout, IDEServices services) throws IOException, URISyntaxException{
-			this.eval = ShellEvaluatorFactory.getDefaultEvaluatorForPathConfig(pcfg, input, stdout, stderr, services);
+			this.eval = ShellEvaluatorFactory.getDefaultEvaluatorForPathConfig(URIUtil.rootLocation("cwd"), pcfg, input, stdout, stderr, services);
 			if (!pcfg.getSrcs().isEmpty()) {
 				ShellEvaluatorFactory.registerProjectAndTargetResolver((ISourceLocation)pcfg.getSrcs().get(0));
 			} else {

--- a/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
+++ b/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
@@ -49,11 +49,11 @@ public class ShellEvaluatorFactory {
         return getBasicEvaluator(input, stdout, stderr, monitor, rootEnvironment);
     }
 
-    public static Evaluator getDefaultEvaluatorForPathConfig(PathConfig pcfg, Reader input, PrintWriter stdout, PrintWriter stderr, IRascalMonitor monitor) {
-        return getDefaultEvaluatorForPathConfig(pcfg, input, stdout, stderr, monitor, ModuleEnvironment.SHELL_MODULE);
+    public static Evaluator getDefaultEvaluatorForPathConfig(ISourceLocation projectRoot, PathConfig pcfg, Reader input, PrintWriter stdout, PrintWriter stderr, IRascalMonitor monitor) {
+        return getDefaultEvaluatorForPathConfig(projectRoot, pcfg, input, stdout, stderr, monitor, ModuleEnvironment.SHELL_MODULE);
     }
     
-    public static Evaluator getDefaultEvaluatorForPathConfig(PathConfig pcfg, Reader input, PrintWriter stdout, PrintWriter stderr, IRascalMonitor monitor, String rootEnvironment) {
+    public static Evaluator getDefaultEvaluatorForPathConfig(ISourceLocation projectRoot, PathConfig pcfg, Reader input, PrintWriter stdout, PrintWriter stderr, IRascalMonitor monitor, String rootEnvironment) {
         var evaluator = getBasicEvaluator(input, stdout, stderr, monitor, rootEnvironment);
         
         stdout.println("Rascal " + RascalManifest.getRascalVersionNumber());
@@ -64,7 +64,8 @@ public class ShellEvaluatorFactory {
             evaluator.addRascalSearchPath(path);
         }
 
-        var libs = pcfg.getLibsAndTarget();
+        var isRascal = projectRoot != null && new RascalManifest().getProjectName(projectRoot).equals("rascal");
+        var libs = isRascal ? pcfg.getLibs() : pcfg.getLibsAndTarget();
         stdout.println("Rascal classloader path:");
         for (var lib : libs) {
             var path = (ISourceLocation)lib;
@@ -86,8 +87,9 @@ public class ShellEvaluatorFactory {
     }
 
     public static Evaluator getDefaultEvaluatorForLocation(ISourceLocation projectFile, Reader input, PrintWriter stdout, PrintWriter stderr, IRascalMonitor monitor, String rootEnvironment) {
-        var pcfg = PathConfig.fromSourceProjectMemberRascalManifest(projectFile, RascalConfigMode.INTERPRETER);
-        return getDefaultEvaluatorForPathConfig(pcfg, input, stdout, stderr, monitor, rootEnvironment);
+        var projectRoot = PathConfig.inferProjectRoot(projectFile);
+        var pcfg = PathConfig.fromSourceProjectRascalManifest(projectFile, RascalConfigMode.INTERPRETER, true);
+        return getDefaultEvaluatorForPathConfig(projectRoot, pcfg, input, stdout, stderr, monitor, rootEnvironment);
     }
 
     public static void registerProjectAndTargetResolver(ISourceLocation projectFile) {


### PR DESCRIPTION
The Evaluator creation methods would erroneously add the target to the class path of an Evaluator for the Rascal project. This PR fixes that, by using the same logic that was in `rascal-lsp` project until recently.