### PR TITLE
Include the original error location as a "parseTree" annotation on the error tree

### DIFF
--- a/src/org/rascalmpl/library/ParseTree.rsc
+++ b/src/org/rascalmpl/library/ParseTree.rsc
@@ -159,7 +159,7 @@ A `Tree` defines the trees normally found after parsing; additional constructors
 <4> A single character.
 }
 
-data Tree //(loc src = |unknown:///|(0,0,<0,0>,<0,0>))
+data Tree(loc parseError = |unknown:///|(0,0,<0,0>,<0,0>)) //loc src = |unknown:///|(0,0,<0,0>,<0,0>)
      = appl(Production prod, list[Tree] args) // <1>
      | cycle(Symbol symbol, int cycleLength)  // <2>
      | amb(set[Tree] alternatives) // <3> 

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ErrorLocationTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ErrorLocationTests.rsc
@@ -1,4 +1,18 @@
-module lang::rascal::tests::concrete::recovery::ErrorLocationTests
+
+/**
+ * Copyright (c) 2025, NWO-I Centrum Wiskunde & Informatica (CWI)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+ module lang::rascal::tests::concrete::recovery::ErrorLocationTests
 
 import lang::rascal::\syntax::Rascal;
 import ParseTree;
@@ -19,6 +33,3 @@ void testLocation() {
     println(prettyTree(errors[0]));
     assert errors[0].parseError == |unknown:///|(30,1,<3,20>,<3,21>);
 }
-
-
-

--- a/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ErrorLocationTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/concrete/recovery/ErrorLocationTests.rsc
@@ -1,0 +1,24 @@
+module lang::rascal::tests::concrete::recovery::ErrorLocationTests
+
+import lang::rascal::\syntax::Rascal;
+import ParseTree;
+import vis::Text;
+import IO;
+import util::ParseErrorRecovery;
+
+/**
+A smoke test to see if parse error position reporting is done correctly.
+The reported parse error location should be the point where the parser originally got stuck (just before the last '|' character)
+even though error recovery results in a tree that skips the string "mn" before the actual parse error.
+*/
+void testLocation() {
+    str src = "module X\n\ndata E=a()|id(str nm|bb();";
+
+    Module m = parse(#Module, src, allowRecovery=true);
+    list[Tree] errors = findBestParseErrors(m);
+    println(prettyTree(errors[0]));
+    assert errors[0].parseError == |unknown:///|(30,1,<3,20>,<3,21>);
+}
+
+
+

--- a/src/org/rascalmpl/parser/gtd/result/SkippedNode.java
+++ b/src/org/rascalmpl/parser/gtd/result/SkippedNode.java
@@ -23,13 +23,15 @@ public class SkippedNode extends AbstractNode {
 	private final URI inputUri;
 	private final int[] skippedChars;
 	private final int offset;
+	private final int errorPosition;
 
-	public SkippedNode(URI inputUri, int[] skippedChars, int offset) {
+	public SkippedNode(URI inputUri, int[] skippedChars, int offset, int errorPosition) {
 		super();
 		
 		this.inputUri = inputUri;
 		this.skippedChars = skippedChars;
 		this.offset = offset;
+		this.errorPosition = errorPosition;
 	}
 	
 	public int getTypeIdentifier(){
@@ -50,7 +52,11 @@ public class SkippedNode extends AbstractNode {
 	public int getOffset(){
 		return offset;
 	}
-	
+
+	public int getErrorPosition() {
+		return errorPosition;
+	}
+
 	public boolean isEmpty() {
 		return (skippedChars.length == 0);
 	}
@@ -65,6 +71,6 @@ public class SkippedNode extends AbstractNode {
 
 	@Override
 	public String toString() {
-		return "SkippedNode[skippedChars=" + new String(skippedChars, 0, skippedChars.length) + ",offset=" + offset + "]";
+		return "SkippedNode[skippedChars=" + new String(skippedChars, 0, skippedChars.length) + ",offset=" + offset + ",errorPos=" + errorPosition + "]";
 	}
 }

--- a/src/org/rascalmpl/parser/gtd/result/out/INodeConstructorFactory.java
+++ b/src/org/rascalmpl/parser/gtd/result/out/INodeConstructorFactory.java
@@ -47,6 +47,8 @@ public interface INodeConstructorFactory<T, P> {
 	P createPositionInformation(URI input, int offset, int endOffset, PositionStore positionStore);
 	
 	T addPositionInformation(T node, P location);
+
+	T addParseErrorPosition(T node, P location);
 	
 	Object getRhs(Object production);
 	

--- a/src/org/rascalmpl/parser/gtd/stack/SkippingStackNode.java
+++ b/src/org/rascalmpl/parser/gtd/stack/SkippingStackNode.java
@@ -20,26 +20,26 @@ import org.rascalmpl.parser.gtd.result.SkippedNode;
 public final class SkippingStackNode<P> extends AbstractMatchableStackNode<P>{
 	private final SkippedNode result;
 	
-	public static SkippedNode createResultUntilCharClass(URI uri, int[] until, int[] input, int startLocation) {
+	public static SkippedNode createResultUntilCharClass(URI uri, int[] until, int[] input, int startLocation, int errorPosition) {
 		for (int to = startLocation ; to < input.length; ++to) {
 			for (int i = 0; i < until.length; ++i) {
 				if (input[to] == until[i]) {
 					int length = to - startLocation;
-					return new SkippedNode(uri, createSkippedToken(input, startLocation, length), startLocation);
+					return new SkippedNode(uri, createSkippedToken(input, startLocation, length), startLocation, errorPosition);
 				}
 			}
 		}
 
-		return new SkippedNode(uri, new int[0], startLocation);
+		return new SkippedNode(uri, new int[0], startLocation, errorPosition);
 	}
 
-	public static SkippedNode createResultUntilEndOfInput(URI uri, int[] input, int startLocation) {
+	public static SkippedNode createResultUntilEndOfInput(URI uri, int[] input, int startLocation, int errorPosition) {
 		int length = input.length - startLocation;
-		return new SkippedNode(uri, createSkippedToken(input, startLocation, length), startLocation);
+		return new SkippedNode(uri, createSkippedToken(input, startLocation, length), startLocation, errorPosition);
 	}
 
-	public static SkippedNode createResultUntilChar(URI uri, int[] input, int startLocation, int endLocation) {
-		return new SkippedNode(uri, createSkippedToken(input, startLocation, endLocation - startLocation), startLocation);
+	public static SkippedNode createResultUntilChar(URI uri, int[] input, int startLocation, int endLocation, int errorPosition) {
+		return new SkippedNode(uri, createSkippedToken(input, startLocation, endLocation - startLocation), startLocation, errorPosition);
 	}
 
 	private static int[] createSkippedToken(int[] input, int startLocation, int length) {

--- a/src/org/rascalmpl/parser/uptr/UPTRNodeFactory.java
+++ b/src/org/rascalmpl/parser/uptr/UPTRNodeFactory.java
@@ -121,6 +121,10 @@ public class UPTRNodeFactory implements INodeConstructorFactory<ITree, ISourceLo
 		return (ITree) node.asWithKeywordParameters().setParameter(RascalValueFactory.Location, location);
 	}
 	
+	public ITree addParseErrorPosition(ITree node, ISourceLocation location) {
+		return (ITree) node.asWithKeywordParameters().setParameter(RascalValueFactory.ParseError, location);
+	}
+
 	public ArrayList<ITree> getChildren(ITree node){
 		IList args = TreeAdapter.getArgs(node);
 		ArrayList<ITree> children = new ArrayList<>(args.length());

--- a/src/org/rascalmpl/parser/uptr/recovery/ToTokenRecoverer.java
+++ b/src/org/rascalmpl/parser/uptr/recovery/ToTokenRecoverer.java
@@ -154,7 +154,7 @@ public class ToTokenRecoverer implements IRecoverer<IConstructor> {
 
 		// If we are at the end of the input, skip nothing
 		if (location >= input.length) {
-			result = SkippingStackNode.createResultUntilEndOfInput(uri, input, startLocation);
+			result = SkippingStackNode.createResultUntilEndOfInput(uri, input, startLocation, location);
 			nodes.add(new SkippingStackNode<>(stackNodeIdDispenser.dispenseId(), prod, result, startLocation));
 			return nodes; // No other nodes would be useful
 		}
@@ -174,7 +174,7 @@ public class ToTokenRecoverer implements IRecoverer<IConstructor> {
 				InputMatcher endMatcher = endIter.next();
 				int matchEnd = endMatcher.match(input, pos);
 				if (matchEnd > 0 && !skipSet.get(matchEnd-startLocation)) {
-					result = SkippingStackNode.createResultUntilChar(uri, input, startLocation, matchEnd);
+					result = SkippingStackNode.createResultUntilChar(uri, input, startLocation, matchEnd, location);
 					skipSet.set(matchEnd-startLocation);
 					nodes.add(new SkippingStackNode<>(stackNodeIdDispenser.dispenseId(), prod, result, startLocation));
 					endIter.remove();
@@ -188,7 +188,7 @@ public class ToTokenRecoverer implements IRecoverer<IConstructor> {
 					InputMatcher nextMatcher = nextIter.next();
 					int matchEnd = nextMatcher.match(input, pos);
 					if (matchEnd > 0 && !skipSet.get(pos-startLocation)) {
-						result = SkippingStackNode.createResultUntilChar(uri, input, startLocation, pos);
+						result = SkippingStackNode.createResultUntilChar(uri, input, startLocation, pos, location);
 						skipSet.set(pos-startLocation);
 						nodes.add(new SkippingStackNode<>(stackNodeIdDispenser.dispenseId(), prod, result, startLocation));
 						nextIter.remove();

--- a/src/org/rascalmpl/values/RascalValueFactory.java
+++ b/src/org/rascalmpl/values/RascalValueFactory.java
@@ -253,6 +253,7 @@ public class RascalValueFactory extends AbstractValueFactoryAdapter implements I
 	public static final Type Grammar_Default = tf.constructor(uptr,  Grammar, "grammar", tf.setType(Symbol), "starts", tf.mapType(Symbol, "sort", Production, "def"), "rules");
     
 	public static final String Location = "src";
+	public static final String ParseError = "parseError";
 	public static final String LegacyLocation = "loc";
 	
 	static {


### PR DESCRIPTION
The error recovery algorithm often skips characters before the position where the parser originally got stuck.
This PR adds a `parseTree` keyword parameter on Trees. This parameter is set on error trees by the parser and holds the original error location.
