### PR TITLE
Type checker: take care of case that generatedResources is not set

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/util/Names.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/util/Names.rsc
@@ -116,7 +116,7 @@ loc getGeneratedTestSrcsDir(str qualifiedModuleName, PathConfig pcfg){
 }
 
 loc getGeneratedResourcesDir(str qualifiedModuleName, PathConfig pcfg){
-    return pcfg.generatedResources + getCompiledPackage(qualifiedModuleName, pcfg) + makeDirName(qualifiedModuleName);
+    return (pcfg.generatedResources ? pcfg.bin) + getCompiledPackage(qualifiedModuleName, pcfg) + makeDirName(qualifiedModuleName);
 }
 str makeDirName(str qualifiedModuleName){
     parts =  escapeJavaKeywords(normalize(split(qualifiedModuleName)));


### PR DESCRIPTION
(cherry picked from commit 1d2b05a92910d38dfaad6c982d501b13cf5621a8)

This fixes the type checker after recent changes to PathConfig.