### PR TITLE
Make sure the exception thrown by a job is not swallowed

### DIFF
--- a/src/org/rascalmpl/library/util/Monitor.rsc
+++ b/src/org/rascalmpl/library/util/Monitor.rsc
@@ -79,8 +79,9 @@ with a parameterized workload and the same label as the job name.
       jobStep(label, message, work=worked);
     });
   }
-  catch x: {
-     throw x;
+  catch "Never caught": {
+    // This is only here because we cannot have a "finally" clause in Rascal without a catch
+    throw "Never caught";
   }
   finally {
     jobEnd(label);
@@ -110,8 +111,9 @@ with a parameterized workload and the same label as the job name.
       jobStep(label, label, work=worked);
     });
   }
-  catch x: {
-    throw x;
+  catch "Never caught": {
+    // This is only here because we cannot have a "finally" clause in Rascal without a catch
+    throw "Never caught";
   }
   finally {
     jobEnd(label);
@@ -137,8 +139,9 @@ with workload `1` and the same label as the job name.
       jobStep(label, label, work=1);
     });
   }
-  catch x: {
-    throw x;
+  catch "Never caught": {
+    // This is only here because we cannot have a "finally" clause in Rascal without a catch
+    throw "Never caught";
   }
   finally {
     jobEnd(label);
@@ -155,8 +158,9 @@ with workload `1` and the same label as the job name.
     jobStart(label, totalWork=totalWork);
     return block();
   }
-  catch x: {
-    throw x;
+  catch "Never caught": {
+    // This is only here because we cannot have a "finally" clause in Rascal without a catch
+    throw "Never caught";
   }
   finally {
     jobEnd(label);


### PR DESCRIPTION
When an exception is thrown during execution of a job, the actual exception was replaced by a new one making it very difficult to diagnose the actual cause.
As Rascal does not support a `finally` clause without a catch, we now use a catch pattern that will never match so the original exception will be propagated but the code in the finally block will still be executed.

Closes usethesource/rascal-language-servers#741