### PR TITLE
Lowered validation level as we only construct the classpath and are not building

### DIFF
--- a/src/org/rascalmpl/util/maven/MavenParser.java
+++ b/src/org/rascalmpl/util/maven/MavenParser.java
@@ -112,8 +112,7 @@ public class MavenParser {
 
     public Artifact parseProject() throws ModelResolutionError {
         var request = new DefaultModelBuildingRequest()
-            .setPomFile(projectPom.toFile())
-            .setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_3_0); // TODO: figure out if we need this
+            .setPomFile(projectPom.toFile());
 
         var resolver = rootResolver.createChildResolver();
 
@@ -215,6 +214,7 @@ public class MavenParser {
         request.setModelResolver(resolver)
             .setModelCache(modelCache)
             .setLocationTracking(true)
+            .setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL)
             .setSystemProperties(System.getProperties());
         return builder.build(request);
     }


### PR DESCRIPTION
Higher validation levels cause plugin configs to be checked which do not need.

This closes #2420 