### PR TITLE
Fix DAP locations

### DIFF
--- a/src/org/rascalmpl/dap/RascalDebugAdapter.java
+++ b/src/org/rascalmpl/dap/RascalDebugAdapter.java
@@ -109,7 +109,7 @@ public class RascalDebugAdapter implements IDebugProtocolServer {
                 services.warning("Could not read contents of " + l.top(), l);
                 return "";
             }
-        });
+        }, lineBase, columnBase);
     }
 
     public void connect(IDebugProtocolClient client) {

--- a/src/org/rascalmpl/dap/RascalDebugAdapter.java
+++ b/src/org/rascalmpl/dap/RascalDebugAdapter.java
@@ -109,7 +109,7 @@ public class RascalDebugAdapter implements IDebugProtocolServer {
                 services.warning("Could not read contents of " + l.top(), l);
                 return "";
             }
-        }, lineBase, columnBase);
+        });
     }
 
     public void connect(IDebugProtocolClient client) {
@@ -313,14 +313,24 @@ public class RascalDebugAdapter implements IDebugProtocolServer {
         }, ownExecutor);
     }
 
+    private int shiftLine(int line) {
+        // Rascal locations use 1 as line base. If DAP is configured to expect base 0, we shift the line number
+        return line + lineBase - 1;
+    }
+
+    private int shiftColumn(int column) {
+        // Rascal locations use 0 as column base. If DAP is configured to expect base 1, we shift the column
+        return column + columnBase;
+    }
+
     private StackFrame createStackFrame(int id, ISourceLocation loc, String name){
         StackFrame frame = new StackFrame();
         frame.setId(id);
         frame.setName(name);
         if(loc != null){
             var offsets = columns.get(loc);
-            var line = offsets.translateLine(loc.getBeginLine());
-            var column = offsets.translateColumn(loc.getBeginLine(), loc.getBeginColumn(), false);
+            var line = shiftLine(loc.getBeginLine());
+            var column = shiftColumn(offsets.translateColumn(loc.getBeginLine(), loc.getBeginColumn(), false));
             frame.setLine(line);
             frame.setColumn(column);
             frame.setSource(getSourceFromISourceLocation(loc));

--- a/src/org/rascalmpl/dap/RascalDebugAdapter.java
+++ b/src/org/rascalmpl/dap/RascalDebugAdapter.java
@@ -170,8 +170,8 @@ public class RascalDebugAdapter implements IDebugProtocolServer {
                 }
                 Breakpoint b = new Breakpoint();
                 b.setId(i);
-                b.setLine(shiftLine(breakpoint.getLine()));
-                b.setColumn(shiftColumn(breakpoint.getColumn()));
+                b.setLine(breakpoint.getLine());
+                b.setColumn(breakpoint.getColumn());
                 b.setVerified(treeBreakableLocation != null);
                 breakpoints[i] = b;
             }
@@ -313,24 +313,14 @@ public class RascalDebugAdapter implements IDebugProtocolServer {
         }, ownExecutor);
     }
 
-    private int shiftLine(int line) {
-        // Rascal locations use 1 as line base. If DAP is configured to expect base 0, we shift the line number
-        return line + lineBase - 1;
-    }
-
-    private int shiftColumn(int column) {
-        // Rascal locations use 0 as column base. If DAP is configured to expect base 1, we shift the column
-        return column + columnBase;
-    }
-
     private StackFrame createStackFrame(int id, ISourceLocation loc, String name){
         StackFrame frame = new StackFrame();
         frame.setId(id);
         frame.setName(name);
         if(loc != null){
             var offsets = columns.get(loc);
-            var line = shiftLine(loc.getBeginLine());
-            var column = shiftColumn(offsets.translateColumn(loc.getBeginLine(), loc.getBeginColumn(), false));
+            var line = offsets.translateLine(loc.getBeginLine());
+            var column = offsets.translateColumn(loc.getBeginLine(), loc.getBeginColumn(), false);
             frame.setLine(line);
             frame.setColumn(column);
             frame.setSource(getSourceFromISourceLocation(loc));

--- a/src/org/rascalmpl/util/locations/ColumnMaps.java
+++ b/src/org/rascalmpl/util/locations/ColumnMaps.java
@@ -40,14 +40,10 @@ public class ColumnMaps {
     private final LoadingCache<ISourceLocation, LineColumnOffsetMap> currentEntries;
 
     public ColumnMaps(Function<ISourceLocation, String> getContents) {
-        this(getContents, 1, 0);
-    }
-
-    public ColumnMaps(Function<ISourceLocation, String> getContents, int lineBase, int columnBase) {
         currentEntries = Caffeine.newBuilder()
             .expireAfterAccess(Duration.ofMinutes(10))
             .softValues()
-            .build(l -> ArrayLineOffsetMap.build(getContents.apply(l), lineBase, columnBase));
+            .build(l -> ArrayLineOffsetMap.build(getContents.apply(l)));
     }
 
     public LineColumnOffsetMap get(ISourceLocation sloc) {

--- a/src/org/rascalmpl/util/locations/ColumnMaps.java
+++ b/src/org/rascalmpl/util/locations/ColumnMaps.java
@@ -40,6 +40,10 @@ public class ColumnMaps {
     private final LoadingCache<ISourceLocation, LineColumnOffsetMap> currentEntries;
 
     public ColumnMaps(Function<ISourceLocation, String> getContents) {
+        this(getContents, 1, 0);
+    }
+
+    public ColumnMaps(Function<ISourceLocation, String> getContents, int lineBase, int columnBase) {
         currentEntries = Caffeine.newBuilder()
             .expireAfterAccess(Duration.ofMinutes(10))
             .softValues()

--- a/src/org/rascalmpl/util/locations/ColumnMaps.java
+++ b/src/org/rascalmpl/util/locations/ColumnMaps.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.util.locations;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import org.rascalmpl.util.locations.impl.ArrayLineOffsetMap;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import io.usethesource.vallang.ISourceLocation;
+
+public class ColumnMaps {
+    private final LoadingCache<ISourceLocation, LineColumnOffsetMap> currentEntries;
+
+    public ColumnMaps(Function<ISourceLocation, String> getContents) {
+        currentEntries = Caffeine.newBuilder()
+            .expireAfterAccess(Duration.ofMinutes(10))
+            .softValues()
+            .build(l -> ArrayLineOffsetMap.build(getContents.apply(l)));
+    }
+
+    public LineColumnOffsetMap get(ISourceLocation sloc) {
+        return currentEntries.get(sloc.top());
+    }
+
+    public void clear(ISourceLocation sloc) {
+        currentEntries.invalidate(sloc.top());
+    }
+
+}

--- a/src/org/rascalmpl/util/locations/ColumnMaps.java
+++ b/src/org/rascalmpl/util/locations/ColumnMaps.java
@@ -47,7 +47,7 @@ public class ColumnMaps {
         currentEntries = Caffeine.newBuilder()
             .expireAfterAccess(Duration.ofMinutes(10))
             .softValues()
-            .build(l -> ArrayLineOffsetMap.build(getContents.apply(l)));
+            .build(l -> ArrayLineOffsetMap.build(getContents.apply(l), lineBase, columnBase));
     }
 
     public LineColumnOffsetMap get(ISourceLocation sloc) {

--- a/src/org/rascalmpl/util/locations/LineColumnOffsetMap.java
+++ b/src/org/rascalmpl/util/locations/LineColumnOffsetMap.java
@@ -32,8 +32,6 @@ package org.rascalmpl.util.locations;
  * vallang uses UTF-32-bit codepoints, while lsp uses UTF-16, so in cases where a codepoint wouldn't fit inside 16bit char, it takes up two chars. Implementations of this class translate these efficiently.
  */
 public interface LineColumnOffsetMap {
-    int translateLine(int line);
-    int translateInverseLine(int line);
     int translateColumn(int line, int column, boolean isEnd);
     int translateInverseColumn(int line, int column, boolean isEnd);
 }

--- a/src/org/rascalmpl/util/locations/LineColumnOffsetMap.java
+++ b/src/org/rascalmpl/util/locations/LineColumnOffsetMap.java
@@ -32,6 +32,8 @@ package org.rascalmpl.util.locations;
  * vallang uses UTF-32-bit codepoints, while lsp uses UTF-16, so in cases where a codepoint wouldn't fit inside 16bit char, it takes up two chars. Implementations of this class translate these efficiently.
  */
 public interface LineColumnOffsetMap {
+    int translateLine(int line);
+    int translateInverseLine(int line);
     int translateColumn(int line, int column, boolean isEnd);
     int translateInverseColumn(int line, int column, boolean isEnd);
 }

--- a/src/org/rascalmpl/util/locations/LineColumnOffsetMap.java
+++ b/src/org/rascalmpl/util/locations/LineColumnOffsetMap.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.util.locations;
+
+/**
+ * Translate ISourceLocation columns to LSP columns
+ *
+ * vallang uses UTF-32-bit codepoints, while lsp uses UTF-16, so in cases where a codepoint wouldn't fit inside 16bit char, it takes up two chars. Implementations of this class translate these efficiently.
+ */
+public interface LineColumnOffsetMap {
+    int translateColumn(int line, int column, boolean isEnd);
+    int translateInverseColumn(int line, int column, boolean isEnd);
+}

--- a/src/org/rascalmpl/util/locations/impl/ArrayLineOffsetMap.java
+++ b/src/org/rascalmpl/util/locations/impl/ArrayLineOffsetMap.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.util.locations.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.rascalmpl.util.locations.LineColumnOffsetMap;
+
+public class ArrayLineOffsetMap implements LineColumnOffsetMap {
+    private final IntArray lines;
+    private final ArrayList<IntArray> wideColumnOffsets;
+    private final ArrayList<IntArray> wideColumnOffsetsInverse;
+
+    public ArrayLineOffsetMap(IntArray lines, ArrayList<IntArray> wideColumnOffsets, ArrayList<IntArray> wideColumnOffsetsInverse) {
+        this.lines = lines;
+        this.wideColumnOffsets = wideColumnOffsets;
+        this.wideColumnOffsetsInverse = wideColumnOffsetsInverse;
+    }
+
+    @Override
+    public int translateColumn(int line, int column, boolean isEnd) {
+        int lineIndex = lines.search(line);
+        if (lineIndex < 0) {
+            return column;
+        }
+        return column + translateColumnForLine(wideColumnOffsets.get(lineIndex), column, isEnd);
+    }
+
+    private int translateColumnForLine(IntArray lineOffsets, int column, boolean isEnd) {
+        int columnIndex = lineOffsets.search(column);
+        if (columnIndex >= 0) {
+            // exact hit
+            if (isEnd) {
+                // for a end cursor, we want to count this char twice as well
+                return columnIndex + 1;
+            }
+            return columnIndex;
+        }
+        else {
+            return Math.abs(columnIndex + 1);
+        }
+    }
+
+    @Override
+    public int translateInverseColumn(int line, int column, boolean isEnd) {
+        int lineIndex = lines.search(line);
+        if (lineIndex < 0) {
+            return column;
+        }
+        return column - translateColumnForLine(wideColumnOffsetsInverse.get(lineIndex), column, isEnd);
+    }
+
+
+    @SuppressWarnings("java:S3776") // parsing tends to be complex
+    public static LineColumnOffsetMap build(String contents) {
+        int line = 0;
+        int column = 0;
+        char prev = '\0';
+        GrowingIntArray linesWithSurrogate = new GrowingIntArray();
+        ArrayList<IntArray> linesMap = new ArrayList<>(0);
+        ArrayList<IntArray> inverseLinesMap = new ArrayList<>(0);
+        GrowingIntArray currentLine = new GrowingIntArray();
+
+        for(int i = 0, n = contents.length() ; i < n ; i++) {
+            char c = contents.charAt(i);
+            if (c == '\n' || c == '\r') {
+                if (c != prev && (prev == '\r' || prev == '\n')) {
+                    continue; // multichar newline skip it
+                }
+                if (!currentLine.isEmpty()) {
+                    linesWithSurrogate.add(line);
+                    linesMap.add(currentLine.build());
+                    inverseLinesMap.add(currentLine.buildInverse());
+                    currentLine = new GrowingIntArray();
+                }
+                line++;
+                column = 0;
+            }
+            else {
+                column++;
+                if (Character.isHighSurrogate(c) && (i + 1) < n && Character.isLowSurrogate(contents.charAt(i + 1))) {
+                    // full surrogate pair, register it, and skip the next char
+                    currentLine.add(column);
+                    i++;
+                }
+            }
+            prev = c;
+        }
+        if (!currentLine.isEmpty()) {
+            // handle last line
+            linesWithSurrogate.add(line);
+            linesMap.add(currentLine.build());
+            inverseLinesMap.add(currentLine.buildInverse());
+        }
+        if (linesMap.isEmpty()) {
+            return EMPTY_MAP;
+        }
+        return new ArrayLineOffsetMap(linesWithSurrogate.build(), linesMap, inverseLinesMap);
+    }
+
+    private static LineColumnOffsetMap EMPTY_MAP = new LineColumnOffsetMap(){
+        @Override
+        public int translateColumn(int line, int column, boolean atEnd) {
+            return column;
+        }
+        @Override
+        public int translateInverseColumn(int line, int column, boolean isEnd) {
+            return column;
+        }
+    };
+
+
+    private static class GrowingIntArray {
+        private int[] data = new int[0];
+        private int filled = 0;
+
+        public void add(int v) {
+            growIfNeeded();
+            data[filled] = v;
+            filled++;
+        }
+
+        public IntArray buildInverse() {
+            int[] result = new int[filled];
+            for (int i = 0; i < filled; i++) {
+                result[i] = data[i] + i;
+            }
+            return new IntArray(result, filled);
+        }
+
+        public boolean isEmpty() {
+            return filled == 0;
+        }
+
+        public IntArray build() {
+            return new IntArray(data, filled);
+        }
+
+        private void growIfNeeded() {
+            if (filled >= data.length) {
+                if (data.length == 0) {
+                    data = new int[4];
+                }
+                else {
+                    data = Arrays.copyOf(data, data.length + (data.length / 2));
+                }
+            }
+        }
+    }
+
+    private static class IntArray {
+        private final int[] data;
+        private final int length;
+
+        public IntArray(int[] data, int length) {
+            this.data = data;
+            this.length = length;
+        }
+
+        /**
+         * search for key, assume it's sorted data
+         * @return >= 0 in case of exact match, below 0 is the insert point
+         */
+        public int search(int key) {
+            if (length <= 8) {
+                // small array, just linear search
+                for (int i = 0; i < length; i++) {
+                    if (data[i] >= key) {
+                        if (data[i] == key) {
+                            return i;
+                        }
+                        return (-i) - 1;
+                    }
+                }
+                return -(length + 1);
+            }
+            return Arrays.binarySearch(data, 0, length, key);
+        }
+    }
+
+
+}

--- a/src/org/rascalmpl/util/locations/impl/ArrayLineOffsetMap.java
+++ b/src/org/rascalmpl/util/locations/impl/ArrayLineOffsetMap.java
@@ -36,26 +36,10 @@ public class ArrayLineOffsetMap implements LineColumnOffsetMap {
     private final ArrayList<IntArray> wideColumnOffsets;
     private final ArrayList<IntArray> wideColumnOffsetsInverse;
 
-    private final int lineBase;
-    private final int columnBase;
-
-    public ArrayLineOffsetMap(IntArray lines, ArrayList<IntArray> wideColumnOffsets, ArrayList<IntArray> wideColumnOffsetsInverse, int lineBase, int columnBase) {
+    public ArrayLineOffsetMap(IntArray lines, ArrayList<IntArray> wideColumnOffsets, ArrayList<IntArray> wideColumnOffsetsInverse) {
         this.lines = lines;
         this.wideColumnOffsets = wideColumnOffsets;
         this.wideColumnOffsetsInverse = wideColumnOffsetsInverse;
-        this.lineBase = lineBase;
-        this.columnBase = columnBase;
-    }
-
-    @Override
-    public int translateLine(int line) {
-        // Rascal locations use 1 as line base. We shift the line number with the configured line base
-        return line + lineBase - 1;
-    }
-
-    @Override
-    public int translateInverseLine(int line) {
-        return line - lineBase + 1;
     }
 
     @Override
@@ -64,12 +48,11 @@ public class ArrayLineOffsetMap implements LineColumnOffsetMap {
         if (lineIndex < 0) {
             return column;
         }
-        // Rascal locations use 0 as column base. We shift the column with the configured column base
-        return column + translateColumnForLine(wideColumnOffsets.get(lineIndex), column, isEnd) + columnBase;
+        return column + translateColumnForLine(wideColumnOffsets.get(lineIndex), column, isEnd);
     }
 
     private int translateColumnForLine(IntArray lineOffsets, int column, boolean isEnd) {
-        int columnIndex = lineOffsets.search(column - columnBase);
+        int columnIndex = lineOffsets.search(column);
         if (columnIndex >= 0) {
             // exact hit
             if (isEnd) {
@@ -93,12 +76,8 @@ public class ArrayLineOffsetMap implements LineColumnOffsetMap {
     }
 
 
-    public static LineColumnOffsetMap build(String contents) {
-        return build(contents, 1, 0);
-    }
-
     @SuppressWarnings("java:S3776") // parsing tends to be complex
-    public static LineColumnOffsetMap build(String contents, int lineBase, int columnBase) {
+    public static LineColumnOffsetMap build(String contents) {
         int line = 0;
         int column = 0;
         char prev = '\0';
@@ -141,18 +120,10 @@ public class ArrayLineOffsetMap implements LineColumnOffsetMap {
         if (linesMap.isEmpty()) {
             return EMPTY_MAP;
         }
-        return new ArrayLineOffsetMap(linesWithSurrogate.build(), linesMap, inverseLinesMap, lineBase, columnBase);
+        return new ArrayLineOffsetMap(linesWithSurrogate.build(), linesMap, inverseLinesMap);
     }
 
     private static LineColumnOffsetMap EMPTY_MAP = new LineColumnOffsetMap(){
-        @Override
-        public int translateLine(int line) {
-            return line;
-        }
-        @Override
-        public int translateInverseLine(int line) {
-            return line;
-        }
         @Override
         public int translateColumn(int line, int column, boolean atEnd) {
             return column;


### PR DESCRIPTION
Rascal's DAP implementation did not report locations correctly. This PR takes the DAP-requested line and column bases into account, and provides UTF-32 to UTF-16 conversions.

Fixes #2377