### PR TITLE
Properly implement the watch feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,6 +569,11 @@
             <artifactId>maven-settings</artifactId>
             <version>${maven-version}</version>
         </dependency>
+        <dependency> <!-- file watch support -->
+            <groupId>engineering.swat</groupId>
+            <artifactId>java-watch</artifactId>
+            <version>0.9.1</version>
+        </dependency>
     </dependencies>
     <profiles>
         <!-- this is preventing a bootstrap and perhaps we do not need it anymore at all?

--- a/src/org/rascalmpl/uri/ISourceLocationWatcher.java
+++ b/src/org/rascalmpl/uri/ISourceLocationWatcher.java
@@ -25,17 +25,25 @@ public interface ISourceLocationWatcher {
 	 * Register a watcher callback for the current scheme at the given root
 	 * @param root        the resource to watch
 	 * @param watcher     the callback to call when something happens to the registred resource
+	 * @param recursive   also watch all nested directories for changes (use {@link #supportsRecursiveWatch()} to verify it's supported)
 	 * @throws IOException
 	 */
-	void watch(ISourceLocation root, Consumer<ISourceLocationChanged> watcher) throws IOException;
+	void watch(ISourceLocation root, Consumer<ISourceLocationChanged> watcher, boolean recursive) throws IOException;
 
 	/**
 	 * Unregister a watcher callback for a specific uri (note, there can be multiple watchers per resource, this only clears this specific watcher)
 	 * @param root the resource to unwatch
 	 * @param watcher the specific callback to unregister
+	 * @param recursive  was the watch registered with a recursive flag (use {@link #supportsRecursiveWatch()} to verify it's supported)
 	 * @throws IOException
 	 */
-	void unwatch(ISourceLocation root, Consumer<ISourceLocationChanged> watcher) throws IOException;
+	void unwatch(ISourceLocation root, Consumer<ISourceLocationChanged> watcher, boolean recursive) throws IOException;
+
+	/**
+	 * Does this watcher support a recursive watch request.
+	 */
+	boolean supportsRecursiveWatch();
+
 
 	public interface ISourceLocationChanged {
 		ISourceLocation getLocation();

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -31,13 +31,11 @@ import java.util.Enumeration;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.rascalmpl.library.Prelude;
 import org.rascalmpl.unicode.UnicodeDetector;
@@ -46,6 +44,7 @@ import org.rascalmpl.unicode.UnicodeOffsetLengthReader;
 import org.rascalmpl.unicode.UnicodeOutputStreamWriter;
 import org.rascalmpl.uri.ISourceLocationWatcher.ISourceLocationChanged;
 import org.rascalmpl.uri.classloaders.IClassloaderLocationResolver;
+import org.rascalmpl.uri.watch.WatchRegistry;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
 
@@ -65,8 +64,6 @@ public class URIResolverRegistry {
 	private final Map<String, ISourceLocationOutput> outputResolvers = new ConcurrentHashMap<>();
 	private final Map<String, Map<String, ILogicalSourceLocationResolver>> logicalResolvers = new ConcurrentHashMap<>();
 	private final Map<String, IClassloaderLocationResolver> classloaderResolvers = new ConcurrentHashMap<>();
-	private final Map<String, ISourceLocationWatcher> watchers = new ConcurrentHashMap<>();
-	private final Map<ISourceLocation, Set<Consumer<ISourceLocationChanged>>> watching = new ConcurrentHashMap<>();
 
 	// we allow the user to define (using -Drascal.fallbackResolver=fully.qualified.classname) a single class that will handle
 	// scheme's not statically registered. That class should implement at least one of these interfaces
@@ -74,15 +71,17 @@ public class URIResolverRegistry {
 	private volatile @Nullable ISourceLocationOutput fallbackOutputResolver;
 	private volatile @Nullable ILogicalSourceLocationResolver fallbackLogicalResolver;
 	private volatile @Nullable IClassloaderLocationResolver fallbackClassloaderResolver;
-	private volatile @Nullable ISourceLocationWatcher fallbackWatcher;
 
 	private static class InstanceHolder {
 		static URIResolverRegistry sInstance = new URIResolverRegistry();
 	}
 
+	private final WatchRegistry watchers;
 	private URIResolverRegistry() {
+		watchers = new WatchRegistry(this, this::safeResolve);
 		loadServices();
 	}
+
 
 	/**
 	 * Use with care! This (expensive) reinitialization method clears all caches of all resolvers by
@@ -179,7 +178,7 @@ public class URIResolverRegistry {
 			}
 
 			if (instance instanceof ISourceLocationWatcher) {
-				fallbackWatcher = (ISourceLocationWatcher) instance;
+				watchers.setFallback((ISourceLocationWatcher) instance);
 			}
 			if (!ok) {
 				System.err.println("WARNING: could not load fallback resolver " + fallbackClass
@@ -300,14 +299,7 @@ public class URIResolverRegistry {
 
 		public void close() throws IOException {
 			super.close();
-
-			if (watchers.get(loc.getScheme()) == null) {
-				notifyWatcher(loc, event);
-			}
-			else {
-				// if there were watchers registered, then they
-				// should do the notifications
-			}
+			notifyWatcher(loc, event);
 		}
 
 		@Override
@@ -417,7 +409,7 @@ public class URIResolverRegistry {
 		return loc;
 	}
 
-	private ISourceLocation safeResolve(ISourceLocation loc) {
+	private @NonNull ISourceLocation safeResolve(@NonNull ISourceLocation loc) {
 		ISourceLocation resolved = null;
 
 		try {
@@ -449,7 +441,7 @@ public class URIResolverRegistry {
 	}
 
 	private void registerWatcher(ISourceLocationWatcher resolver) {
-		watchers.put(resolver.scheme(), resolver);
+		watchers.registerNative(resolver.scheme(), resolver);
 	}
 
 	public void unregisterLogical(String scheme, String auth) {
@@ -585,27 +577,8 @@ public class URIResolverRegistry {
 		notifyWatcher(URIUtil.getParentLocation(uri), ISourceLocationWatcher.directoryCreated(uri));
 	}
 
-	private final ExecutorService exec = Executors.newCachedThreadPool(new ThreadFactory() {
-			public Thread newThread(Runnable r) {
-            	SecurityManager s = System.getSecurityManager();
-            	ThreadGroup group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
-				Thread t = new Thread(group, r, "Generic watcher thread-pool");
-				t.setDaemon(true);
-				return t;
-			}
-		});
 	private void notifyWatcher(ISourceLocation key, ISourceLocationChanged event) {
-		if (watchers.containsKey(key.getScheme())) {
-			// the registered watcher will do the callback itself
-			return;
-		}
-		Set<Consumer<ISourceLocationChanged>> callbacks = watching.get(key);
-		if (callbacks != null) {
-			// we schedule the call in the background
-			for (Consumer<ISourceLocationChanged> c : callbacks) {
-				exec.submit(() -> c.accept(event));
-			}
-		}
+		watchers.notifySimulatedWatchers(key, event);
 	}
 
 	public void remove(ISourceLocation uri, boolean recursive) throws IOException {
@@ -1005,7 +978,6 @@ public class URIResolverRegistry {
 		// It is assumed that if writeable file channels are supported for a given scheme,
 		// that also a watcher is registered for the given stream, so we do not have to
 		// notify any watchers ourselves
-		assert watchers.get(uri.getScheme()) != null;
 		return resolver.getWritableOutputStream(uri, append);
 	}
 
@@ -1020,78 +992,13 @@ public class URIResolverRegistry {
 
 	public void watch(ISourceLocation loc, boolean recursive, final Consumer<ISourceLocationChanged> callback)
 		throws IOException {
-		if (!isDirectory(loc)) {
-			// so underlying implementations of ISourceLocationWatcher only have to support
-			// watching directories (the native NEO file watchers are like that)
-			loc = URIUtil.getParentLocation(loc);
-		}
-
-		final ISourceLocation finalLocCopy = loc;
-		final ISourceLocation resolvedLoc  = safeResolve(loc);
-
-		Consumer<ISourceLocationChanged> newCallback = !resolvedLoc.equals(loc) ? 
-			// we resolved logical resolvers in order to use native watchers as much as possible
-			// for efficiency sake, but this breaks the logical URI abstraction. We have to undo
-			// this renaming before we trigger the callback.
-			changes -> {
-				ISourceLocation relative = URIUtil.relativize(resolvedLoc, changes.getLocation());
-				ISourceLocation unresolved = URIUtil.getChildLocation(finalLocCopy, relative.getPath());
-				callback.accept(ISourceLocationWatcher.makeChange(unresolved, changes.getChangeType(), changes.getType()));
-			}
-			: callback;
-
-		ISourceLocationWatcher watcher = watchers.getOrDefault(resolvedLoc.getScheme(), fallbackWatcher);
-		if (watcher != null) {
-			watcher.watch(resolvedLoc, callback);
-		}
-		else {
-			watching.computeIfAbsent(resolvedLoc, k -> ConcurrentHashMap.newKeySet()).add(newCallback);
-		}
-
-		if (isDirectory(resolvedLoc) && recursive) {
-			for (ISourceLocation elem : list(resolvedLoc)) {
-				if (isDirectory(elem)) {
-					try {
-						watch(elem, recursive, newCallback);
-					}
-					catch (IOException e) {
-						// we swallow recursive IO errors which can be caused by file permissions.
-						// it is acceptable that inaccessible files are not watched
-					}
-				}
-			}
-		}
+		watchers.watch(loc, recursive, callback);
 	}
+
 
 	public void unwatch(ISourceLocation loc, boolean recursive, Consumer<ISourceLocationChanged> callback)
 		throws IOException {
-		loc = safeResolve(loc);
-		if (!isDirectory(loc)) {
-			// so underlying implementations of ISourceLocationWatcher only have to support
-			// watching directories (the native NEO file watchers are like that)
-			loc = URIUtil.getParentLocation(loc);
-		}
-		ISourceLocationWatcher watcher = watchers.getOrDefault(loc.getScheme(), fallbackWatcher);
-		if (watcher != null) {
-			watcher.unwatch(loc, callback);
-		}
-		else {
-			watching.getOrDefault(loc, Collections.emptySet()).remove(callback);
-		}
-		if (isDirectory(loc) && recursive) {
-			for (ISourceLocation elem : list(loc)) {
-				if (isDirectory(elem)) {
-					try {
-						unwatch(elem, recursive, callback);
-					}
-					catch (IOException e) {
-						// we swallow recursive IO errors which can be caused by file permissions.
-						// it is acceptable that inaccessible files are not watched
-					}
-				}
-			}
-		}
-
+		watchers.unwatch(loc, recursive, callback);
 	}
 
 	// these types must align with their correspondig types in IO.rsc
@@ -1130,7 +1037,7 @@ public class URIResolverRegistry {
 			result.insert(vf.constructor(loadCap));
 		}
 
-		if (watchers.containsKey(scheme)) {
+		if (watchers.hasNativeSupport(scheme)) {
 			result.insert(vf.constructor(watchCap));
 		}
 	
@@ -1154,7 +1061,7 @@ public class URIResolverRegistry {
 	}
 
 	public boolean hasNativelyWatchableResolver(ISourceLocation loc) {
-		return watchers.containsKey(loc.getScheme()) || watchers.containsKey(safeResolve(loc).getScheme());
+		return watchers.hasNativeSupport(loc.getScheme()) || watchers.hasNativeSupport(safeResolve(loc).getScheme());
 	}
 
 }

--- a/src/org/rascalmpl/uri/file/FileURIResolver.java
+++ b/src/org/rascalmpl/uri/file/FileURIResolver.java
@@ -26,45 +26,37 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.OpenOption;
-import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Map;
-import java.util.Set;
-import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 
 import org.rascalmpl.uri.BadURIException;
 import org.rascalmpl.uri.ISourceLocationInputOutput;
 import org.rascalmpl.uri.ISourceLocationWatcher;
-import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.uri.classloaders.IClassloaderLocationResolver;
 
+import engineering.swat.watch.ActiveWatch;
+import engineering.swat.watch.Approximation;
+import engineering.swat.watch.Watch;
+import engineering.swat.watch.WatchEvent;
+import engineering.swat.watch.WatchScope;
 import io.usethesource.vallang.ISourceLocation;
 
 public class FileURIResolver implements ISourceLocationInputOutput, IClassloaderLocationResolver, ISourceLocationWatcher {
-	private final Map<ISourceLocation, Set<Consumer<ISourceLocationChanged>>> watchers = new ConcurrentHashMap<>();
-	private final Map<WatchKey, ISourceLocation> watchKeys = new ConcurrentHashMap<>();
-	private final WatchService watcher;
+	private final Map<WatchId, ActiveWatch> watchers = new ConcurrentHashMap<>();
 	
 	public FileURIResolver() throws IOException {
 		super();
-		this.watcher = FileSystems.getDefault().newWatchService();
-		createFileWatchingThread();
 	}
 	
 	
@@ -240,138 +232,110 @@ public class FileURIResolver implements ISourceLocationInputOutput, IClassloader
 		}
 		throw new IOException("uri has no path: " + uri);
 	}
+
+	private final ExecutorService watcherPool = Executors.newCachedThreadPool((Runnable r) -> {
+		SecurityManager s = System.getSecurityManager();
+		ThreadGroup group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+		Thread t = new Thread(group, r, "file:/// watcher thread-pool");
+		t.setDaemon(true);
+		return t;
+	});
 	
 	@Override
-	public void watch(ISourceLocation root, Consumer<ISourceLocationChanged> callback) throws IOException {
-		watchers.computeIfAbsent(root, k -> ConcurrentHashMap.newKeySet()).add(callback);
+	public void watch(ISourceLocation root, Consumer<ISourceLocationChanged> callback, boolean recursive) throws IOException {
+		var rootFile = resolveToFile(root);
 
-		WatchKey key = resolveToFile(root).toPath().register(watcher,
-			StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY
-		);
-
-		synchronized(watchKeys) {
-			// to avoid races with an unwatch, we lock here
-			watchKeys.put(key, root);
+		WatchScope scope;
+		if (rootFile.isFile()) {
+			scope = WatchScope.PATH_ONLY;
 		}
+		else if (recursive) {
+			scope = WatchScope.PATH_AND_ALL_DESCENDANTS;
+		}
+		else {
+			scope = WatchScope.PATH_AND_CHILDREN;
+		}
+
+		var watch = Watch.build(rootFile.toPath(), scope)
+			.onOverflow(Approximation.ALL)
+			.withExecutor(watcherPool)
+			.on(e -> {
+				var change = calculateChange(e, root);
+				if (change != null) {
+					watcherPool.submit(() -> callback.accept(change));
+				}
+			})
+			.start();
+
+		watchers.put(new WatchId(root, callback, recursive), watch);
 	}
 
 	@Override
-	public void unwatch(ISourceLocation root, Consumer<ISourceLocationChanged> callback) throws IOException {
-		Set<Consumer<ISourceLocationChanged>> registered = watchers.get(root);
-		if (registered == null || !registered.remove(callback)) {
-			return;
-		}
-		if (registered.isEmpty()) {
-			// we have to try and clear the relevant watchkey
-			// but sadly this is a full loop
-			for (Entry<WatchKey, ISourceLocation> e: watchKeys.entrySet()) {
-				if (e.getValue().equals(root)) {
-					synchronized(watchKeys) {
-						// avoiding races with watch, we lock on the map remove
-						if (registered.isEmpty()) {// check again if we truly aren't replacing a key that should still be active
-							WatchKey k = e.getKey();
-							k.cancel();
-							watchKeys.remove(k);
-						}
-					}
-					break;
-				}
-			}
-		}
+	public boolean supportsRecursiveWatch() {
+		return true;
 	}
 
-	private void createFileWatchingThread() {
-		// make a threadpool of daemon threads, to avoid this pool keeping the process running
-		ExecutorService exec = Executors.newCachedThreadPool(new ThreadFactory() {
-			public Thread newThread(Runnable r) {
-            	SecurityManager s = System.getSecurityManager();
-            	ThreadGroup group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
-				Thread t = new Thread(group, r, "file:/// watcher thread-pool");
-				t.setDaemon(true);
-				return t;
-			}
-		});
-
-		exec.execute(() -> {
-			while (true) {
-				// wait for key to be signaled
-				try {
-					WatchKey key = watcher.take();
-					try {
-						ISourceLocation root = watchKeys.get(key);
-						if (root == null) {
-							continue; // key not in the map anymore/yet?
-						}
-						for (WatchEvent<?> event: key.pollEvents()) {
-							WatchEvent.Kind<?> kind = event.kind();
-							
-							if (kind == StandardWatchEventKinds.OVERFLOW) {
-								continue;
-							}
-							
-							Set<Consumer<ISourceLocationChanged>> callbacks = watchers.get(root);
-							if (callbacks != null) {
-								@SuppressWarnings("unchecked")
-								Path filename = ((WatchEvent<Path>)event).context();
-								ISourceLocation subject = URIUtil.getChildLocation(root, filename.toString());
-
-								ISourceLocationChanged change = calculateChange(key, root, kind, subject);
-								if (change != null) {
-									for (Consumer<ISourceLocationChanged> c: callbacks) {
-										exec.execute(() -> c.accept(change));
-									}
-								}
-							}
-						}
-
-					} finally {
-						if (!key.reset()) {
-							watchKeys.remove(key);
-						}
-					}
-
-				} catch (InterruptedException e ){
-					return;
-				} catch (Throwable x) {
-					System.err.println("Error handling callback in FileURIResolver: " + x.getMessage());
-					x.printStackTrace(System.err);
-					continue;
-				}
-			}
-		});
+	@Override
+	public void unwatch(ISourceLocation root, Consumer<ISourceLocationChanged> callback, boolean recursive) throws IOException {
+		var activeWatch = watchers.remove(new WatchId(root, callback, recursive));
+		activeWatch.close();
 	}
 
-
-	private ISourceLocationChanged calculateChange(WatchKey key, ISourceLocation root, WatchEvent.Kind<?> kind,
-		ISourceLocation subject) {
-		boolean isDirectory = URIResolverRegistry.getInstance().isDirectory(subject);
-		switch (kind.name()) {
-			case "ENTRY_CREATE":
+	private ISourceLocationChanged calculateChange(WatchEvent event, ISourceLocation root) {
+		var subject = URIUtil.getChildLocation(root, event.getRelativePath().toString());
+		// note in case of delete we don't know anymore if the deleted entry was a file or a directory
+		boolean isDirectory = event.getRelativePath().toString().isEmpty() || Files.isDirectory(event.calculateFullPath()); 
+		switch (event.getKind()) {
+			case CREATED:
 				return ISourceLocationWatcher.makeChange(
 					subject, 
 					ISourceLocationChangeType.CREATED, 
 					isDirectory ? ISourceLocationType.DIRECTORY : ISourceLocationType.FILE);
-			case "ENTRY_DELETE":
-
-				watchers.remove(subject);
-				if (root.equals(subject)) {
-					watchKeys.remove(key);
-				}
-
+			case DELETED:
 				return ISourceLocationWatcher.makeChange(
 					subject, 
 					ISourceLocationChangeType.DELETED, 
 					isDirectory ? ISourceLocationType.DIRECTORY : ISourceLocationType.FILE);
 
-			case "ENTRY_MODIFY":
+			case MODIFIED:
 				return ISourceLocationWatcher.makeChange(
 					subject, 
 					ISourceLocationChangeType.MODIFIED, 
 					isDirectory ? ISourceLocationType.DIRECTORY : ISourceLocationType.FILE)
 				;
-			case "OVERFLOW": //ignored
+			case OVERFLOW:
 			default:
 				return null;
 		}
+	}
+
+
+	private static class WatchId {
+		final ISourceLocation root;
+		final Consumer<ISourceLocationChanged> callback;
+		final boolean recursive;
+		public WatchId(ISourceLocation root, Consumer<ISourceLocationChanged> callback, boolean recursive) {
+			this.root = root;
+			this.callback = callback;
+			this.recursive = recursive;
+		}
+		@Override
+		public int hashCode() {
+			return Objects.hash(root, callback, recursive);
+		}
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (!(obj instanceof WatchId)) {
+				return false;
+			}
+			WatchId other = (WatchId) obj;
+			return Objects.equals(root, other.root) 
+				&& Objects.equals(callback, other.callback)
+				&& recursive == other.recursive;
+		}
+		
 	}
 }

--- a/src/org/rascalmpl/uri/watch/SimulatedRecursiveWatcher.java
+++ b/src/org/rascalmpl/uri/watch/SimulatedRecursiveWatcher.java
@@ -1,0 +1,125 @@
+package org.rascalmpl.uri.watch;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+import org.rascalmpl.uri.ISourceLocationWatcher;
+import org.rascalmpl.uri.ISourceLocationWatcher.ISourceLocationChanged;
+import org.rascalmpl.uri.URIResolverRegistry;
+
+import io.usethesource.vallang.ISourceLocation;
+
+/**
+ * Some ISourceLocationWatchers do not support recursive watches, this class approximates that feature on top of the native one
+ */
+public class SimulatedRecursiveWatcher implements Closeable {
+
+    private volatile boolean closed = false;
+    private final ISourceLocationWatcher nativeWatcher;
+    private final List<Consumer<ISourceLocationChanged>> subscriptions = new CopyOnWriteArrayList<>();
+    private final Set<ISourceLocation> activeWatches = ConcurrentHashMap.newKeySet();
+    private final Executor exec;
+
+    public SimulatedRecursiveWatcher(ISourceLocation rootLocation, Consumer<ISourceLocationChanged> initialConsumer,
+        ISourceLocationWatcher nativeWatcher, Executor exec) {
+        this.nativeWatcher = nativeWatcher;
+        this.exec = exec;
+        subscriptions.add(initialConsumer);
+        try {
+            nativeWatcher.watch(rootLocation, this::handler, false);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        registerChildWatches(rootLocation);
+    }
+
+    private void handler(ISourceLocationChanged event) {
+        if (closed) {
+            return;
+        }
+        for (var s : subscriptions) {
+            exec.execute(() -> s.accept(event));
+        }
+
+        var loc = event.getLocation();
+        if (event.isCreated() && event.isDirectory()) {
+            registerChildWatches(loc);
+        }
+        else if (event.isDeleted() && activeWatches.contains(loc)) {
+            try {
+                activeWatches.remove(loc);
+                nativeWatcher.unwatch(loc, this::handler, false);
+            }
+            catch (Exception ignored) { }
+        }
+    }
+
+    private void registerChildWatches(ISourceLocation loc) {
+        if (closed) {
+            return;
+        }
+        exec.execute(() -> {
+            var reg = URIResolverRegistry.getInstance();
+            Deque<ISourceLocation> todo = new ArrayDeque<>();
+            todo.push(loc);
+            while (!todo.isEmpty()) {
+                var current = todo.pop();
+                if (!activeWatches.contains(current)) {
+                    try {
+                        nativeWatcher.watch(current, this::handler, false);
+                        activeWatches.add(current);
+                        for (var e: reg.list(current)) {
+                            if (reg.isDirectory(e)) {
+                                todo.push(e);
+                            }
+                        }
+                    }
+                    catch (IOException e) {
+                    }
+                }
+            }
+        });
+    }
+
+    public void add(Consumer<ISourceLocationChanged> c) {
+        subscriptions.add(c);
+    }
+
+    public void remove(Consumer<ISourceLocationChanged> c) {
+        subscriptions.remove(c);
+    }
+
+    public boolean isEmpty() {
+        return subscriptions.isEmpty();
+    }
+
+    public SimulatedRecursiveWatcher merge(SimulatedRecursiveWatcher b) {
+        subscriptions.addAll(b.subscriptions);
+        try {
+            b.close();
+        } catch (Exception ignore) {}
+        return this;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        for (var a: activeWatches) {
+            try {
+                nativeWatcher.unwatch(a, this::handler, false);
+            }
+            catch (IOException e) {
+            }
+        }
+        activeWatches.clear();
+    }
+
+}

--- a/src/org/rascalmpl/uri/watch/WatchRegistry.java
+++ b/src/org/rascalmpl/uri/watch/WatchRegistry.java
@@ -1,0 +1,258 @@
+package org.rascalmpl.uri.watch;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.rascalmpl.uri.ISourceLocationWatcher;
+import org.rascalmpl.uri.ISourceLocationWatcher.ISourceLocationChanged;
+import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.uri.URIUtil;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.usethesource.vallang.ISourceLocation;
+
+/**
+ * This is a companion class to the {@link URIResolverRegistry} that contains all the logic around watches and simulated watches
+ * to reduce the class size of the uri registry
+ */
+public class WatchRegistry {
+    /** schemes with native support */
+    private final Map<String, ISourceLocationWatcher> watchers = new ConcurrentHashMap<>();
+    /** simulate recursive watches active on schemes with native support */
+    private final Map<ISourceLocation, SimulatedRecursiveWatcher> simulatedRecursiveWatchers = new ConcurrentHashMap<>();
+
+    /** simulated locations that are watched */
+    private final NavigableMap<ISourceLocation, Set<SimulatedWatchEntry>> internalWatchers = new ConcurrentSkipListMap<>(makeISourceLocationComparator());
+
+    /** keep track of original wrappers vs translating wrappers to provide the correct instance to unwatch (not an actual cache!) */
+    private final Cache<Consumer<ISourceLocationChanged>, Consumer<ISourceLocationChanged>> wrappedHandlers = Caffeine.newBuilder()
+        .weakKeys()
+        .weakValues()
+        .build();
+    private final URIResolverRegistry reg;
+    private final UnaryOperator<ISourceLocation> resolver;
+    private volatile @Nullable ISourceLocationWatcher fallback;
+
+    public WatchRegistry(URIResolverRegistry reg, UnaryOperator<ISourceLocation> resolver) {
+        this.reg = reg;
+        this.resolver = resolver;
+        cleanup();
+    }
+
+
+    public void registerNative(String scheme, ISourceLocationWatcher watcher) {
+        watchers.put(scheme, watcher);
+    }
+    public void setFallback(ISourceLocationWatcher fallback) {
+        this.fallback = fallback;
+    }
+
+    private ISourceLocation safeResolve(ISourceLocation loc) {
+        return resolver.apply(loc);
+    }
+    
+    private static Comparator<ISourceLocation> makeISourceLocationComparator() {
+        return Comparator
+            .comparing(ISourceLocation::getScheme)
+            .thenComparing(ISourceLocation::getAuthority)
+            .thenComparing(ISourceLocation::getPath)
+            .thenComparing(ISourceLocation::getQuery);
+    }
+
+    public void watch(ISourceLocation loc, boolean recursive, final Consumer<ISourceLocationChanged> callback)
+        throws IOException {
+        var resolvedLoc = safeResolve(loc);
+        var watcher = watchers.getOrDefault(resolvedLoc.getScheme(), fallback);
+        if (watcher != null) {
+            startNormalWatch(loc, recursive, callback, resolvedLoc, watcher);
+        }
+        startSimulatedWatch(loc, recursive, callback, resolvedLoc);
+    }
+
+    private void startSimulatedWatch(ISourceLocation loc, boolean recursive, Consumer<ISourceLocationChanged> callback,
+        ISourceLocation resolvedLoc) {
+        internalWatchers
+            .computeIfAbsent(resolvedLoc, k -> ConcurrentHashMap.newKeySet())
+            .add(new SimulatedWatchEntry(recursive, translateWatchEvents(callback, loc, resolvedLoc)));
+    }
+
+    private ISourceLocation startNormalWatch(ISourceLocation loc, boolean recursive,
+        final Consumer<ISourceLocationChanged> callback, ISourceLocation resolvedLoc, ISourceLocationWatcher watcher)
+        throws IOException {
+        // a watcher should be able to deal with single file watches
+        // but not a recursive one
+        if (recursive && !reg.isDirectory(resolvedLoc)) {
+            loc = URIUtil.getParentLocation(loc);
+            resolvedLoc = safeResolve(loc);
+        }
+        var translator = translateWatchEvents(callback, loc, resolvedLoc);
+        if ((recursive && watcher.supportsRecursiveWatch()) || !recursive) {
+            watcher.watch(resolvedLoc, translator, recursive);
+        }
+        else {
+            // we have to simulate a recursive watch based on an non recursive watch
+            // this is always a limit, as we have to deal with removes & additions
+            // but we do our best to simulate the recursive behavior
+            simulatedRecursiveWatchers
+                .computeIfAbsent(resolvedLoc, rl -> new SimulatedRecursiveWatcher(rl, translator, watcher, exec))
+                .add(translator);
+        }
+        return loc;
+    }
+
+    private Consumer<ISourceLocationChanged> translateWatchEvents(Consumer<ISourceLocationChanged> original, ISourceLocation originalLoc, ISourceLocation resolvedLoc) {
+        if (resolvedLoc.equals(originalLoc)) {
+            return original;
+        }
+        // we resolved logical resolvers in order to use native watchers as much as possible
+        // for efficiency sake, but this breaks the logical URI abstraction. We have to undo
+        // this renaming before we trigger the callback.
+        Consumer<ISourceLocationChanged> newHandler = changes -> {
+            ISourceLocation relative = URIUtil.relativize(resolvedLoc, changes.getLocation());
+            ISourceLocation unresolved = URIUtil.getChildLocation(originalLoc, relative.getPath());
+            original.accept(ISourceLocationWatcher.makeChange(unresolved, changes.getChangeType(), changes.getType()));
+        };
+        // for the unwatch we have to keep track of all the handlers we've passed along
+        wrappedHandlers.put(original, newHandler);
+        return newHandler;
+    }
+
+    public void unwatch(ISourceLocation loc, boolean recursive, Consumer<ISourceLocationChanged> callback)
+        throws IOException {
+        // we might have wrapped it, so let's first lookup that wrapped callback
+        var actualCallback = wrappedHandlers.getIfPresent(callback);
+        if (actualCallback != null) {
+            wrappedHandlers.invalidate(callback);
+            callback = actualCallback;
+        }
+
+        loc = safeResolve(loc);
+
+        var watcher = watchers.getOrDefault(loc.getScheme(), fallback);
+        if (watcher != null) {
+            var simulated = simulatedRecursiveWatchers.get(loc);
+            if (simulated != null) {
+                simulated.remove(callback);
+            }
+            else {
+                watcher.unwatch(loc, callback, recursive);
+            }
+        }
+        else {
+            var entries = internalWatchers.get(loc);
+            if (entries != null) {
+                final var finalCallback = callback;
+                entries.removeIf(p -> p.isRecursive() == recursive && p.getHandler() == finalCallback);
+            }
+        }
+    }
+
+    /** a private daemon thread thread-pool */
+    private final ExecutorService exec = Executors.newCachedThreadPool((Runnable r) -> {
+        SecurityManager s = System.getSecurityManager();
+        ThreadGroup group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        Thread t = new Thread(group, r, "Generic watcher thread-pool");
+        t.setDaemon(true);
+        return t;
+    });
+
+    public void notifySimulatedWatchers(ISourceLocation key, ISourceLocationChanged event) {
+        if (watchers.containsKey(key.getScheme())) {
+            // the registered watcher will do the callback itself
+            return;
+        }
+        var callbacks = internalWatchers.floorEntry(key);
+        if (callbacks != null) {
+            var exactMatch = callbacks.getKey().equals(key);
+            if (exactMatch || URIUtil.isParentOf(callbacks.getKey(), key)) {
+                var onlyRecursive = !exactMatch && !URIUtil.getParentLocation(key).equals(callbacks.getKey());
+                for (var c : callbacks.getValue()) {
+                    if (!onlyRecursive || c.isRecursive()) {
+                        // we schedule the call in the background
+                        exec.submit(() -> c.getHandler().accept(event));
+                    }
+                }
+            }
+        }
+    }
+
+    private void cleanup() {
+        try {
+            cleanupInternalWatchers();
+            cleanupSimulatedWatchers();
+        }
+        finally {
+            CompletableFuture.delayedExecutor(1, TimeUnit.MINUTES, exec)
+                .execute(this::cleanup);
+        }
+    }
+
+
+    private void cleanupSimulatedWatchers() {
+        for (var e: simulatedRecursiveWatchers.entrySet()) {
+            if (e.getValue().isEmpty()) {
+                var k = e.getKey();
+                var v = e.getValue(); 
+                if (simulatedRecursiveWatchers.remove(k, v) && !v.isEmpty()) {
+                    // lost the race between cleanup and a new watch
+                    simulatedRecursiveWatchers.merge(k, v, (a, b) -> a.merge(b));
+                }
+                else {
+                    v.close();
+                }
+            }
+        }
+    }
+
+
+    private void cleanupInternalWatchers() {
+        for (var e : internalWatchers.entrySet()) {
+            if (e.getValue().isEmpty()) {
+                // take a copy in case we loose a race
+                var k = e.getKey();
+                var v = e.getValue(); 
+                if (internalWatchers.remove(k, v) && !v.isEmpty()) {
+                    // lost the race between cleanup and a new watch
+                    internalWatchers.merge(k, v, (a,b) -> { a.addAll(b); return a; });
+                }
+            }
+        }
+    }
+
+    public boolean hasNativeSupport(String scheme) {
+        return watchers.containsKey(scheme);
+    }
+
+    private static class SimulatedWatchEntry {
+        private final boolean recursive;
+        private final Consumer<ISourceLocationChanged> handler;
+
+        public SimulatedWatchEntry(boolean recursive, Consumer<ISourceLocationChanged> handler) {
+            this.recursive = recursive;
+            this.handler = handler;
+        }
+
+        public boolean isRecursive() {
+            return recursive;
+        }
+
+        public Consumer<ISourceLocationChanged> getHandler() {
+            return handler;
+        }
+    }
+
+}


### PR DESCRIPTION
This PR introduces:

- a new implementation of the watch feature that on OSX used the native APIs that avoid the current JDK polling
- fixes a range of bugs found in our emulation of the watches for resolvers that did not support it nativly
- allows resolvers to support recursive watches
- fix bugs in implementation that would simulate the recursive watches (for example, it would not register a watch in a new directory)

This replaces the #1659 PR.