### PR TITLE
Print test results to stdout when all succeeded

### DIFF
--- a/src/org/rascalmpl/interpreter/DefaultTestResultListener.java
+++ b/src/org/rascalmpl/interpreter/DefaultTestResultListener.java
@@ -79,8 +79,8 @@ public class DefaultTestResultListener implements ITestResultListener {
 	        }
 	        else {
 	            out.println("\t" + successes + "/" + count + " tests succeeded");
-	            err.println("\t" + failures + "/" + count + " tests failed");
-	            err.println("\t" + errors + "/" + count + " tests threw exceptions");
+	            (failures == 0 ? out : err).println("\t" + failures + "/" + count + " tests failed");
+	            (errors == 0 ? out : err).println("\t" + errors + "/" + count + " tests threw exceptions");
 	        }
 
 	        if (ignored != 0) {


### PR DESCRIPTION
Instead of printing "0/n tests threw exceptions" or "0/n tests failed" in red (stderr), print them to stdout. Only print statistics in red where actually failures occurred.

Closes #2154