### PR TITLE
diamond clashes tests

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Bottom.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Bottom.rsc
@@ -1,0 +1,9 @@
+module lang::rascal::tests::diamondImports::Bottom
+
+data Exp;
+
+data Bool
+    = \true()
+    | \false()
+    ;
+    

--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Left.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Left.rsc
@@ -9,6 +9,4 @@ data Exp
     | \false()
     ;
 
-data Exp2 = or(Exp lhs, Exp rhs);
-
 public str global = "World";

--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Left.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Left.rsc
@@ -1,0 +1,14 @@
+module lang::rascal::tests::diamondImports::Left
+
+import lang::rascal::tests::diamondImports::Bottom;
+
+data Exp
+    = or(Exp lhs, Exp rhs)
+    | maybe()
+    | \true()
+    | \false()
+    ;
+
+data Exp2 = and(Exp lhs, Exp rhs);
+
+public str global = "World";

--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Left.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Left.rsc
@@ -9,6 +9,6 @@ data Exp
     | \false()
     ;
 
-data Exp2 = and(Exp lhs, Exp rhs);
+data Exp2 = or(Exp lhs, Exp rhs);
 
 public str global = "World";

--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Right.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Right.rsc
@@ -6,4 +6,8 @@ data Exp
     = and(Bool lhs, Bool rhs)
     ;
 
+data Exp2 
+    = or(Exp lhs, Exp rhs)
+    ;
+
  public str global = "Hello"; 

--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Right.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Right.rsc
@@ -1,0 +1,9 @@
+module lang::rascal::tests::diamondImports::Right
+
+import lang::rascal::tests::diamondImports::Bottom;
+
+data Exp 
+    = and(Bool lhs, Bool rhs)
+    ;
+
+ public str global = "Hello"; 

--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Top.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Top.rsc
@@ -8,7 +8,7 @@ import lang::rascal::tests::diamondImports::Right;
 
 @expected{UnexpectedType}
 test bool fieldNameClashTest(bool leftOrRight) {
-    Exp example = leftOrRight 
+    example = leftOrRight 
         ? and(\true(), \true()) 
         : or(maybe(), maybe())
         ;
@@ -46,9 +46,15 @@ test bool whichConstructor(bool choice) {
         assert Exp _ := and(\true(), \false());
     }
 
-    // here we know which one to use
-    assert Exp2 _ := lang::rascal::tests::diamondImports::Left::and(\true(), \true());
-    assert Exp  _ := lang::rascal::tests::diamondImports::Right::and(\true(), \true());
+    // here we declare which one to use by module
+    assert Exp2 _ := lang::rascal::tests::diamondImports::Left::and(\true(), \true());  // \true() is unique because the context is provided
+    assert Exp  _ := lang::rascal::tests::diamondImports::Right::and(\true(), \true()); // \true() is unique because the context is provided
 
+    // it would be better if we could write shorter prefixes like: `Left::and(Left::\true())``
+    
+    // here we declare which one to use my ADT
+    assert Exp2 _ := Exp2::and(\true(), \true());  // \true() is unique because the context is provided
+    assert Exp  _ :=  Exp::and(\true(), \true());  // \true() is unique because the context is provided
+   
     return true;
 }

--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Top.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Top.rsc
@@ -47,8 +47,8 @@ test bool whichConstructor(bool choice) {
     }
 
     // here we declare which one to use by module
-    assert Exp2 _ := lang::rascal::tests::diamondImports::Left::or(\true(), \true());  // \true() is unique because the context is provided
-    assert Exp  _ := lang::rascal::tests::diamondImports::Right::or(\true(), \true()); // \true() is unique because the context is provided
+    assert Exp _ := lang::rascal::tests::diamondImports::Left::or(\true(), \true());  // \true() is unique because the context is provided
+    assert Exp2  _ := lang::rascal::tests::diamondImports::Right::or(\true(), \true()); // \true() is unique because the context is provided
 
     // it would be better if we could write shorter prefixes like: `Left::and(Left::\true())``
     

--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Top.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Top.rsc
@@ -1,0 +1,54 @@
+module lang::rascal::tests::diamondImports::Top
+
+import lang::rascal::tests::diamondImports::Bottom;
+
+// these imports should be allowed even though Left and Right contain conflicting field names
+import lang::rascal::tests::diamondImports::Left;
+import lang::rascal::tests::diamondImports::Right;
+
+@expected{UnexpectedType}
+test bool fieldNameClashTest(bool leftOrRight) {
+    Exp example = leftOrRight 
+        ? and(\true(), \true()) 
+        : or(maybe(), maybe())
+        ;
+
+    assert Bool _ := example.lhs; // ambiguous .lhs does not always produce a Bool
+    assert Exp _  := example.lhs; // ambiguous .lhs does not always produce an Exp
+
+    return true;
+}
+
+@expected{AssertionFailed}
+test bool whichGlobal(bool choice) {
+    if (choice) {
+        // this use should trigger an error: "ambiguous global variable reference"
+        assert global == "Hello";
+    }
+    else {
+        // this use should trigger an error: "ambiguous global variable reference"
+        assert global == "World";
+    }
+
+    assert lang::rascal::tests::diamondImports::Left::global == "Hello";
+    assert lang::rascal::tests::diamondImports::Right::global == "World";
+
+    return true;
+}
+
+test bool whichConstructor(bool choice) {
+    if (choice) {
+        // type-checker should complain that `and` and `true` are either from Left or from Right, or advise to use `extend
+        // NOTA BENE: this would be after RAP6; right now the constructors are simply overloaded and dynamically dispatched in arbitrary order.
+        assert Exp2 _ := and(\true(), \true());
+    }
+    else {
+        assert Exp _ := and(\true(), \false());
+    }
+
+    // here we know which one to use
+    assert Exp2 _ := lang::rascal::tests::diamondImports::Left::and(\true(), \true());
+    assert Exp  _ := lang::rascal::tests::diamondImports::Right::and(\true(), \true());
+
+    return true;
+}

--- a/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Top.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/diamondImports/Top.rsc
@@ -8,9 +8,9 @@ import lang::rascal::tests::diamondImports::Right;
 
 @expected{UnexpectedType}
 test bool fieldNameClashTest(bool leftOrRight) {
-    example = leftOrRight 
-        ? and(\true(), \true()) 
-        : or(maybe(), maybe())
+    Exp example = leftOrRight 
+        ? Exp::and(\true(), \true()) // resolution of \true() should be Bool::\true() due to context?
+        : Exp::or(maybe(), maybe())
         ;
 
     assert Bool _ := example.lhs; // ambiguous .lhs does not always produce a Bool
@@ -40,21 +40,21 @@ test bool whichConstructor(bool choice) {
     if (choice) {
         // type-checker should complain that `and` and `true` are either from Left or from Right, or advise to use `extend
         // NOTA BENE: this would be after RAP6; right now the constructors are simply overloaded and dynamically dispatched in arbitrary order.
-        assert Exp2 _ := and(\true(), \true());
+        assert Exp2 _ := or(\true(), \true());
     }
     else {
-        assert Exp _ := and(\true(), \false());
+        assert Exp _ := or(\true(), \false());
     }
 
     // here we declare which one to use by module
-    assert Exp2 _ := lang::rascal::tests::diamondImports::Left::and(\true(), \true());  // \true() is unique because the context is provided
-    assert Exp  _ := lang::rascal::tests::diamondImports::Right::and(\true(), \true()); // \true() is unique because the context is provided
+    assert Exp2 _ := lang::rascal::tests::diamondImports::Left::or(\true(), \true());  // \true() is unique because the context is provided
+    assert Exp  _ := lang::rascal::tests::diamondImports::Right::or(\true(), \true()); // \true() is unique because the context is provided
 
     // it would be better if we could write shorter prefixes like: `Left::and(Left::\true())``
     
     // here we declare which one to use my ADT
-    assert Exp2 _ := Exp2::and(\true(), \true());  // \true() is unique because the context is provided
-    assert Exp  _ :=  Exp::and(\true(), \true());  // \true() is unique because the context is provided
+    assert Exp2 _ := Exp2::or(\true(), \true());  // \true() is unique because the context is provided
+    assert Exp  _ :=  Exp::or(\true(), \true());  // \true() is unique because the context is provided
    
     return true;
 }

--- a/test/org/rascalmpl/test/AllSuite.java
+++ b/test/org/rascalmpl/test/AllSuite.java
@@ -16,6 +16,6 @@ import org.rascalmpl.test.infrastructure.RecursiveTest;
 import org.rascalmpl.test.infrastructure.RecursiveTestSuite;
 
 @RunWith(RecursiveTestSuite.class)
-@RecursiveTest({"basic", "concrete", "extend", "functionality", "imports", "library", "parser", "recovery", "syntax", "demo", "benchmark"})
+@RecursiveTest({"basic", "concrete", "extend", "functionality", "imports", "diamondImports", "library", "parser", "recovery", "syntax", "demo", "benchmark"})
 public class AllSuite {
 }


### PR DESCRIPTION
This branch adds a number of tests for the behavior of "diamond-shaped" imports and extends and the name collisions that can come from them, and how the static and dynamic semantics of Rascal should deal with them.

This is a work in progress. Currently we have this module setup:

```
                    Top
                  /  |   \
                imp  |    imp 
               /     |       \
            Left     |       Right
              \     imp      /
               imp    |    imp
                  \   |    /
                    Bottom
```

* [ ] We add correct but conflicting definitions to Left and Right, which are correct by themselves
* [ ] We add usages of the ambiguous names to `Top` and express expectations about static semantics and dynamic semantics as much as possible in code, and otherwise in comments.

> *Notice* these static and dynamic semantics are influenced greatly by what is described in [RAP6](https://www.rascal-mpl.org/docs/RascalAmendmentProposals/RAP6/)
> It could be (very) beneficial (i.e. save time) to apply RAP6 as we are resolving these issues, in the same go. 
> This is because RAP6 clarifies the differences between `import` and `extend` and also resolves a number of
> hard to follow interactions w.r.t. to overloaded and ambiguous names in Rascal.