### PR TITLE
Improve handling of project/target schemes

### DIFF
--- a/src/org/rascalmpl/ideservices/BasicIDEServices.java
+++ b/src/org/rascalmpl/ideservices/BasicIDEServices.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 
 import org.jline.terminal.Terminal;
 import org.rascalmpl.debug.IRascalMonitor;
+import org.rascalmpl.interpreter.utils.RascalManifest;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
 
@@ -36,11 +37,15 @@ public class BasicIDEServices implements IDEServices {
   private final IRascalMonitor monitor;
   private final PrintWriter stderr;
   private final Terminal terminal;
+  private final ISourceLocation projectRoot;
+  private final String projectName;
 
-  public BasicIDEServices(PrintWriter stderr, IRascalMonitor monitor, Terminal terminal){
+  public BasicIDEServices(PrintWriter stderr, IRascalMonitor monitor, Terminal terminal, ISourceLocation projectRoot){
     this.stderr = stderr;
     this.monitor = monitor;
     this.terminal = terminal;
+    this.projectRoot = projectRoot;
+    this.projectName = new RascalManifest().getProjectName(projectRoot);
   }
 
   @Override
@@ -145,5 +150,14 @@ public class BasicIDEServices implements IDEServices {
   @Override
   public void warning(String message, ISourceLocation src) {
     monitor.warning(message,  src);
+  }
+
+  @Override
+  public ISourceLocation resolveProjectLocation(ISourceLocation input) {
+    if (projectName != "" && input.getScheme().equals("project") && input.getAuthority().equals(projectName)) {
+      return URIUtil.getChildLocation(projectRoot, input.getPath());
+    }
+    
+    return input;
   }
 }

--- a/src/org/rascalmpl/interpreter/utils/JavaBridge.java
+++ b/src/org/rascalmpl/interpreter/utils/JavaBridge.java
@@ -435,7 +435,7 @@ public class JavaBridge {
 								args[i] = (IDEServices) monitor;
 							}
 							else {
-								args[i] = new BasicIDEServices(err, monitor, null);
+								args[i] = new BasicIDEServices(err, monitor, null, URIUtil.rootLocation("cwd"));
 							}
 						}
 						else if (formals[i].isAssignableFrom(IResourceLocationProvider.class)) {

--- a/src/org/rascalmpl/library/util/Eval.java
+++ b/src/org/rascalmpl/library/util/Eval.java
@@ -207,12 +207,7 @@ public class Eval {
 		private int duration = -1;
 		
 		public RascalRuntime(PathConfig pcfg, Reader input, PrintWriter stderr, PrintWriter stdout, IDEServices services) throws IOException, URISyntaxException{
-			this.eval = ShellEvaluatorFactory.getDefaultEvaluatorForPathConfig(URIUtil.rootLocation("cwd"), pcfg, input, stdout, stderr, services);
-			if (!pcfg.getSrcs().isEmpty()) {
-				ShellEvaluatorFactory.registerProjectAndTargetResolver((ISourceLocation)pcfg.getSrcs().get(0));
-			} else {
-				ShellEvaluatorFactory.registerProjectAndTargetResolver(URIUtil.rootLocation("cwd"));
-			}
+			eval = ShellEvaluatorFactory.getDefaultEvaluatorForPathConfig(URIUtil.rootLocation("cwd"), pcfg, input, stdout, stderr, services);
 		}
 
 		public IValue staticTypeOf(String line) {

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -62,6 +62,7 @@ import org.rascalmpl.shell.ShellEvaluatorFactory;
 import org.rascalmpl.uri.ISourceLocationWatcher.ISourceLocationChanged;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.values.ValueFactoryFactory;
 import org.rascalmpl.values.functions.IFunction;
 import org.rascalmpl.values.parsetrees.ITree;
 
@@ -114,7 +115,7 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
      * Build an IDE service, in most places you want to override this function to construct a specific one for the setting you are in.
      */
     protected IDEServices buildIDEService(PrintWriter err, IRascalMonitor monitor, Terminal term) {
-        return new BasicIDEServices(err, monitor, term);
+        return new BasicIDEServices(err, monitor, term, URIUtil.rootLocation("cwd"));
     }
 
     /**

--- a/src/org/rascalmpl/runtime/RascalExecutionContext.java
+++ b/src/org/rascalmpl/runtime/RascalExecutionContext.java
@@ -86,7 +86,8 @@ public class RascalExecutionContext implements IRascalMonitor {
 		this.errwriter = errwriter;
 		
 		this.pcfg = pcfg == null ? new PathConfig() : pcfg;
-		this.ideServices = ideServices == null ? new BasicIDEServices(errwriter, this, null) : ideServices;
+		ISourceLocation projectRoot = inferProjectRoot(clazz);
+		this.ideServices = ideServices == null ? new BasicIDEServices(errwriter, this, null, projectRoot) : ideServices;
 		$RVF = new RascalRuntimeValueFactory(this);
 		$VF = ValueFactoryFactory.getValueFactory();
 		$TF = TypeFactory.getInstance();
@@ -96,7 +97,6 @@ public class RascalExecutionContext implements IRascalMonitor {
 		$TS = new TypeStore();
 		rascalSearchPath = new RascalSearchPath();
 		
-		ISourceLocation projectRoot = inferProjectRoot(clazz);
 	    URIResolverRegistry reg = URIResolverRegistry.getInstance();
 	    String projectName = new RascalManifest().getProjectName(projectRoot);
 	    if(!projectName.isEmpty()) {

--- a/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
+++ b/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
@@ -114,7 +114,7 @@ public class ShellEvaluatorFactory {
         }
     }
 
-    public static void registerProjectAndTargetResolver(Function<ISourceLocation,ISourceLocation> resolver) {
+    private static void registerProjectAndTargetResolver(Function<ISourceLocation,ISourceLocation> resolver) {
         var reg = URIResolverRegistry.getInstance();
         reg.registerLogical(new IDEProjectURIResolver(resolver));
         reg.registerLogical(new IDETargetURIResolver(resolver));

--- a/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
+++ b/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
@@ -2,8 +2,10 @@ package org.rascalmpl.shell;
 
 import java.io.PrintWriter;
 import java.io.Reader;
+import java.util.function.Function;
 
 import org.rascalmpl.debug.IRascalMonitor;
+import org.rascalmpl.ideservices.IDEServices;
 import org.rascalmpl.interpreter.Evaluator;
 import org.rascalmpl.interpreter.env.GlobalEnvironment;
 import org.rascalmpl.interpreter.env.ModuleEnvironment;
@@ -16,6 +18,8 @@ import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.uri.classloaders.SourceLocationClassLoader;
 import org.rascalmpl.uri.file.MavenRepositoryURIResolver;
+import org.rascalmpl.uri.project.IDEProjectURIResolver;
+import org.rascalmpl.uri.project.IDETargetURIResolver;
 import org.rascalmpl.uri.project.ProjectURIResolver;
 import org.rascalmpl.uri.project.TargetURIResolver;
 import org.rascalmpl.values.ValueFactoryFactory;
@@ -54,6 +58,12 @@ public class ShellEvaluatorFactory {
     }
     
     public static Evaluator getDefaultEvaluatorForPathConfig(ISourceLocation projectRoot, PathConfig pcfg, Reader input, PrintWriter stdout, PrintWriter stderr, IRascalMonitor monitor, String rootEnvironment) {
+        if (monitor instanceof IDEServices) {
+            registerProjectAndTargetResolver(((IDEServices) monitor)::resolveProjectLocation);
+        } else {
+            registerProjectAndTargetResolver(projectRoot);
+        }
+        
         var evaluator = getBasicEvaluator(input, stdout, stderr, monitor, rootEnvironment);
         
         stdout.println("Rascal " + RascalManifest.getRascalVersionNumber());
@@ -88,11 +98,11 @@ public class ShellEvaluatorFactory {
 
     public static Evaluator getDefaultEvaluatorForLocation(ISourceLocation projectFile, Reader input, PrintWriter stdout, PrintWriter stderr, IRascalMonitor monitor, String rootEnvironment) {
         var projectRoot = PathConfig.inferProjectRoot(projectFile);
-        var pcfg = PathConfig.fromSourceProjectRascalManifest(projectFile, RascalConfigMode.INTERPRETER, true);
+        var pcfg = PathConfig.fromSourceProjectRascalManifest(projectRoot, RascalConfigMode.INTERPRETER, true);
         return getDefaultEvaluatorForPathConfig(projectRoot, pcfg, input, stdout, stderr, monitor, rootEnvironment);
     }
 
-    public static void registerProjectAndTargetResolver(ISourceLocation projectFile) {
+    private static void registerProjectAndTargetResolver(ISourceLocation projectFile) {
         var reg = URIResolverRegistry.getInstance();
         var projectRoot = PathConfig.inferProjectRoot(projectFile);
         if (projectRoot != null) {
@@ -102,6 +112,12 @@ public class ShellEvaluatorFactory {
                 reg.registerLogical(new TargetURIResolver(projectRoot, projectName));
             }
         }
+    }
+
+    public static void registerProjectAndTargetResolver(Function<ISourceLocation,ISourceLocation> resolver) {
+        var reg = URIResolverRegistry.getInstance();
+        reg.registerLogical(new IDEProjectURIResolver(resolver));
+        reg.registerLogical(new IDETargetURIResolver(resolver));
     }
 
 }

--- a/src/org/rascalmpl/test/infrastructure/RascalJUnitParallelRecursiveTestRunner.java
+++ b/src/org/rascalmpl/test/infrastructure/RascalJUnitParallelRecursiveTestRunner.java
@@ -297,7 +297,6 @@ public class RascalJUnitParallelRecursiveTestRunner extends Runner {
         private void initializeEvaluator() {
             if (projectRoot != null) {
                 evaluator = ShellEvaluatorFactory.getDefaultEvaluatorForLocation(projectRoot, Reader.nullReader(), new PrintWriter(System.err, true), new PrintWriter(System.out, true), RascalJunitConsoleMonitor.getInstance(), JUNIT_TEST);
-                ShellEvaluatorFactory.registerProjectAndTargetResolver(projectRoot);
             } else {
                 evaluator = ShellEvaluatorFactory.getBasicEvaluator(Reader.nullReader(), new PrintWriter(System.err, true), new PrintWriter(System.out, true), RascalJunitConsoleMonitor.getInstance(), JUNIT_TEST);
             }

--- a/src/org/rascalmpl/test/infrastructure/RascalJUnitTestRunner.java
+++ b/src/org/rascalmpl/test/infrastructure/RascalJUnitTestRunner.java
@@ -59,7 +59,6 @@ public class RascalJUnitTestRunner extends Runner {
 
         if (projectRoot != null) {
             evaluator = ShellEvaluatorFactory.getDefaultEvaluatorForLocation(projectRoot, Reader.nullReader(), new PrintWriter(System.err, true), new PrintWriter(System.out, false), RascalJunitConsoleMonitor.getInstance(), JUNIT_TEST);
-            ShellEvaluatorFactory.registerProjectAndTargetResolver(projectRoot);
             evaluator.getConfiguration().setErrors(true);
         } else {
             throw new IllegalArgumentException("could not setup tests for " + clazz.getCanonicalName());

--- a/src/org/rascalmpl/test/infrastructure/TestFramework.java
+++ b/src/org/rascalmpl/test/infrastructure/TestFramework.java
@@ -62,7 +62,6 @@ public class TestFramework {
 		}
 		evaluator = ShellEvaluatorFactory.getDefaultEvaluatorForLocation(projectLoc, Reader.nullReader(), new PrintWriter(System.err, true), new PrintWriter(System.out, false), RascalJunitConsoleMonitor.getInstance(), ROOT_TEST_ENVIRONMENT);
 
-		ShellEvaluatorFactory.registerProjectAndTargetResolver(projectLoc);
 		heap = evaluator.getHeap();
 		root = heap.getModule(ROOT_TEST_ENVIRONMENT);
 	


### PR DESCRIPTION
* `BasicIDEServices` now resolves project locations for the project/directory it is constructed in
* During `Evaluator` construction, project/target resolvers are registered based on whether the provided monitor is in fact `IDEServices` or not.
* Fixes #2273 