### PR TITLE
Removed artificial limit on recovery nodes in queue

### DIFF
--- a/src/org/rascalmpl/parser/gtd/SGTDBF.java
+++ b/src/org/rascalmpl/parser/gtd/SGTDBF.java
@@ -1503,9 +1503,6 @@ public abstract class SGTDBF<P, T, S> implements IGTD<P, T, S> {
 		if (recoveryNodesInQueue == 0) {
 			return false;
 		}
-		if (recoveryNodesInQueue > 51) {
-			return false;
-		}
 
 		return recoveryNodesInQueue == totalNodesInQueue;
 	}

--- a/src/org/rascalmpl/parser/uptr/recovery/ToTokenRecoverer.java
+++ b/src/org/rascalmpl/parser/uptr/recovery/ToTokenRecoverer.java
@@ -163,10 +163,7 @@ public class ToTokenRecoverer implements IRecoverer<IConstructor> {
 		List<InputMatcher> endMatchers = findEndMatchers(recoveryNode);
 		List<InputMatcher> nextMatchers = findNextMatchers(recoveryNode);
 
-		int end = Math.min(location + MAX_RECOVERY_LOOKAHEAD, input.length);
-		if (startLocation + MAX_RECOVERY_LOOKAHEAD < end) {
-			return nodes;
-		}
+		int end = Math.min(startLocation + MAX_RECOVERY_LOOKAHEAD, input.length);
 
 		BitSet skipSet = new BitSet(end-startLocation);
 		int pos = startLocation;


### PR DESCRIPTION
This PR also fixes two bugs in `ToTokenRecover`.

After this PR succesful recovery percentage for all files (both large and small) is back to around 90%,.