### PR TITLE
Relativize now returns the literal input location instead of a normalized location

### DIFF
--- a/src/org/rascalmpl/uri/URIUtil.java
+++ b/src/org/rascalmpl/uri/URIUtil.java
@@ -397,6 +397,7 @@ public class URIUtil {
 	public static ISourceLocation relativize(ISourceLocation outside, ISourceLocation inside) {
 		// first we normalize trailing slashes, since "relativize" does not consider them meaningful
 		// while ISourceLocation does.
+		var originalInside = inside; // We want to be able to return the literal original input location
 		try {
 			if (outside.getPath().endsWith(URI_PATH_SEPARATOR)) {
 				outside = changePath(outside, outside.getPath().substring(0, outside.getPath().length() - 1));
@@ -414,7 +415,7 @@ public class URIUtil {
 		}
 
 		if (!isParentOf(outside, inside)) {
-			return inside;
+			return originalInside;
 		}
 
 		String[] outsidePath = outside.getPath().split(URI_PATH_SEPARATOR);


### PR DESCRIPTION
`relativize` would return the `inside` location if `outside` is not a parent of `inside`. However, `inside` is normalized at the top of this function. This PR fixes `relativize` so it returns the original location instead.

NB: this seems to be the expected behavior, cf. https://github.com/usethesource/rascal/blob/be83ccc132d55be4ceba94dd48873bcacfdeef4a/src/org/rascalmpl/library/Location.rsc#L41.