### PR TITLE
Implemented "isDefined" (tree.field?) for non-error trees.

### DIFF
--- a/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
+++ b/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
@@ -142,7 +142,13 @@ public class ConcreteSyntaxResult extends ConstructorResult {
 		
 		return super.fieldUpdate(name, repl, store);
 	}
-	
+
+	private static boolean hasField(IConstructor prod, Name field) {
+		IList syms = ProductionAdapter.getSymbols(prod);
+		int index = SymbolAdapter.indexOfLabel(syms, Names.name(field));
+		return index >= 0;
+	}
+
 	private static boolean errorHasFieldBeforeDot(IConstructor errorProd, Name field) {
 		int dot = ProductionAdapter.getErrorDot(errorProd);
 		IList syms = ProductionAdapter.getSymbols(ProductionAdapter.getErrorProduction(errorProd));
@@ -173,8 +179,12 @@ public class ConcreteSyntaxResult extends ConstructorResult {
 	public Result<IBool> isDefined(Name name) {
 		if (TreeAdapter.isAppl((ITree) getValue())) {
 			IConstructor prod = TreeAdapter.getProduction((ITree) getValue());
-			if (ProductionAdapter.isError(prod) && errorHasFieldBeforeDot(prod, name)) {
-				return ResultFactory.bool(true, ctx);
+			if (ProductionAdapter.isError(prod)) {
+				if (errorHasFieldBeforeDot(prod, name)) {
+					return ResultFactory.bool(true, ctx);
+				}
+			} else if (hasField(prod, name)) {
+				ResultFactory.bool(true, ctx);
 			}
 		}
 

--- a/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
+++ b/src/org/rascalmpl/interpreter/result/ConcreteSyntaxResult.java
@@ -145,6 +145,9 @@ public class ConcreteSyntaxResult extends ConstructorResult {
 
 	private static boolean hasField(IConstructor prod, Name field) {
 		IList syms = ProductionAdapter.getSymbols(prod);
+		if (syms == null) {
+			return false;
+		}
 		int index = SymbolAdapter.indexOfLabel(syms, Names.name(field));
 		return index >= 0;
 	}
@@ -184,7 +187,7 @@ public class ConcreteSyntaxResult extends ConstructorResult {
 					return ResultFactory.bool(true, ctx);
 				}
 			} else if (hasField(prod, name)) {
-				ResultFactory.bool(true, ctx);
+				return ResultFactory.bool(true, ctx);
 			}
 		}
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ErrorTreeSemanticsTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ErrorTreeSemanticsTests.rsc
@@ -180,6 +180,19 @@ test bool testIsDefinedValidTree() {
     return stat.var?;
 }
 
+test bool testTreeBuiltinFieldPresence() {
+    Statement stat = parse(#Statement, "a := 42");
+    return stat.prod? && stat.args?;
+}
+
+data Tree(int testThisField=-1);
+
+test bool testTreeKeywordFieldPresence() {
+    Statement stat = parse(#Statement, "a := 42");
+    stat.testThisField=42;
+    return stat.testThisField?;
+}
+
 test bool testIsDefinedAfterDot() = !getTestStatement().val?;
 
 test bool testFieldAccessBeforeDot() = "<getTestStatement().var>" == "input";

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ErrorTreeSemanticsTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ErrorTreeSemanticsTests.rsc
@@ -175,6 +175,11 @@ test bool testHasAfterDot() = !(getTestStatement() has val);
 
 test bool testIsDefinedBeforeDot() = getTestStatement().var?;
 
+test bool testIsDefinedValidTree() {
+    Statement stat = parse(#Statement, "a := 42");
+    return stat.var?;
+}
+
 test bool testIsDefinedAfterDot() = !getTestStatement().val?;
 
 test bool testFieldAccessBeforeDot() = "<getTestStatement().var>" == "input";


### PR DESCRIPTION
The "isDefined" operator (`tree.field?`) has support for error trees but not yet for "regular" trees.
This PR fixes this oversight.