### PR TITLE
Do not swallow messages when type-check aborts early.

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
@@ -559,11 +559,9 @@ list[ModuleMessages] check(list[loc] moduleLocs, RascalCompilerConfig compilerCo
     pcfg1 = compilerConfig.typepalPathConfig;
     compilerConfig.typepalPathConfig = pcfg1;
     ms = rascalTModelForLocs(moduleLocs, compilerConfig, dummy_compile1);
-    messagesNoModule = {};
-    for(mname <- ms.messages, !ms.moduleLocs[mname]?){
-        messagesNoModule += ms.messages[mname];
-    }   
-    return [ program(ms.moduleLocs[mname], ms.messages[mname] + messagesNoModule) | mname <- ms.messages, ms.moduleLocs[mname] ?  ];
+    moduleNames = domain(ms.moduleLocs);
+    messagesNoModule = {*ms.messages[mname] | mname <- ms.messages, mname notin moduleNames};
+    return [ program(ms.moduleLocs[mname], (ms.messages[mname] ? {}) + messagesNoModule) | mname <- moduleNames ];
 }
 
 list[ModuleMessages] checkAll(loc root, RascalCompilerConfig compilerConfig){


### PR DESCRIPTION
Make sure the type checker also returns messages for modules that are only dependencies of the module that triggered the type-check, even when the triggering module does not return `ModuleMessages` (e.g. when binary incompatibilty of modules caused early termination of the type check).

The PR fixes #2324.