### PR TITLE
Removed spurious PathConfig messages about missing folders

### DIFF
--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -802,14 +802,12 @@ public class PathConfig {
 
         boolean foundSrc = false;
 
+        // For backward compatibility, first check the source roots in the manifest relative to the jar root
         for (String src : manifest.getSourceRoots(jar)) {
             ISourceLocation srcLib = URIUtil.getChildLocation(unpacked, src);
             if (reg.exists(srcLib)) {
                 srcsWriter.append(srcLib);
                 foundSrc = true;
-            }
-            else {
-                messages.append(Messages.error(srcLib + " source folder does not exist.", URIUtil.getChildLocation(jar, RascalManifest.META_INF_RASCAL_MF)));
             }
         }
 


### PR DESCRIPTION
During PathConfig creation, the source roots in the RASCAL.MF are checked relative to a jar root. While this was once expected, in the current situation all source files are located at root level (and not at, say, `src/main/rascal`). This PR removes the spurious messages.

NB: the jar root is, as expected, added to the Rascal search path.