### PR TITLE
Fix rascal lsp hard coded path config

### DIFF
--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -568,13 +568,15 @@ public class PathConfig {
             if (libProjectName.equals("rascal")) {
                 return; 
             }
-            boolean dependsOnRascalLSP = libProjectName.equals("rascal-lsp");
-            if (dependsOnRascalLSP) {
+            if (libProjectName.equals("rascal-lsp")) {
                 checkLSPVersionsMatch(manifestRoot, messages, dep);
+                // we'll be adding the rascal-lsp by hand later
+                // so we ignore the rascal-lsp dependency
+                return;
             }
             ISourceLocation projectLoc = URIUtil.correctLocation("project", libProjectName, "");
 
-            if (reg.exists(projectLoc) && !dependsOnRascalLSP) {
+            if (reg.exists(projectLoc)) {
                 // The project we depend on is available in the current workspace. 
                 // so we configure for using the current state of that project.
                 messages.append(Messages.info("Redirected: " + art.getCoordinate() + " to: " + projectLoc, getPomXmlLocation(manifestRoot)));
@@ -611,7 +613,7 @@ public class PathConfig {
                 var otherVersion = new Manifest(in2).getMainAttributes().getValue("Specification-Version");
 
                 if (version != null && !version.equals(otherVersion)) {
-                    messages.append(Messages.warning("Pom.xml dependency on rascal-lsp has version " + otherVersion + " while the effective version in the VScode extension is " + version + ". This can have funny effects in the IDE while debugging or code browsing.", getPomXmlLocation(manifestRoot)));
+                    messages.append(Messages.warning("Pom.xml dependency on rascal-lsp has version " + otherVersion + " while the effective version in the VScode extension is " + version + ". This can have funny effects in the IDE while debugging or code browsing, for that reason we've replaced it with the effective one, please update your pom.xml.", getPomXmlLocation(manifestRoot)));
                 }
             }
         }

--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -529,16 +529,7 @@ public class PathConfig {
         // This version of rascal-lsp is added last, so an explicit rascal-lsp dependency takes precedence
         try {
             var lsp = PathConfig.resolveProjectOnClasspath("rascal-lsp");
-
-            var reg = URIResolverRegistry.getInstance();
-            // the interpreter must find the Rascal sources of util::LanguageServer etc.
-            if (URIUtil.getLocationName(lsp).equals("classes")
-                && URIUtil.getLocationName(URIUtil.getParentLocation(lsp)).equals("target")) {
-                    var lspLocation = JarURIResolver.jarify(URIUtil.getParentLocation(URIUtil.getParentLocation(lsp)));
-                    addLibraryToSourcePath(reg, srcs, messages, lspLocation);
-            } else {
-                addLibraryToSourcePath(reg, srcs, messages, JarURIResolver.jarify(lsp));
-            }
+            srcs.append(URIUtil.getChildLocation(JarURIResolver.jarify(lsp), "library"));
             // the interpreter must load the Java parts for calling util::IDEServices and registerLanguage
             addLibraryToLibPath(libs, mode, lsp);
         }


### PR DESCRIPTION
This PR smooths a bit of how rascal-lsp is added to the class path, and is a precursor to https://github.com/usethesource/rascal-language-servers/pull/667