### PR TITLE
added the location of the AST where the illegally used field is on, for easier debugging of the interpreter or Rascal code that triggers this

### DIFF
--- a/src/org/rascalmpl/ast/Assignable.java
+++ b/src/org/rascalmpl/ast/Assignable.java
@@ -31,91 +31,91 @@ public abstract class Assignable extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Assignable> getArguments() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasElements() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Assignable> getElements() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasArg() {
     return false;
   }
 
   public org.rascalmpl.ast.Assignable getArg() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasReceiver() {
     return false;
   }
 
   public org.rascalmpl.ast.Assignable getReceiver() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasDefaultExpression() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getDefaultExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSecond() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getSecond() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSubscript() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getSubscript() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasAnnotation() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getAnnotation() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasField() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getField() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasOptFirst() {
     return false;
   }
 
   public org.rascalmpl.ast.OptionalExpression getOptFirst() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasOptLast() {
     return false;
   }
 
   public org.rascalmpl.ast.OptionalExpression getOptLast() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasQualifiedName() {
     return false;
   }
 
   public org.rascalmpl.ast.QualifiedName getQualifiedName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Body.java
+++ b/src/org/rascalmpl/ast/Body.java
@@ -31,7 +31,7 @@ public abstract class Body extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Toplevel> getToplevels() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Bound.java
+++ b/src/org/rascalmpl/ast/Bound.java
@@ -31,7 +31,7 @@ public abstract class Bound extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Case.java
+++ b/src/org/rascalmpl/ast/Case.java
@@ -31,14 +31,14 @@ public abstract class Case extends AbstractAST {
   }
 
   public org.rascalmpl.ast.PatternWithAction getPatternWithAction() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStatement() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getStatement() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Catch.java
+++ b/src/org/rascalmpl/ast/Catch.java
@@ -31,14 +31,14 @@ public abstract class Catch extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getPattern() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasBody() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getBody() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Class.java
+++ b/src/org/rascalmpl/ast/Class.java
@@ -31,28 +31,28 @@ public abstract class Class extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Range> getRanges() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasCharClass() {
     return false;
   }
 
   public org.rascalmpl.ast.Class getCharClass() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasLhs() {
     return false;
   }
 
   public org.rascalmpl.ast.Class getLhs() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasRhs() {
     return false;
   }
 
   public org.rascalmpl.ast.Class getRhs() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Command.java
+++ b/src/org/rascalmpl/ast/Command.java
@@ -31,35 +31,35 @@ public abstract class Command extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Declaration getDeclaration() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasExpression() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasImported() {
     return false;
   }
 
   public org.rascalmpl.ast.Import getImported() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasCommand() {
     return false;
   }
 
   public org.rascalmpl.ast.ShellCommand getCommand() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStatement() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getStatement() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Commands.java
+++ b/src/org/rascalmpl/ast/Commands.java
@@ -31,7 +31,7 @@ public abstract class Commands extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.EvalCommand> getCommands() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/CommonKeywordParameters.java
+++ b/src/org/rascalmpl/ast/CommonKeywordParameters.java
@@ -31,7 +31,7 @@ public abstract class CommonKeywordParameters extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.KeywordFormal> getKeywordFormalList() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Comprehension.java
+++ b/src/org/rascalmpl/ast/Comprehension.java
@@ -31,28 +31,28 @@ public abstract class Comprehension extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getGenerators() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasResults() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getResults() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasFrom() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getFrom() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTo() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getTo() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/ConcreteHole.java
+++ b/src/org/rascalmpl/ast/ConcreteHole.java
@@ -31,14 +31,14 @@ public abstract class ConcreteHole extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSymbol() {
     return false;
   }
 
   public org.rascalmpl.ast.Sym getSymbol() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/DataTarget.java
+++ b/src/org/rascalmpl/ast/DataTarget.java
@@ -31,7 +31,7 @@ public abstract class DataTarget extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Name getLabel() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/DataTypeSelector.java
+++ b/src/org/rascalmpl/ast/DataTypeSelector.java
@@ -31,14 +31,14 @@ public abstract class DataTypeSelector extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Name getProduction() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSort() {
     return false;
   }
 
   public org.rascalmpl.ast.QualifiedName getSort() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/DateTimeLiteral.java
+++ b/src/org/rascalmpl/ast/DateTimeLiteral.java
@@ -31,21 +31,21 @@ public abstract class DateTimeLiteral extends AbstractAST {
   }
 
   public org.rascalmpl.ast.DateAndTime getDateAndTime() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasDate() {
     return false;
   }
 
   public org.rascalmpl.ast.JustDate getDate() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTime() {
     return false;
   }
 
   public org.rascalmpl.ast.JustTime getTime() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Declaration.java
+++ b/src/org/rascalmpl/ast/Declaration.java
@@ -31,98 +31,98 @@ public abstract class Declaration extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Type> getTypes() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasVariables() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Variable> getVariables() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasVariants() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Variant> getVariants() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasCommonKeywordParameters() {
     return false;
   }
 
   public org.rascalmpl.ast.CommonKeywordParameters getCommonKeywordParameters() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasFunctionDeclaration() {
     return false;
   }
 
   public org.rascalmpl.ast.FunctionDeclaration getFunctionDeclaration() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasKind() {
     return false;
   }
 
   public org.rascalmpl.ast.Kind getKind() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTags() {
     return false;
   }
 
   public org.rascalmpl.ast.Tags getTags() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasAnnoType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getAnnoType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasBase() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getBase() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasOnType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getOnType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasUser() {
     return false;
   }
 
   public org.rascalmpl.ast.UserType getUser() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasVisibility() {
     return false;
   }
 
   public org.rascalmpl.ast.Visibility getVisibility() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Declarator.java
+++ b/src/org/rascalmpl/ast/Declarator.java
@@ -31,14 +31,14 @@ public abstract class Declarator extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Variable> getVariables() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/EvalCommand.java
+++ b/src/org/rascalmpl/ast/EvalCommand.java
@@ -31,21 +31,21 @@ public abstract class EvalCommand extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Declaration getDeclaration() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasImported() {
     return false;
   }
 
   public org.rascalmpl.ast.Import getImported() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStatement() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getStatement() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Expression.java
+++ b/src/org/rascalmpl/ast/Expression.java
@@ -31,280 +31,280 @@ public abstract class Expression extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getArguments() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasElements() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getElements() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasElements0() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getElements0() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasGenerators() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getGenerators() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSubscripts() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getSubscripts() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasFields() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Field> getFields() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasMappings() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Mapping_Expression> getMappings() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStatements() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getStatements() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStatements0() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getStatements0() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasComprehension() {
     return false;
   }
 
   public org.rascalmpl.ast.Comprehension getComprehension() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasConcrete() {
     return false;
   }
 
   public org.rascalmpl.ast.Concrete getConcrete() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasArgument() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getArgument() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasCondition() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getCondition() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasDefinitions() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getDefinitions() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasElseExp() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getElseExp() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasExpression() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasFirst() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getFirst() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasInit() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getInit() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasLast() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getLast() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasLhs() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getLhs() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPattern() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getPattern() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasReplacement() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getReplacement() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasResult() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getResult() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasRhs() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getRhs() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSecond() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getSecond() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSymbol() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getSymbol() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasThenExp() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getThenExp() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasValue() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getValue() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasKeywordArguments() {
     return false;
   }
 
   public org.rascalmpl.ast.KeywordArguments_Expression getKeywordArguments() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasLabel() {
     return false;
   }
 
   public org.rascalmpl.ast.Label getLabel() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasLiteral() {
     return false;
   }
 
   public org.rascalmpl.ast.Literal getLiteral() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasField() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getField() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasKey() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getKey() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasOptFirst() {
     return false;
   }
 
   public org.rascalmpl.ast.OptionalExpression getOptFirst() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasOptLast() {
     return false;
   }
 
   public org.rascalmpl.ast.OptionalExpression getOptLast() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasParameters() {
     return false;
   }
 
   public org.rascalmpl.ast.Parameters getParameters() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasQualifiedName() {
     return false;
   }
 
   public org.rascalmpl.ast.QualifiedName getQualifiedName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasVisit() {
     return false;
   }
 
   public org.rascalmpl.ast.Visit getVisit() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Field.java
+++ b/src/org/rascalmpl/ast/Field.java
@@ -31,14 +31,14 @@ public abstract class Field extends AbstractAST {
   }
 
   public org.rascalmpl.ast.IntegerLiteral getFieldIndex() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasFieldName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getFieldName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Formals.java
+++ b/src/org/rascalmpl/ast/Formals.java
@@ -31,7 +31,7 @@ public abstract class Formals extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getFormals() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/FunctionBody.java
+++ b/src/org/rascalmpl/ast/FunctionBody.java
@@ -31,7 +31,7 @@ public abstract class FunctionBody extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getStatements() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/FunctionDeclaration.java
+++ b/src/org/rascalmpl/ast/FunctionDeclaration.java
@@ -31,42 +31,42 @@ public abstract class FunctionDeclaration extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getConditions() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasExpression() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasBody() {
     return false;
   }
 
   public org.rascalmpl.ast.FunctionBody getBody() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSignature() {
     return false;
   }
 
   public org.rascalmpl.ast.Signature getSignature() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTags() {
     return false;
   }
 
   public org.rascalmpl.ast.Tags getTags() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasVisibility() {
     return false;
   }
 
   public org.rascalmpl.ast.Visibility getVisibility() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/FunctionModifiers.java
+++ b/src/org/rascalmpl/ast/FunctionModifiers.java
@@ -31,7 +31,7 @@ public abstract class FunctionModifiers extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.FunctionModifier> getModifiers() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/FunctionType.java
+++ b/src/org/rascalmpl/ast/FunctionType.java
@@ -31,14 +31,14 @@ public abstract class FunctionType extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.TypeArg> getArguments() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Header.java
+++ b/src/org/rascalmpl/ast/Header.java
@@ -31,28 +31,28 @@ public abstract class Header extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Import> getImports() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasParams() {
     return false;
   }
 
   public org.rascalmpl.ast.ModuleParameters getParams() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.QualifiedName getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTags() {
     return false;
   }
 
   public org.rascalmpl.ast.Tags getTags() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Import.java
+++ b/src/org/rascalmpl/ast/Import.java
@@ -31,28 +31,28 @@ public abstract class Import extends AbstractAST {
   }
 
   public org.rascalmpl.ast.ImportedModule getModule() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasAt() {
     return false;
   }
 
   public org.rascalmpl.ast.LocationLiteral getAt() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.QualifiedName getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSyntax() {
     return false;
   }
 
   public org.rascalmpl.ast.SyntaxDefinition getSyntax() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/ImportedModule.java
+++ b/src/org/rascalmpl/ast/ImportedModule.java
@@ -31,21 +31,21 @@ public abstract class ImportedModule extends AbstractAST {
   }
 
   public org.rascalmpl.ast.ModuleActuals getActuals() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.QualifiedName getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasRenamings() {
     return false;
   }
 
   public org.rascalmpl.ast.Renamings getRenamings() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/IntegerLiteral.java
+++ b/src/org/rascalmpl/ast/IntegerLiteral.java
@@ -31,21 +31,21 @@ public abstract class IntegerLiteral extends AbstractAST {
   }
 
   public org.rascalmpl.ast.DecimalIntegerLiteral getDecimal() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasHex() {
     return false;
   }
 
   public org.rascalmpl.ast.HexIntegerLiteral getHex() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasOctal() {
     return false;
   }
 
   public org.rascalmpl.ast.OctalIntegerLiteral getOctal() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/KeywordArgument_Expression.java
+++ b/src/org/rascalmpl/ast/KeywordArgument_Expression.java
@@ -31,14 +31,14 @@ public abstract class KeywordArgument_Expression extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/KeywordArguments_Expression.java
+++ b/src/org/rascalmpl/ast/KeywordArguments_Expression.java
@@ -31,14 +31,14 @@ public abstract class KeywordArguments_Expression extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.KeywordArgument_Expression> getKeywordArgumentList() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasOptionalComma() {
     return false;
   }
 
   public org.rascalmpl.ast.OptionalComma getOptionalComma() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/KeywordFormal.java
+++ b/src/org/rascalmpl/ast/KeywordFormal.java
@@ -31,21 +31,21 @@ public abstract class KeywordFormal extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/KeywordFormals.java
+++ b/src/org/rascalmpl/ast/KeywordFormals.java
@@ -31,14 +31,14 @@ public abstract class KeywordFormals extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.KeywordFormal> getKeywordFormalList() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasOptionalComma() {
     return false;
   }
 
   public org.rascalmpl.ast.OptionalComma getOptionalComma() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Label.java
+++ b/src/org/rascalmpl/ast/Label.java
@@ -31,7 +31,7 @@ public abstract class Label extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Literal.java
+++ b/src/org/rascalmpl/ast/Literal.java
@@ -31,56 +31,56 @@ public abstract class Literal extends AbstractAST {
   }
 
   public org.rascalmpl.ast.BooleanLiteral getBooleanLiteral() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasDateTimeLiteral() {
     return false;
   }
 
   public org.rascalmpl.ast.DateTimeLiteral getDateTimeLiteral() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasIntegerLiteral() {
     return false;
   }
 
   public org.rascalmpl.ast.IntegerLiteral getIntegerLiteral() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasLocationLiteral() {
     return false;
   }
 
   public org.rascalmpl.ast.LocationLiteral getLocationLiteral() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasRationalLiteral() {
     return false;
   }
 
   public org.rascalmpl.ast.RationalLiteral getRationalLiteral() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasRealLiteral() {
     return false;
   }
 
   public org.rascalmpl.ast.RealLiteral getRealLiteral() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasRegExpLiteral() {
     return false;
   }
 
   public org.rascalmpl.ast.RegExpLiteral getRegExpLiteral() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStringLiteral() {
     return false;
   }
 
   public org.rascalmpl.ast.StringLiteral getStringLiteral() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/LocalVariableDeclaration.java
+++ b/src/org/rascalmpl/ast/LocalVariableDeclaration.java
@@ -31,7 +31,7 @@ public abstract class LocalVariableDeclaration extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Declarator getDeclarator() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/LocationLiteral.java
+++ b/src/org/rascalmpl/ast/LocationLiteral.java
@@ -31,14 +31,14 @@ public abstract class LocationLiteral extends AbstractAST {
   }
 
   public org.rascalmpl.ast.PathPart getPathPart() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasProtocolPart() {
     return false;
   }
 
   public org.rascalmpl.ast.ProtocolPart getProtocolPart() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Mapping_Expression.java
+++ b/src/org/rascalmpl/ast/Mapping_Expression.java
@@ -31,14 +31,14 @@ public abstract class Mapping_Expression extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getFrom() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTo() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getTo() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Module.java
+++ b/src/org/rascalmpl/ast/Module.java
@@ -31,14 +31,14 @@ public abstract class Module extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Body getBody() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasHeader() {
     return false;
   }
 
   public org.rascalmpl.ast.Header getHeader() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/ModuleActuals.java
+++ b/src/org/rascalmpl/ast/ModuleActuals.java
@@ -31,7 +31,7 @@ public abstract class ModuleActuals extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Type> getTypes() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/ModuleParameters.java
+++ b/src/org/rascalmpl/ast/ModuleParameters.java
@@ -31,7 +31,7 @@ public abstract class ModuleParameters extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.TypeVar> getParameters() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/OptionalExpression.java
+++ b/src/org/rascalmpl/ast/OptionalExpression.java
@@ -31,7 +31,7 @@ public abstract class OptionalExpression extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Parameters.java
+++ b/src/org/rascalmpl/ast/Parameters.java
@@ -31,14 +31,14 @@ public abstract class Parameters extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Formals getFormals() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasKeywordFormals() {
     return false;
   }
 
   public org.rascalmpl.ast.KeywordFormals getKeywordFormals() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/PathPart.java
+++ b/src/org/rascalmpl/ast/PathPart.java
@@ -31,28 +31,28 @@ public abstract class PathPart extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPathChars() {
     return false;
   }
 
   public org.rascalmpl.ast.PathChars getPathChars() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTail() {
     return false;
   }
 
   public org.rascalmpl.ast.PathTail getTail() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPre() {
     return false;
   }
 
   public org.rascalmpl.ast.PrePathChars getPre() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/PathTail.java
+++ b/src/org/rascalmpl/ast/PathTail.java
@@ -31,28 +31,28 @@ public abstract class PathTail extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasMid() {
     return false;
   }
 
   public org.rascalmpl.ast.MidPathChars getMid() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTail() {
     return false;
   }
 
   public org.rascalmpl.ast.PathTail getTail() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPost() {
     return false;
   }
 
   public org.rascalmpl.ast.PostPathChars getPost() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/PatternWithAction.java
+++ b/src/org/rascalmpl/ast/PatternWithAction.java
@@ -31,21 +31,21 @@ public abstract class PatternWithAction extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getPattern() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasReplacement() {
     return false;
   }
 
   public org.rascalmpl.ast.Replacement getReplacement() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStatement() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getStatement() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Prod.java
+++ b/src/org/rascalmpl/ast/Prod.java
@@ -31,56 +31,56 @@ public abstract class Prod extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.ProdModifier> getModifiers() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSyms() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Sym> getSyms() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasAssociativity() {
     return false;
   }
 
   public org.rascalmpl.ast.Assoc getAssociativity() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasReferenced() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getReferenced() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasGroup() {
     return false;
   }
 
   public org.rascalmpl.ast.Prod getGroup() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasLhs() {
     return false;
   }
 
   public org.rascalmpl.ast.Prod getLhs() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasRhs() {
     return false;
   }
 
   public org.rascalmpl.ast.Prod getRhs() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/ProdModifier.java
+++ b/src/org/rascalmpl/ast/ProdModifier.java
@@ -31,14 +31,14 @@ public abstract class ProdModifier extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Assoc getAssociativity() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTag() {
     return false;
   }
 
   public org.rascalmpl.ast.Tag getTag() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/ProtocolPart.java
+++ b/src/org/rascalmpl/ast/ProtocolPart.java
@@ -31,28 +31,28 @@ public abstract class ProtocolPart extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPre() {
     return false;
   }
 
   public org.rascalmpl.ast.PreProtocolChars getPre() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasProtocolChars() {
     return false;
   }
 
   public org.rascalmpl.ast.ProtocolChars getProtocolChars() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTail() {
     return false;
   }
 
   public org.rascalmpl.ast.ProtocolTail getTail() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/ProtocolTail.java
+++ b/src/org/rascalmpl/ast/ProtocolTail.java
@@ -31,28 +31,28 @@ public abstract class ProtocolTail extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasMid() {
     return false;
   }
 
   public org.rascalmpl.ast.MidProtocolChars getMid() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPost() {
     return false;
   }
 
   public org.rascalmpl.ast.PostProtocolChars getPost() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTail() {
     return false;
   }
 
   public org.rascalmpl.ast.ProtocolTail getTail() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/QualifiedName.java
+++ b/src/org/rascalmpl/ast/QualifiedName.java
@@ -31,7 +31,7 @@ public abstract class QualifiedName extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Name> getNames() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Range.java
+++ b/src/org/rascalmpl/ast/Range.java
@@ -31,21 +31,21 @@ public abstract class Range extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Char getCharacter() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasEnd() {
     return false;
   }
 
   public org.rascalmpl.ast.Char getEnd() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStart() {
     return false;
   }
 
   public org.rascalmpl.ast.Char getStart() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Renaming.java
+++ b/src/org/rascalmpl/ast/Renaming.java
@@ -31,14 +31,14 @@ public abstract class Renaming extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Name getFrom() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTo() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getTo() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Renamings.java
+++ b/src/org/rascalmpl/ast/Renamings.java
@@ -31,7 +31,7 @@ public abstract class Renamings extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Renaming> getRenamings() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Replacement.java
+++ b/src/org/rascalmpl/ast/Replacement.java
@@ -31,14 +31,14 @@ public abstract class Replacement extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getConditions() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasReplacementExpression() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getReplacementExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/ShellCommand.java
+++ b/src/org/rascalmpl/ast/ShellCommand.java
@@ -31,35 +31,35 @@ public abstract class ShellCommand extends AbstractAST {
   }
 
   public org.rascalmpl.ast.@org.checkerframework.checker.nullness.qual.MonotonicNonNull QualifiedName getOptName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasExpression() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSign() {
     return false;
   }
 
   public org.rascalmpl.ast.OptionalEqualSign getSign() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTerminator() {
     return false;
   }
 
   public org.rascalmpl.ast.OptionalTerminator getTerminator() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.QualifiedName getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Signature.java
+++ b/src/org/rascalmpl/ast/Signature.java
@@ -31,35 +31,35 @@ public abstract class Signature extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Type> getExceptions() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasModifiers() {
     return false;
   }
 
   public org.rascalmpl.ast.FunctionModifiers getModifiers() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasParameters() {
     return false;
   }
 
   public org.rascalmpl.ast.Parameters getParameters() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Statement.java
+++ b/src/org/rascalmpl/ast/Statement.java
@@ -31,175 +31,175 @@ public abstract class Statement extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Case> getCases() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasHandlers() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Catch> getHandlers() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasConditions() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getConditions() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasGenerators() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getGenerators() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasNames() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.QualifiedName> getNames() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasVariables() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.QualifiedName> getVariables() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStatements() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getStatements() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasAssignable() {
     return false;
   }
 
   public org.rascalmpl.ast.Assignable getAssignable() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasOperator() {
     return false;
   }
 
   public org.rascalmpl.ast.Assignment getOperator() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasBound() {
     return false;
   }
 
   public org.rascalmpl.ast.Bound getBound() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasDataTarget() {
     return false;
   }
 
   public org.rascalmpl.ast.DataTarget getDataTarget() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasCondition() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getCondition() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasExpression() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasMessage() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getMessage() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasFunctionDeclaration() {
     return false;
   }
 
   public org.rascalmpl.ast.FunctionDeclaration getFunctionDeclaration() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasLabel() {
     return false;
   }
 
   public org.rascalmpl.ast.Label getLabel() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasDeclaration() {
     return false;
   }
 
   public org.rascalmpl.ast.LocalVariableDeclaration getDeclaration() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasBody() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getBody() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasElseStatement() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getElseStatement() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasFinallyBody() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getFinallyBody() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStatement() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getStatement() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasThenStatement() {
     return false;
   }
 
   public org.rascalmpl.ast.Statement getThenStatement() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTarget() {
     return false;
   }
 
   public org.rascalmpl.ast.Target getTarget() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasVisit() {
     return false;
   }
 
   public org.rascalmpl.ast.Visit getVisit() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/StringLiteral.java
+++ b/src/org/rascalmpl/ast/StringLiteral.java
@@ -31,35 +31,35 @@ public abstract class StringLiteral extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPre() {
     return false;
   }
 
   public org.rascalmpl.ast.PreStringChars getPre() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasConstant() {
     return false;
   }
 
   public org.rascalmpl.ast.StringConstant getConstant() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTail() {
     return false;
   }
 
   public org.rascalmpl.ast.StringTail getTail() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTemplate() {
     return false;
   }
 
   public org.rascalmpl.ast.StringTemplate getTemplate() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/StringMiddle.java
+++ b/src/org/rascalmpl/ast/StringMiddle.java
@@ -31,28 +31,28 @@ public abstract class StringMiddle extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasMid() {
     return false;
   }
 
   public org.rascalmpl.ast.MidStringChars getMid() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTail() {
     return false;
   }
 
   public org.rascalmpl.ast.StringMiddle getTail() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTemplate() {
     return false;
   }
 
   public org.rascalmpl.ast.StringTemplate getTemplate() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/StringTail.java
+++ b/src/org/rascalmpl/ast/StringTail.java
@@ -31,35 +31,35 @@ public abstract class StringTail extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasMid() {
     return false;
   }
 
   public org.rascalmpl.ast.MidStringChars getMid() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPost() {
     return false;
   }
 
   public org.rascalmpl.ast.PostStringChars getPost() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTail() {
     return false;
   }
 
   public org.rascalmpl.ast.StringTail getTail() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTemplate() {
     return false;
   }
 
   public org.rascalmpl.ast.StringTemplate getTemplate() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/StringTemplate.java
+++ b/src/org/rascalmpl/ast/StringTemplate.java
@@ -31,84 +31,84 @@ public abstract class StringTemplate extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getConditions() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasGenerators() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Expression> getGenerators() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPostStats() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getPostStats() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPostStatsElse() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getPostStatsElse() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPostStatsThen() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getPostStatsThen() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPreStats() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getPreStats() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPreStatsElse() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getPreStatsElse() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasPreStatsThen() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Statement> getPreStatsThen() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasCondition() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getCondition() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasBody() {
     return false;
   }
 
   public org.rascalmpl.ast.StringMiddle getBody() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasElseString() {
     return false;
   }
 
   public org.rascalmpl.ast.StringMiddle getElseString() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasThenString() {
     return false;
   }
 
   public org.rascalmpl.ast.StringMiddle getThenString() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/StructuredType.java
+++ b/src/org/rascalmpl/ast/StructuredType.java
@@ -31,14 +31,14 @@ public abstract class StructuredType extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.TypeArg> getArguments() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasBasicType() {
     return false;
   }
 
   public org.rascalmpl.ast.BasicType getBasicType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Sym.java
+++ b/src/org/rascalmpl/ast/Sym.java
@@ -31,91 +31,91 @@ public abstract class Sym extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Sym> getAlternatives() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasParameters() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Sym> getParameters() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSequence() {
     return false;
   }
 
   public java.util.List<org.rascalmpl.ast.Sym> getSequence() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasCistring() {
     return false;
   }
 
   public org.rascalmpl.ast.CaseInsensitiveStringConstant getCistring() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasCharClass() {
     return false;
   }
 
   public org.rascalmpl.ast.Class getCharClass() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasColumn() {
     return false;
   }
 
   public org.rascalmpl.ast.IntegerLiteral getColumn() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasNonterminal() {
     return false;
   }
 
   public org.rascalmpl.ast.Nonterminal getNonterminal() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasLabel() {
     return false;
   }
 
   public org.rascalmpl.ast.NonterminalLabel getLabel() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasString() {
     return false;
   }
 
   public org.rascalmpl.ast.StringConstant getString() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasFirst() {
     return false;
   }
 
   public org.rascalmpl.ast.Sym getFirst() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasMatch() {
     return false;
   }
 
   public org.rascalmpl.ast.Sym getMatch() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSep() {
     return false;
   }
 
   public org.rascalmpl.ast.Sym getSep() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSymbol() {
     return false;
   }
 
   public org.rascalmpl.ast.Sym getSymbol() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/SyntaxDefinition.java
+++ b/src/org/rascalmpl/ast/SyntaxDefinition.java
@@ -31,28 +31,28 @@ public abstract class SyntaxDefinition extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Prod getProduction() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStart() {
     return false;
   }
 
   public org.rascalmpl.ast.Start getStart() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasDefined() {
     return false;
   }
 
   public org.rascalmpl.ast.Sym getDefined() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasVis() {
     return false;
   }
 
   public org.rascalmpl.ast.Visibility getVis() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Tag.java
+++ b/src/org/rascalmpl/ast/Tag.java
@@ -31,21 +31,21 @@ public abstract class Tag extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getExpression() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasContents() {
     return false;
   }
 
   public org.rascalmpl.ast.TagString getContents() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Tags.java
+++ b/src/org/rascalmpl/ast/Tags.java
@@ -31,7 +31,7 @@ public abstract class Tags extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Tag> getTags() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Target.java
+++ b/src/org/rascalmpl/ast/Target.java
@@ -31,7 +31,7 @@ public abstract class Target extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Toplevel.java
+++ b/src/org/rascalmpl/ast/Toplevel.java
@@ -31,7 +31,7 @@ public abstract class Toplevel extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Declaration getDeclaration() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Type.java
+++ b/src/org/rascalmpl/ast/Type.java
@@ -31,56 +31,56 @@ public abstract class Type extends AbstractAST {
   }
 
   public org.rascalmpl.ast.BasicType getBasic() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSelector() {
     return false;
   }
 
   public org.rascalmpl.ast.DataTypeSelector getSelector() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasFunction() {
     return false;
   }
 
   public org.rascalmpl.ast.FunctionType getFunction() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStructured() {
     return false;
   }
 
   public org.rascalmpl.ast.StructuredType getStructured() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSymbol() {
     return false;
   }
 
   public org.rascalmpl.ast.Sym getSymbol() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasTypeVar() {
     return false;
   }
 
   public org.rascalmpl.ast.TypeVar getTypeVar() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasUser() {
     return false;
   }
 
   public org.rascalmpl.ast.UserType getUser() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/TypeArg.java
+++ b/src/org/rascalmpl/ast/TypeArg.java
@@ -31,14 +31,14 @@ public abstract class TypeArg extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasType() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getType() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/TypeVar.java
+++ b/src/org/rascalmpl/ast/TypeVar.java
@@ -31,14 +31,14 @@ public abstract class TypeVar extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasBound() {
     return false;
   }
 
   public org.rascalmpl.ast.Type getBound() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/UserType.java
+++ b/src/org/rascalmpl/ast/UserType.java
@@ -31,14 +31,14 @@ public abstract class UserType extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Type> getParameters() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.QualifiedName getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Variable.java
+++ b/src/org/rascalmpl/ast/Variable.java
@@ -31,14 +31,14 @@ public abstract class Variable extends AbstractAST {
   }
 
   public org.rascalmpl.ast.Expression getInitial() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Variant.java
+++ b/src/org/rascalmpl/ast/Variant.java
@@ -31,21 +31,21 @@ public abstract class Variant extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.TypeArg> getArguments() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasKeywordArguments() {
     return false;
   }
 
   public org.rascalmpl.ast.KeywordFormals getKeywordArguments() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasName() {
     return false;
   }
 
   public org.rascalmpl.ast.Name getName() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/ast/Visit.java
+++ b/src/org/rascalmpl/ast/Visit.java
@@ -31,21 +31,21 @@ public abstract class Visit extends AbstractAST {
   }
 
   public java.util.List<org.rascalmpl.ast.Case> getCases() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasSubject() {
     return false;
   }
 
   public org.rascalmpl.ast.Expression getSubject() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
   public boolean hasStrategy() {
     return false;
   }
 
   public org.rascalmpl.ast.Strategy getStrategy() {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(this.src.toString());
   }
 
   

--- a/src/org/rascalmpl/library/lang/rascal/grammar/SyntaxTreeGenerator.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/grammar/SyntaxTreeGenerator.rsc
@@ -146,7 +146,7 @@ public str classForSort(str pkg, list[str] imports, AST ast) {
          '  }
          '
          '  public <makeMonotonic(a)> get<clabel>() {
-         '    throw new UnsupportedOperationException();
+         '    throw new UnsupportedOperationException(this.src.toString());
          '  }<}>
          '
          '  <if (leaf(_) := ast) {><lexicalClass(ast.name)><}>


### PR DESCRIPTION
UnsupportedOperatorException usually happens at the end of a very deep Java stacktrace, where the deepest is an AST "getter" for a field which does not exist on this type of syntax rule. 

To understand what is happening the origin location of the given AST node can give insight immediately into what is happening. For me it was an `<-` applied to a syntax tree which did not support iteration. The bug can then be fixed in either the interpreter (throw a better error) or the Rascal source code (prevent the illegal usage of the field by changing the source code). 

This is only relevant for the interpreter. The compiler would typically produce a static error already before running. 