### PR TITLE
Fixed issue where the fallback resolver would be skipped if a nested scheme was not registered

### DIFF
--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -461,7 +461,10 @@ public class URIResolverRegistry {
 			Matcher m = splitScheme.matcher(scheme);
 			if (m.find()) {
 				String subScheme = m.group(1);
-				return inputResolvers.get(subScheme);
+				result = inputResolvers.get(subScheme);
+				if (result != null) {
+					return result;
+				}
 			}
 			return fallbackInputResolver;
 		}
@@ -474,7 +477,10 @@ public class URIResolverRegistry {
 			Matcher m = splitScheme.matcher(scheme);
 			if (m.find()) {
 				String subScheme = m.group(1);
-				return classloaderResolvers.get(subScheme);
+				result = classloaderResolvers.get(subScheme);
+				if (result != null) {
+					return result;
+				}
 			}
 			return fallbackClassloaderResolver;
 		}
@@ -487,7 +493,10 @@ public class URIResolverRegistry {
 			Matcher m = splitScheme.matcher(scheme);
 			if (m.find()) {
 				String subScheme = m.group(1);
-				return outputResolvers.get(subScheme);
+				result = outputResolvers.get(subScheme);
+				if (result != null) {
+					return result;
+				}
 			}
 			return fallbackOutputResolver;
 		}


### PR DESCRIPTION
This surfaced during integration of the latest RC in `rascal-lsp`, where a spurious runtime exception was thrown where the fallback resolver was expected to be used.