### PR TITLE
Fixes debug generated parser persisting

### DIFF
--- a/src/org/rascalmpl/parser/ParserGenerator.java
+++ b/src/org/rascalmpl/parser/ParserGenerator.java
@@ -219,7 +219,7 @@ public class ParserGenerator {
 			synchronized (evaluator) {
 				classString = (IString) evaluator.call(monitor, "newGenerate", vf.string(packageName), vf.string(normName), grammar);
 			}
-			debugOutput(classString, System.getProperty("java.io.tmpdir") + "/parser.java");
+			debugOutput(classString.getValue(), System.getProperty("java.io.tmpdir") + "/parser.java");
 			
 			return bridge.compileJava(loc, packageName + "." + normName, classString.getValue());
 		} catch (ClassCastException e) {
@@ -248,7 +248,7 @@ public class ParserGenerator {
 		synchronized (evaluator) {
 			classString = (IString) evaluator.call(monitor, "newGenerate", vf.string(packageName), vf.string(normName), grammar);
 		}
-		debugOutput(classString, System.getProperty("java.io.tmpdir") + "/parser.java");
+		debugOutput(classString.getValue(), System.getProperty("java.io.tmpdir") + "/parser.java");
 		
 		bridge.compileJava(loc, packageName + "." + normName, classString.getValue(), out);
 	} catch (ClassCastException e) {


### PR DESCRIPTION
The generated parser was being stored in escaped string format in a file with a `.java` extension.

Since this is rather inconvenient, this PR corrects this.