### PR TITLE
Remove log4j calls from Rascal code after the DAP migration

### DIFF
--- a/src/org/rascalmpl/dap/RascalDebugAdapter.java
+++ b/src/org/rascalmpl/dap/RascalDebugAdapter.java
@@ -88,7 +88,7 @@ public class RascalDebugAdapter implements IDebugProtocolServer {
         this.services = services;
         this.ownExecutor = threadPool;
 
-        this.suspendedState = new SuspendedState(evaluator);
+        this.suspendedState = new SuspendedState(evaluator, services);
         this.breakpointsCollection = new BreakpointsCollection(debugHandler);
 
         this.eventTrigger = new RascalDebugEventTrigger(this, breakpointsCollection, suspendedState, debugHandler);

--- a/src/org/rascalmpl/dap/variable/RascalVariable.java
+++ b/src/org/rascalmpl/dap/variable/RascalVariable.java
@@ -26,6 +26,8 @@
  */
 package org.rascalmpl.dap.variable;
 
+import org.rascalmpl.ideservices.IDEServices;
+
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.type.Type;
 
@@ -38,12 +40,12 @@ public class RascalVariable {
     private int namedVariables = 0;
     private int indexedVariables = 0;
 
-    public RascalVariable(Type type, String name, IValue value){
+    public RascalVariable(Type type, String name, IValue value, IDEServices services) {
         this.referenceID = -1;
         this.type = type;
         this.name = name;
         this.value = value;
-        this.displayValue = RascalVariableUtils.getDisplayString(value);
+        this.displayValue = RascalVariableUtils.getDisplayString(value, services);
     }
 
     public void setNamedVariables(int namedVariables) {

--- a/src/org/rascalmpl/dap/variable/RascalVariableUtils.java
+++ b/src/org/rascalmpl/dap/variable/RascalVariableUtils.java
@@ -29,6 +29,8 @@ package org.rascalmpl.dap.variable;
 import java.io.IOException;
 import java.io.Writer;
 
+import org.rascalmpl.dap.RascalDebugAdapter;
+import org.rascalmpl.ideservices.IDEServices;
 import org.rascalmpl.interpreter.utils.LimitedResultWriter;
 
 import io.usethesource.vallang.IValue;
@@ -39,7 +41,7 @@ public class RascalVariableUtils {
     private static final int MAX_SIZE_STRING_NAME = 128;
 
     // copied from Rascal Eclipse debug.core.model.RascalValue
-    public static String getDisplayString(IValue value) {
+    public static String getDisplayString(IValue value, IDEServices services) {
         if(value == null) {
             return "null";
         }
@@ -50,7 +52,7 @@ public class RascalVariableUtils {
         } catch (LimitedResultWriter.IOLimitReachedException e) {
             return w.toString();
         } catch (IOException e) {
-            System.err.println(e.getMessage());
+            services.warning(e.getMessage(), RascalDebugAdapter.DEBUGGER_LOC);
             return "error during serialization...";
         }
     }

--- a/src/org/rascalmpl/dap/variable/RascalVariableUtils.java
+++ b/src/org/rascalmpl/dap/variable/RascalVariableUtils.java
@@ -26,14 +26,13 @@
  */
 package org.rascalmpl.dap.variable;
 
-import io.usethesource.vallang.IValue;
-import io.usethesource.vallang.io.StandardTextWriter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.rascalmpl.interpreter.utils.LimitedResultWriter;
-
 import java.io.IOException;
 import java.io.Writer;
+
+import org.rascalmpl.interpreter.utils.LimitedResultWriter;
+
+import io.usethesource.vallang.IValue;
+import io.usethesource.vallang.io.StandardTextWriter;
 
 public class RascalVariableUtils {
 
@@ -51,8 +50,7 @@ public class RascalVariableUtils {
         } catch (LimitedResultWriter.IOLimitReachedException e) {
             return w.toString();
         } catch (IOException e) {
-            final Logger logger = LogManager.getLogger(RascalVariableUtils.class);
-            logger.error(e.getMessage(), e);
+            System.err.println(e.getMessage());
             return "error during serialization...";
         }
     }


### PR DESCRIPTION
While in `rascal-lsp`, the DAP classes used log4j for logging. After migrating them to Rascal, these calls were still there. This PR removes them from the `rascal` codebase.