### PR TITLE
Implemented low-hanging fruit from error tree support

### DIFF
--- a/src/org/rascalmpl/exceptions/RuntimeExceptionFactory.java
+++ b/src/org/rascalmpl/exceptions/RuntimeExceptionFactory.java
@@ -107,6 +107,8 @@ public class RuntimeExceptionFactory {
     public static final Type StackOverflow = TF.constructor(TS, Exception, "StackOverflow");
     public static final Type UnavailableInformation = TF.constructor(TS,Exception, "UnavailableInformation");
 	
+	public static final Type ParseErrorRecovery = TF.constructor(TS, Exception, "ParseErrorRecovery", Exception, "trigger", TF.sourceLocationType(), "location");
+
 	// The "official" exceptions that a Rascal program can catch (alphabetical order)
 	
     // ambiguity
@@ -739,5 +741,14 @@ public class RuntimeExceptionFactory {
 	
 	public static Throw nameMismatch(String expected, String got, AbstractAST ast, StackTrace trace) {
 		return new Throw(VF.constructor(NameMismatch, VF.string(expected), VF.string(got)), ast != null ? ast.getLocation() : null, trace);
+	}
+
+	// ParseErrorRecovery -- not in Exception, defined in ParseTree.rsc
+	public static Throw parseErrorRecovery(IValue trigger, ISourceLocation loc) {
+		return new Throw(VF.constructor(ParseErrorRecovery, trigger, loc));
+	}
+
+	public static Throw parseErrorRecoveryNoSuchField(String name, ISourceLocation loc) {
+		return new Throw(VF.constructor(ParseErrorRecovery, VF.constructor(NoSuchField, VF.string(name)), loc));
 	}
 }

--- a/src/org/rascalmpl/library/ParseTree.rsc
+++ b/src/org/rascalmpl/library/ParseTree.rsc
@@ -194,6 +194,17 @@ data Production
      = \error(Symbol def, Production prod, int dot)
      | \skipped(Symbol def);
 
+@synopsis{A special exception that wraps errors that are (almost) certainly caused by unexpected parse errors}
+@description{
+  Certain operations will always succeed on regular parse trees but will fail when the parse tree is an error Tree
+  resulting from error recovery.
+  A typical example is `t.someField` where `t` is an error node and `someField` is a field that would normally
+  be present in the tree but is after the dot so it is missing.
+  Normally  a `NoSuchField("someField")` exception would be thrown but because this problem is caused by a parse error,
+  the original exception is wrapped like this: `ParseErrorRecovery(NoSuchField("someField"), t.src)`.
+}
+data RuntimeException = ParseErrorRecovery(RuntimeException trigger, loc src);
+
 @synopsis{Attributes in productions.}
 @description{
 An `Attr` (attribute) documents additional semantics of a production rule. Neither tags nor

--- a/src/org/rascalmpl/values/parsetrees/ProductionAdapter.java
+++ b/src/org/rascalmpl/values/parsetrees/ProductionAdapter.java
@@ -21,7 +21,10 @@ import io.usethesource.vallang.IListWriter;
 import io.usethesource.vallang.INode;
 import io.usethesource.vallang.ISet;
 import io.usethesource.vallang.IString;
+import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.IValue;
+
+import static org.rascalmpl.values.RascalValueFactory.Symbol_Lit;
 
 import org.rascalmpl.exceptions.ImplementationError;
 import org.rascalmpl.values.RascalValueFactory;
@@ -81,6 +84,40 @@ public class ProductionAdapter {
 		}
 		
 		return writer.done();
+	}
+
+	public static int getErrorDot(IConstructor prod) {
+		if (!isError(prod)) {
+			throw new ImplementationError("This is not an error production: " + prod);
+		}
+
+		return ((IInteger)prod.get(2)).intValue();
+	}
+
+	public static IConstructor getErrorProduction(IConstructor prod) {
+		if (!isError(prod)) {
+			throw new ImplementationError("This is not an error production: " + prod);
+		}
+
+		return ((IConstructor) prod.get(1));
+	}
+
+	public static int getAstArgCount(IConstructor prod) {
+		int count = 0;
+		boolean isLayout = false;
+		for (IValue child : ProductionAdapter.getSymbols(prod)) {
+			if (isLayout) {
+				isLayout = false;
+			} else {
+				IConstructor symbol = SymbolAdapter.delabel((IConstructor) child);
+				if (!SymbolAdapter.isLiteral(symbol) && !SymbolAdapter.isCILiteral(symbol)) {
+					count++;
+				}
+				isLayout = true; // Next symbol will be layout
+			}
+		}
+
+		return count;
 	}
 	
 	public static boolean isContextFree(IConstructor tree) {


### PR DESCRIPTION
This PR implements the following improvements:
- `is label` now fails on error trees
- `tree has field` now returns true if `field` is before the dot in an error tree
- `tree.field?` now returns true if `field` is before the dot in an error tree
- `tree.field` succeeds when `field` is before the dot and throws a wrapped exception when it is after the dot
- `tree.field = value` succeeds when `field` is before the dot and throws a wrapped exception when it is after the dot
- `tree[index]` now succeeds when `index` is before the dot and throws a wrapped exception when it is after the dot