### PR TITLE
Registering diagnostics if the provided monitor is actually IDEServices

### DIFF
--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -650,7 +650,7 @@ public class PathConfig {
      */
     public static PathConfig fromSourceProjectRascalManifest(ISourceLocation manifestRoot, RascalConfigMode mode, boolean isRoot)  {
         manifestRoot = safeResolve(manifestRoot);
-        // once we have proper support for poject locs we should do this instead:
+        // once we have proper support for project locs we should do this instead:
         //manifestRoot = upgradeToProjectScheme(manifestRoot, projectName);
         RascalManifest manifest = new RascalManifest();
         IRascalValueFactory vf = IRascalValueFactory.getInstance();

--- a/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
+++ b/src/org/rascalmpl/shell/ShellEvaluatorFactory.java
@@ -87,6 +87,9 @@ public class ShellEvaluatorFactory {
         if (!pcfg.getMessages().isEmpty()) {
             stdout.println("PathConfig messages:");
             Messages.write(pcfg.getMessages(), pcfg.getSrcs(), stdout);
+            if (monitor instanceof IDEServices) {
+                ((IDEServices) monitor).registerDiagnostics(pcfg.getMessages());
+            }
         }
 
         return evaluator;


### PR DESCRIPTION
This registration used to happen in `LSPTerminalREPL`.

Also: fixed a typo.