### PR TITLE
Fix/extend-cycle-checking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
         <dependency>
             <groupId>org.rascalmpl</groupId>
             <artifactId>typepal</artifactId>
-            <version>0.15.2-RC3</version>
+            <version>0.15.2-RC9</version>
            <!-- <scope>provided</scope> for shade plugin it can't be provided. At least the rascal dependency in typepal should be provided -->
            <scope>compile</scope>
         </dependency>

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
@@ -130,6 +130,7 @@ ModuleStatus rascalTModelForLocs(
     if(compilerConfig.logPathConfig) { iprintln(pcfg); }
 
     ModuleStatus ms = newModuleStatus(compilerConfig);
+    mlocs = [m.top | m <- mlocs];
 
     set[Message] msgs = validatePathConfigForChecker(pcfg, mlocs[0]);
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
@@ -130,7 +130,7 @@ ModuleStatus rascalTModelForLocs(
     if(compilerConfig.logPathConfig) { iprintln(pcfg); }
 
     ModuleStatus ms = newModuleStatus(compilerConfig);
-    mlocs = [m.top | m <- mlocs];
+    mlocs = [m.top | loc m <- mlocs];
 
     set[Message] msgs = validatePathConfigForChecker(pcfg, mlocs[0]);
 
@@ -187,11 +187,10 @@ ModuleStatus rascalTModelForLocs(
     topModuleNames = toSet(mnames);
     try {
         ms = getImportAndExtendGraph(topModuleNames, ms);
+        // if(/error(_,_) := ms.messages){
 
-        if(/error(_,_) := ms.messages){
-
-            return clearTModelCache(ms);
-        }
+        //     return clearTModelCache(ms);
+        // }
 
         imports_and_extends = ms.strPaths<0,2>;
         <components, sorted> = stronglyConnectedComponentsAndTopSort(imports_and_extends);
@@ -479,7 +478,7 @@ tuple[TModel, ModuleStatus] rascalTModelComponent(set[str] moduleNames, ModuleSt
         }
         tm = c.run();
 
-        tm.paths =  ms.paths;
+        tm.paths =  getPaths(ms.strPaths, ms);
 
         if(!isEmpty(namedTrees)){
             s = newSolver(namedTrees, tm);
@@ -565,9 +564,6 @@ list[ModuleMessages] check(list[loc] moduleLocs, RascalCompilerConfig compilerCo
     ms = rascalTModelForLocs(moduleLocs, compilerConfig, dummy_compile1);
 
     return reportModuleMessages(ms);
-    // moduleNames = domain(ms.moduleLocs);
-    // messagesNoModule = {*ms.messages[mname] | mname <- ms.messages, mname notin moduleNames} + toSet(ms.pathConfig.messages);
-    // return [ program(ms.moduleLocs[mname], (ms.messages[mname] ? {}) + messagesNoModule) | mname <- moduleNames ];
 }
 
 list[ModuleMessages] reportModuleMessages(ModuleStatus ms){
@@ -650,7 +646,6 @@ int main(
 list[ModuleMessages] checkModules(list[str] moduleNames, RascalCompilerConfig compilerConfig) {
     ModuleStatus ms = rascalTModelForNames(moduleNames, compilerConfig, dummy_compile1);
     return reportModuleMessages(ms);
-    //return  (mname : toList(msgs) | mname <- ms.messages, msgs := ms.messages[mname], !isEmpty(msgs));
 }
 
 // -- calculate rename changes

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
@@ -426,11 +426,11 @@ tuple[TModel, ModuleStatus] rascalTModelComponent(set[str] moduleNames, ModuleSt
     map[str, Module] namedTrees = ();
     for(str nm <- moduleNames){
         ms.status[nm] = {};
-        ms.messages[nm] = {};
+        //ms.messages[nm] = {};
         ms = removeTModel(nm, ms);
         mloc = |unknown:///|(0,0,<0,0>,<0,0>);
         try {
-            mloc = getRascalModuleLocation(nm, pcfg);
+            mloc = getRascalModuleLocation(nm, ms);
         } catch e: {
             err = error("Cannot get location for <nm>: <e>", mloc);
             ms.messages[nm] = { err };
@@ -486,7 +486,7 @@ tuple[TModel, ModuleStatus] rascalTModelComponent(set[str] moduleNames, ModuleSt
         }
         tm.usesPhysicalLocs = true;
         for(mname <- moduleNames){
-            ms.messages[mname] = toSet(tm.messages);
+            ms.messages[mname] ? {} += toSet(tm.messages);
         }
         //iprintln(tm.messages);
 
@@ -500,6 +500,8 @@ tuple[TModel, ModuleStatus] rascalTModelComponent(set[str] moduleNames, ModuleSt
         return <tm, ms>;
     }
 }
+
+
 
 // ---- rascalTModelForName a checker version that works on module names
 
@@ -568,7 +570,7 @@ list[ModuleMessages] check(list[loc] moduleLocs, RascalCompilerConfig compilerCo
 
 list[ModuleMessages] reportModuleMessages(ModuleStatus ms){
     moduleNames = domain(ms.moduleLocs);
-    messagesNoModule = {*ms.messages[mname] | mname <- ms.messages, mname notin moduleNames} + toSet(ms.pathConfig.messages);
+    messagesNoModule = {*ms.messages[mname] | mname <- ms.messages, (mname notin moduleNames || mname notin ms.moduleLocs)} + toSet(ms.pathConfig.messages);
     return [ program(ms.moduleLocs[mname], (ms.messages[mname] ? {}) + messagesNoModule) | mname <- moduleNames ];
 }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
@@ -187,10 +187,10 @@ ModuleStatus rascalTModelForLocs(
     try {
         ms = getImportAndExtendGraph(topModuleNames, ms);
 
-        // if(/error(_,_) := ms.messages){
+        if(/error(_,_) := ms.messages){
 
-        //     return clearTModelCache(ms);
-        // }
+            return clearTModelCache(ms);
+        }
 
         imports_and_extends = ms.strPaths<0,2>;
         <components, sorted> = stronglyConnectedComponentsAndTopSort(imports_and_extends);
@@ -539,10 +539,12 @@ tuple[bool, ModuleStatus] libraryDependenciesAreCompatible(list[loc] candidates,
     for(candidate <- candidates){
         mname = getRascalModuleName(candidate, pcfg);
         <found, tm, ms> = getTModelForModule(mname, ms, convert=false);
-        imports_and_extends = ms.strPaths<0,2>[mname];
-        <compatible, ms> = importsAndExtendsAreBinaryCompatible(tm, imports_and_extends, ms);
-        if(!compatible){
-            return <false, ms>;
+        if(found){
+            imports_and_extends = ms.strPaths<0,2>[mname];
+            <compatible, ms> = importsAndExtendsAreBinaryCompatible(tm, imports_and_extends, ms);
+            if(!compatible){
+                return <false, ms>;
+            }
         }
     }
     return <true, ms>;

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
@@ -130,7 +130,6 @@ ModuleStatus rascalTModelForLocs(
     if(compilerConfig.logPathConfig) { iprintln(pcfg); }
 
     ModuleStatus ms = newModuleStatus(compilerConfig);
-    mlocs = [m.top | loc m <- mlocs];
 
     set[Message] msgs = validatePathConfigForChecker(pcfg, mlocs[0]);
 
@@ -187,6 +186,7 @@ ModuleStatus rascalTModelForLocs(
     topModuleNames = toSet(mnames);
     try {
         ms = getImportAndExtendGraph(topModuleNames, ms);
+
         // if(/error(_,_) := ms.messages){
 
         //     return clearTModelCache(ms);
@@ -478,7 +478,7 @@ tuple[TModel, ModuleStatus] rascalTModelComponent(set[str] moduleNames, ModuleSt
         }
         tm = c.run();
 
-        tm.paths =  getPaths(ms.strPaths, ms);
+        tm.paths =  ms.paths;
 
         if(!isEmpty(namedTrees)){
             s = newSolver(namedTrees, tm);
@@ -539,13 +539,13 @@ tuple[bool, ModuleStatus] libraryDependenciesAreCompatible(list[loc] candidates,
     for(candidate <- candidates){
         mname = getRascalModuleName(candidate, pcfg);
         <found, tm, ms> = getTModelForModule(mname, ms, convert=false);
-        if(found){
+        //if(found){
             imports_and_extends = ms.strPaths<0,2>[mname];
             <compatible, ms> = importsAndExtendsAreBinaryCompatible(tm, imports_and_extends, ms);
             if(!compatible){
                 return <false, ms>;
             }
-        }
+        //}
     }
     return <true, ms>;
 }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CheckerCommon.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CheckerCommon.rsc
@@ -342,13 +342,6 @@ ModuleStatus  addTModel (str qualifiedModuleName, TModel tm, ModuleStatus ms){
 
 private type[TModel] ReifiedTModel = #TModel;  // precomputed for efficiency
 
-void reportLogicalPaths(TModel tm){
-    for(tup: <loc from, r, loc to> <- tm.paths){
-        if(from.scheme == "rascal+module" || to.scheme == "rascal+module"){
-            println("**** <tm.modelName>: <tup>");
-        }
-    }
-}
 tuple[bool, TModel, ModuleStatus] getTModelForModule(str qualifiedModuleName, ModuleStatus ms, bool convert = true){
     if(traceTModelCache) println("getTModelForModule: <qualifiedModuleName>");
     pcfg = ms.pathConfig;
@@ -358,7 +351,6 @@ tuple[bool, TModel, ModuleStatus] getTModelForModule(str qualifiedModuleName, Mo
             tm = convertTModel2PhysicalLocs(tm);
             ms.tmodels[qualifiedModuleName] = tm;
         }
-        //reportLogicalPaths(tm);
         return <true, tm, ms>;
     }
     while(size(ms.tmodels) >= tmodelCacheSize && size(ms.tmodelLIFO) > 0 && ms.tmodelLIFO[-1] != qualifiedModuleName){
@@ -383,7 +375,6 @@ tuple[bool, TModel, ModuleStatus] getTModelForModule(str qualifiedModuleName, Mo
                 ms.status[qualifiedModuleName] ? {} += {tpl_uptodate(), tpl_saved()};
                 ms.messages[qualifiedModuleName] = toSet(tm.messages);
                 ms.tmodelLIFO = [qualifiedModuleName, *ms.tmodelLIFO];
-                //reportLogicalPaths(tm);
                 return <true, tm, ms>;
              }
         } catch e: {

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
@@ -192,8 +192,8 @@ ModuleStatus getImportAndExtendGraph(str qualifiedModuleName, ModuleStatus ms){
 
     <found, tm, ms> = getTModelForModule(qualifiedModuleName, ms, convert=true);
     if(found){
-        ms.paths = tm.paths;
-        ms.strPaths = getStrPaths(tm.paths, pcfg);
+        ms.paths += tm.paths;
+        ms.strPaths += getStrPaths(tm.paths, pcfg);
         //assert PathsAreEquivalent(ms);
         allImportsAndExtendsValid = true;
         rel[str, PathRole] localImportsAndExtends = {};
@@ -270,7 +270,7 @@ ModuleStatus getImportAndExtendGraph(str qualifiedModuleName, ModuleStatus ms){
             ms.moduleLocs += tm.moduleLocs;
             ms.paths += tm.paths;
             ms.strPaths += {<qualifiedModuleName, pathRole, imp> | <str imp, PathRole pathRole> <- localImportsAndExtends };
-            assert PathsAreEquivalent(ms);
+            //assert PathsAreEquivalent(ms);
             ms.status[qualifiedModuleName] += module_dependencies_extracted();
             ms.messages[qualifiedModuleName] ? {} += toSet(tm.messages);
             for(<imp, pr> <- localImportsAndExtends, isEmpty({module_dependencies_extracted()} & ms.status[imp])  ){
@@ -443,6 +443,7 @@ tuple[map[str,TModel], ModuleStatus] prepareForCompilation(set[str] component, m
             return <(m: tmodel(modelName=m,messages=toList(ms.messages[m]))), ms>;
         }
     }
+    tm.paths = visit(tm.paths){ case loc l => l.top };
     transient_tms = (m : tm | m <- component);
     org_tm = tm;
     for(m <- component, rsc_not_found() notin ms.status[m], MStatus::ignored() notin ms.status[m]){

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
@@ -86,7 +86,7 @@ ModuleStatus reportCycles(rel[loc from,PathRole r, loc to] paths, rel[loc,loc] e
         if(size(cycle) > 0){
             mname = getRascalModuleName(mloc, ms.pathConfig);
             ms.messages[mname] ? {} += { error("Mixed import/extend cycle not allowed: {<intercalate(", ", toList(cycle))>}", mloc) };
-            ms.status[mname] += check_error();
+            ms.status[mname] ? {} += {check_error()};
         }
     }
     return ms;

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
@@ -117,30 +117,6 @@ rel[loc from, PathRole r, loc to] getPaths(rel[str from, PathRole r, str to] str
     return paths;
 }
 
-// bool PathsAreEquivalent(ModuleStatus ms){
-//     if(size(ms.paths) == size(ms.strPaths)) return true;
-//     if(size(ms.paths) != size(ms.strPaths)) {
-//         println("PathsAreEquivalent: unequal length");
-//         iprintln(ms.paths); iprintln(ms.strPaths);
-//         return false;
-//     }
-//     if(getStrPaths(ms.paths, ms.pathConfig) != ms.strPaths) {
-//         println("PathsAreEquivalent: unequal strPaths");
-//         println("Missing: <getStrPaths(ms.paths, ms.pathConfig) - ms.strPaths>");
-//         return false;
-//     }
-//     if(getPaths(ms.strPaths, ms) != ms.paths){
-//         println("PathsAreEquivalent: unequal paths");
-//         println("getPaths: <getPaths(ms.
-//         strPaths, ms)>");
-//         println("ms.paths: <ms.paths>");
-//         println("ms.strPaths: <ms.strPaths>");
-//         println("Missing: < ms.paths - getPaths(ms.strPaths, ms)>");
-//         return false;
-//     }
-//     return true;
-// }
-
 // Complete a ModuleStatus by adding a contains relation that adds transitive edges for extend
 ModuleStatus completeModuleStatus(ModuleStatus ms){
     pcfg = ms.pathConfig;
@@ -409,7 +385,7 @@ tuple[ModuleStatus, rel[str, PathRole, str]] getModulePathsAsStr(Module m, Modul
 // ---- Save modules ----------------------------------------------------------
 
 map[str, loc] getModuleScopes(TModel tm)
-    = (id: defined.top | <loc _, str id, str _orgId, moduleId(),  loc defined, DefInfo _> <- tm.defines);
+    = (id: defined | <loc _, str id, str _orgId, moduleId(),  loc defined, DefInfo _> <- tm.defines);
 
 loc getModuleScope(str qualifiedModuleName, map[str, loc] moduleScopes, PathConfig pcfg){
     if(moduleScopes[qualifiedModuleName]?){
@@ -444,7 +420,7 @@ tuple[map[str,TModel], ModuleStatus] prepareForCompilation(set[str] component, m
             return <(m: tmodel(modelName=m,messages=toList(ms.messages[m]))), ms>;
         }
     }
-    tm.paths = visit(tm.paths){ case loc l => l.top };
+    tm.paths = visit(tm.paths){ case loc l => l.top }; // redundant?
     transient_tms = (m : tm | m <- component);
     org_tm = tm;
     for(m <- component, rsc_not_found() notin ms.status[m], MStatus::ignored() notin ms.status[m]){
@@ -568,7 +544,7 @@ ModuleStatus doSaveModule(set[str] component, map[str,set[str]] m_imports, map[s
         m1.usesPhysicalLocs = true;
         ms.status[qualifiedModuleName] -= {tpl_saved()};
         ms = addTModel(qualifiedModuleName, m1, ms);
-        //println("added tmodel for <qualifiedModuleName>:"); iprintln(m1);
+        println("added tmodel for <qualifiedModuleName>:"); iprintln(m1);
     }
     return ms;
 }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
@@ -378,17 +378,16 @@ bool rascalReportUnused(loc def, TModel tm){
 // - adding transitive edges for extend
 // - adding imports via these extends
 TModel rascalPreSolver(map[str,Tree] _namedTrees, TModel m){
-    paths = visit(m.paths) { case loc l => l.top };
-    extendPlus = {<from, to> | <loc from, extendPath(), loc to> <- paths}+;
-    paths += { <from, extendPath(), to> | <loc from, loc to> <- extendPlus};
+    extendPlus = {<from, to> | <loc from, extendPath(), loc to> <- m.paths}+;
+    m.paths += { <from, extendPath(), to> | <loc from, loc to> <- extendPlus};
 
     delta = { <from, importPath(), to2> 
             | <loc from, loc to1> <- extendPlus, 
-              <loc to1, importPath(), loc to2> <- paths,
-              <from, extendPath(), to2> notin paths, 
+              <loc to1, importPath(), loc to2> <- m.paths,
+              <from, extendPath(), to2> notin m.paths, 
               from != to2
             };
-    m.paths = paths + delta;
+    m.paths += delta;
     return m;
 }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
@@ -382,8 +382,8 @@ TModel rascalPreSolver(map[str,Tree] _namedTrees, TModel m){
     m.paths += { <from, extendPath(), to> | <loc from, loc to> <- extendPlus};
 
     delta = { <from, importPath(), to2> 
-            | <loc from, loc to1> <- extendPlus, 
-              <loc to1, importPath(), loc to2> <- m.paths,
+            | <loc from, loc _to1> <- extendPlus, 
+              <loc _to1, importPath(), loc to2> <- m.paths,
               <from, extendPath(), to2> notin m.paths, 
               from != to2
             };
@@ -396,7 +396,6 @@ void checkOverloading(map[str,Tree] namedTrees, Solver s){
 
     set[Define] defines = s.getAllDefines();
     facts = s.getFacts();
-    set[loc] actuallyUsedDefs = range(s.getUseDef());
     moduleScopes = { t@\loc | t <- range(namedTrees) };
 
     funDefs = {<define.id, define> | define <- defines, define.idRole == functionId() };
@@ -423,7 +422,8 @@ void checkOverloading(map[str,Tree] namedTrees, Solver s){
                     r1 = visit(t1.ret) {case p:aparameter(_,_,closed=true) => p[closed=false] };
                     r2 = visit(t2.ret) {case p:aparameter(_,_,closed=true) => p[closed=false] };
                     if(!comparable(r1, r2)){
-                        msgs = [ error("Return type `<prettyAType(t1.ret)>` of function `<id>` is not comparable with return type `<prettyAType(r2)>` of other declaration with comparable arguments at <d2.defined>", d1.defined) ];
+                        causes = [ info("ther declaration with comparable arguments", d2.defined) ];
+                        msgs = [ error("Return type `<prettyAType(t1.ret)>` of function `<id>` is not comparable with return type `<prettyAType(r2)>` of other declaration with comparable arguments", d1.defined, causes=causes) ];
                         s.addMessages(msgs);
                     }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
@@ -386,15 +386,6 @@ private void printTuples(str header, rel[loc from, PathRole r, loc to] tuples){
     }
 }
 
-private rel[loc,PathRole,loc] select(rel[loc,PathRole,loc] given){
-    lres =for(tup:<loc from, PathRole r, loc to> <- given){
-            if(contains("<tup>", "Tst1")){
-                append tup;
-            }
-        };
-    return toSet(lres);
-}
-
 // Enhance TModel before running Solver by 
 // - adding transitive edges for extend
 // - adding imports via these extends

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
@@ -380,7 +380,7 @@ bool rascalReportUnused(loc def, TModel tm){
 TModel rascalPreSolver(map[str,Tree] _namedTrees, TModel m){
     paths = visit(m.paths) { case loc l => l.top };
     extendPlus = {<from, to> | <loc from, extendPath(), loc to> <- paths}+;
-    m.paths += { <from, extendPath(), to> | <loc from, loc to> <- extendPlus};
+    paths += { <from, extendPath(), to> | <loc from, loc to> <- extendPlus};
 
     delta = { <from, importPath(), to2> 
             | <loc from, loc to1> <- extendPlus, 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ChangeScenarioTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ChangeScenarioTests.rsc
@@ -108,37 +108,47 @@ test bool fixMissingExtend(){
 
 test bool fixErrorInImport(){
     clearMemory();
-    assert checkModuleOK("module A public bool b = false;");
-    B = "module B import A; int n = b + 1;";
+    assert checkModuleOK("module A public bool a = false;");
+    B = "module B import A; int b = a + 1;";
     assert unexpectedTypeInModule(B);
-    assert checkModuleOK("module A public int b = 0;"); // change b to type int
+    assert checkModuleOK("module A public int a = 0;"); // change a to type int
     return checkModuleOK(B);
 }
 
 test bool fixErrorInExtend(){
     clearMemory();
-    assert checkModuleOK("module A bool b = false;");
-    B = "module B extend A; int n = b + 1;";
+    assert checkModuleOK("module A bool a = false;");
+    B = "module B extend A; int b = a + 1;";
     assert unexpectedTypeInModule(B);
-    assert checkModuleOK("module A int b = 0;"); // change b to type int
+    assert checkModuleOK("module A int a = 0;"); // change a to type int
     return checkModuleOK(B);
+}
+
+test bool fixErrorInIndirectExtend(){
+    clearMemory();
+    assert checkModuleOK("module A public bool a = false;");
+    assert checkModuleOK("module B extend A;");
+    C = "module C import B; int c = a + 1;";
+    assert unexpectedTypeInModule(C);
+    assert checkModuleOK("module A public int a = 0;"); // change a to type int
+    return checkModuleOK(C);
 }
 
 test bool introduceErrorInImport(){
     clearMemory();
-    assert checkModuleOK("module A public int b = 0;");
-    B = "module B import A; int n = b + 1;";
+    assert checkModuleOK("module A public int a = 0;");
+    B = "module B import A; int b = a + 1;";
     assert checkModuleOK(B);
-    assert checkModuleOK("module A public bool b = false;");
+    assert checkModuleOK("module A public bool a = false;");
     return unexpectedTypeInModule(B);
 }
 
 test bool introduceErrorInExtend(){
     clearMemory();
-    assert checkModuleOK("module A int b = 0;");
-    B = "module B extend A; int n = b + 1;";
+    assert checkModuleOK("module A int a = 0;");
+    B = "module B extend A; int b = a + 1;";
     assert checkModuleOK(B);
-    assert checkModuleOK("module A bool b = false;");
+    assert checkModuleOK("module A bool a = false;");
     return unexpectedTypeInModule(B);
 }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ChangeScenarioTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ChangeScenarioTests.rsc
@@ -543,6 +543,22 @@ test bool onlyChangedModulesAreReChecked0(){
     assert changeAndCheck(topLoc, ["Exception"], pcfg);
     return changeAndCheck(topLoc, ["Map"], pcfg);
 }
+
+test bool simpleChange(){
+    pcfg = pathConfigForTesting();
+    A = "module A import B; void f() throws EmptyList {}";
+    B = "module B data RuntimeException = EmptyList();";
+    writeModules(A, B);
+    ALoc = getRascalModuleLocation("A", pcfg);
+    BLoc = getRascalModuleLocation("B", pcfg);
+    assert checkModuleOK(ALoc);
+    assert checkModuleOK(BLoc);
+    A1 = "module A import B; void f() throws EmptyList {} public int n = 0;";
+    writeModule(A1);
+    assert checkModuleOK(ALoc);
+    assert checkModuleOK(BLoc);
+    return true;
+}
 @ignore{Can no longer test in this way since all "Checked .." messages are preserved}
 test bool onlyChangedModulesAreReChecked1(){
     clearMemory();

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/DeclarationTCTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/DeclarationTCTests.rsc
@@ -699,8 +699,7 @@ test bool LU4(){
 test bool LU5() {
 	writeModule("module A int twice(int n) = 2 * n;");
     writeModule("module B
-            		import A;
-            		import B;");
+            		import A;");
     return checkModuleOK("        
         module LU5
            	import A;

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ImportTCTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ImportTCTests.rsc
@@ -280,13 +280,55 @@ test bool QualifiedOverloadedModuleVarOk(){
 		");
 }
 
-test bool cyclicImportOk(){
+test bool selfImportNotOK(){
+	return unexpectedDeclarationInModule("module A import A;");
+}
+
+test bool selfExtendNotOK(){
+	return unexpectedDeclarationInModule("module A extend A;");
+}
+
+test bool cyclic2ImportOk(){
 	writeModule("module A import B;");
 	return checkModuleOK("module B import A;");
 }
 
-@ignore{TODO}
-test bool cyclicExtendNotOk(){
+test bool cyclic3ImportOk(){
+	writeModule("module A import B;");
+	writeModule("module B import C;");
+	return checkModuleOK("module C import A;");
+}
+
+test bool cyclic2ExtendNotOk(){
 	writeModule("module A extend B;");
 	return unexpectedDeclarationInModule("module B extend A;");
 }
+
+test bool cyclic2MixedOk(){
+	writeModule("module A extend B;");
+	return unexpectedDeclarationInModule("module B import A;");
+}
+
+test bool cyclic3ExtendNotOk(){
+	writeModule("module A extend B;");
+	writeModule("module B extend C;");
+	return unexpectedDeclarationInModule("module C extend A;");
+}
+
+// test bool cyclic3MixedNotOk1(){
+// 	writeModule("module A import B;");
+// 	writeModule("module B extend C;");
+// 	return unexpectedDeclarationInModule("module C extend A;");
+// }
+
+test bool cyclic3MixedNotOk1(){
+	writeModule("module A extend B;");
+	writeModule("module B import C;");
+	return unexpectedDeclarationInModule("module C extend A;");
+}
+
+// test bool cyclic3MixedNotOk1(){
+// 	writeModule("module A extend B;");
+// 	writeModule("module B extend C;");
+// 	return unexpectedDeclarationInModule("module C import A;");
+// }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ImportTCTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ImportTCTests.rsc
@@ -274,7 +274,7 @@ test bool QualifiedOverloadedModuleVarOk(){
 	writeModule("module Left public str global = \"World\";");
 	writeModule("module Right public str global = \"Hello\";");
 	return checkModuleOK("
-		module OverloadedModuleVarNotOk
+		module OverloadedModuleVarOk
 			import Left; import Right;
 			str main() = Left::global;	// ok: global is explicitly resolved
 		");

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ImportTCTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ImportTCTests.rsc
@@ -315,20 +315,33 @@ test bool cyclic3ExtendNotOk(){
 	return unexpectedDeclarationInModule("module C extend A;");
 }
 
-// test bool cyclic3MixedNotOk1(){
-// 	writeModule("module A import B;");
-// 	writeModule("module B extend C;");
-// 	return unexpectedDeclarationInModule("module C extend A;");
-// }
-
 test bool cyclic3MixedNotOk1(){
+	writeModule("module A import B;");
+	writeModule("module B extend C;");
+	return unexpectedDeclarationInModule("module C extend A;");
+}
+
+test bool cyclic3MixedNotOk2(){
 	writeModule("module A extend B;");
 	writeModule("module B import C;");
 	return unexpectedDeclarationInModule("module C extend A;");
 }
 
-// test bool cyclic3MixedNotOk1(){
-// 	writeModule("module A extend B;");
-// 	writeModule("module B extend C;");
-// 	return unexpectedDeclarationInModule("module C import A;");
-// }
+test bool cyclic3MixedNotOk3(){
+	writeModule("module A extend B;");
+	writeModule("module B extend C;");
+	return unexpectedDeclarationInModule("module C import A;");
+}
+
+test bool indirectExtendOk(){
+	writeModule("module A int f() = 42;");
+	writeModule("module B extend A;");
+	return unexpectedDeclarationInModule("module C extend B; int main() = f();");
+}
+
+test bool extendWithImportCycleOK(){
+	writeModule("module Base alias INTEGER = int;");
+	writeModule("module BaseExtended extend Base;");
+	writeModule("module A2 extend BaseExtended; import A1; INTEGER N = 0;");
+	return checkModuleOK("module A1 extend Base; import A2; INTEGER M = 1;");
+}

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ImportTCTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ImportTCTests.rsc
@@ -336,7 +336,7 @@ test bool cyclic3MixedNotOk3(){
 test bool indirectExtendOk(){
 	writeModule("module A int f() = 42;");
 	writeModule("module B extend A;");
-	return unexpectedDeclarationInModule("module C extend B; int main() = f();");
+	return checkModuleOK("module C extend B; int main() = f();");
 }
 
 test bool extendWithImportCycleOK(){

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/StaticTestingUtils.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/StaticTestingUtils.rsc
@@ -431,6 +431,8 @@ list[str] unexpectedDeclarationMsgs = [
 	"Nested iteration",
 	"Element name _ ignored",
 	"Non-well-formed _ type, labels must be distinct",
+	"Self import not allowed",
+	"Extend cycle not allowed",
 	"Mixed import/extend cycle not allowed"
 ];
 
@@ -447,8 +449,8 @@ bool unexpectedDeclaration(str stmts) =
 
 list[str] missingModuleMsgs = [
 	"Reference to name _ cannot be resolved",
-	 "Undefined module _",
-	 "Module _ not found_"
+	"Undefined module _",
+	"Module _ not found_"
 ];
 bool missingModuleInModule(str moduleText, PathConfig pathConfig = getDefaultTestingPathConfig())
 	= checkModuleAndFilter(moduleText, missingModuleMsgs, pathConfig=pathConfig);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/StaticTestingUtils.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/StaticTestingUtils.rsc
@@ -371,7 +371,8 @@ bool argumentMismatch(str stmts) =
 
 list[str] redeclaredVariableMsgs = [
 	"Undefined _ due to double declaration",
-	"Double declaration of _"
+	"Double declaration of _",
+	"Multiple declarations of _ are applicable here"
 ];
 
 bool redeclaredVariableInModule(str moduleText, PathConfig pathConfig = getDefaultTestingPathConfig())
@@ -412,6 +413,7 @@ list[str] unexpectedDeclarationMsgs = [
 	"Invalid initialization of _",
 	"Undefined _",
 	"Double declaration of _",
+	"Multiple declarations of _ are applicable here",
 	"Constructor _ overlaps with other declaration for type _, see _",
 	"Incompatible field _ in _: _ in constructor _ clashes with _ in constructor _",
 	"Constructor _ is used without qualifier and overlaps with other declaration, _",

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
@@ -25,7 +25,5 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::A
-                                               
-import lang::rascalcore::compile::Examples::B;
-
-void f() throws EmptyList {}
+                                                  
+data D = d1();

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
@@ -25,5 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::A
-                  
-int x = 0;
+                                               
+import lang::rascalcore::compile::Examples::B;
+
+void f() throws EmptyList {}

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
@@ -25,5 +25,4 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::A
-                                                  
 data D = d1();

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
@@ -25,4 +25,5 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::A
-data D = d1();
+ 
+import   lang::rascalcore::compile::Examples::A;                

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
@@ -26,4 +26,4 @@ POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::A
  
-import   lang::rascalcore::compile::Examples::A;                
+extend   lang::rascalcore::compile::Examples::B;                

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc
@@ -24,8 +24,7 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
-module  lang::rascalcore::compile::Examples::B
-                 
+module  lang::rascalcore::compile::Examples::B        
 extend lang::rascalcore::compile::Examples::A;
 
 // int x = 1;

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc
@@ -26,9 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::B
                  
-data RuntimeException 
-    = EmptyList()
-    ;  
+extend lang::rascalcore::compile::Examples::A;
 
 // int x = 1;
 // // data D = d(int n) | d(str s);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc
@@ -25,13 +25,15 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::B
-                    
-extend lang::rascalcore::compile::Examples::A;
+                 
+data RuntimeException 
+    = EmptyList()
+    ;  
 
-int x = 1;
+// int x = 1;
 // // data D = d(int n) | d(str s);
 
-// // void f(D x){
+// // void f(D x){  
 // //     d(arg) := x;
 // // }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc
@@ -25,7 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::B        
-extend lang::rascalcore::compile::Examples::A;
+extend lang::rascalcore::compile::Examples::C;
 
 // int x = 1;
 // // data D = d(int n) | d(str s);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/C.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/C.rsc
@@ -24,6 +24,4 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
-module  lang::rascalcore::compile::Examples::C      
-import lang::rascalcore::compile::Examples::B;		
-D x = d1();
+module  lang::rascalcore::compile::Examples::C

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/C.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/C.rsc
@@ -24,9 +24,6 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
-module  lang::rascalcore::compile::Examples::C
-                                           
-                
-import lang::rascalcore::compile::Examples::B;
-			
-D x = d1();  
+module  lang::rascalcore::compile::Examples::C      
+import lang::rascalcore::compile::Examples::B;		
+D x = d1();

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/C.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/C.rsc
@@ -25,6 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::C
-extend lang::rascalcore::compile::Examples::B;
-                  
-void fff(DocumentEdit DE) { }
+     
+import lang::rascalcore::compile::Examples::B;
+			
+A x = [A] "a";

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/C.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/C.rsc
@@ -25,7 +25,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::C
-     
+                                           
+                
 import lang::rascalcore::compile::Examples::B;
 			
-A x = [A] "a";
+D x = d1();  

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/D.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/D.rsc
@@ -1,4 +1,4 @@
 module  lang::rascalcore::compile::Examples::D
  
-data RuntimeException
-    = TypePalUsage(str reason)  ;
+import lang::rascalcore::compile::Examples::A;
+import lang::rascalcore::compile::Examples::B;

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/D.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/D.rsc
@@ -1,4 +1,5 @@
 module  lang::rascalcore::compile::Examples::D
- 
+
 import lang::rascalcore::compile::Examples::A;
 import lang::rascalcore::compile::Examples::B;
+// Foooooooooooooo

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/Tst1.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/Tst1.rsc
@@ -25,10 +25,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 module lang::rascalcore::compile::Examples::Tst1
+import IO;
+data PathRole = extendPath();
 
-datetime now() = $2025-07-17T22:11:24.970+00:00$;
-                     
-datetime created(int n) = now();
-data D = created(int n);
- 
-bool main(){  return created(0) <= now(); }
+void main() {
+    x = <|file:///Users/paulklint/git/rascal/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc|(0,1837,<1,0>,<50,7>),extendPath(),|file:///Users/paulklint/git/rascal/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/B.rsc|(0,1837,<1,0>,<50,7>)>;
+    iprintln({x, x});
+  }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/ShowTPL.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/ShowTPL.rsc
@@ -28,14 +28,35 @@ module lang::rascalcore::compile::ShowTPL
 
 import IO;
 import ValueIO;
+import String;
 import lang::rascalcore::check::CheckerCommon;
+loc tplLoc =  |file:///Users/paulklint/git/compiled-rascal/src/main/java/rascal/lang/rascalcore/compile/Examples/$C.tpl|;
+TModel tm = tmodel(); // {try return readBinaryValueFile(#TModel, tplLoc); catch _: return tmodel();};
 
-loc tplLoc =  |file:///Users/paulklint/git/compiled-rascal/src/main/java/rascal/rascalcore/compile/Examples/$A.tpl|;
-TModel tm = {try return readBinaryValueFile(#TModel, tplLoc); catch _: return tmodel();};
+void main() {
+    setTPL(tplLoc);
+}
 
 void setTPL(loc tpl){
     tplLoc = tpl;
     tm = readBinaryValueFile(#TModel, tplLoc);
+}
+
+void showAll(){
+    iprintln(tm, lineLimit=10000);
+}
+
+void saveAll(loc destination){
+    iprintToFile(destination, tm);   
+}
+
+void saveAll(loc tmLoc, loc destination){
+    if(endsWith(tmLoc.path, ".tpl")){
+    tm = readBinaryValueFile(#TModel, tmLoc);
+    iprintToFile(destination, tm);  
+    } else {
+        throw "Not a tpl file: <tmLoc>";
+    } 
 }
 
 void defines(str search = ""){

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/ShowTPL.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/ShowTPL.rsc
@@ -30,7 +30,7 @@ import IO;
 import ValueIO;
 import lang::rascalcore::check::CheckerCommon;
 
-loc tplLoc = |unknown:///|;
+loc tplLoc =  |file:///Users/paulklint/git/compiled-rascal/src/main/java/rascal/rascalcore/compile/Examples/$A.tpl|;
 TModel tm = {try return readBinaryValueFile(#TModel, tplLoc); catch _: return tmodel();};
 
 void setTPL(loc tpl){

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/muRascal2Java/JGenie.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/muRascal2Java/JGenie.rsc
@@ -117,8 +117,6 @@ JGenie makeJGenie(MuModule m,
     TModel currentTModel = tmodels[moduleName];
     checkAllTypesAvailable(currentTModel);  // TODO: remove
     loc currentModuleScope = moduleLocs[moduleName];
-    set[loc] extending = currentTModel.paths[currentModuleScope, extendPath()];
-    rel[loc, loc] importedByExtend = {<i, e> | e <- extending, i <- currentTModel.paths[e, importPath()]};
     str functionName = "$UNKNOWN";
     MuFunction function = muFunction("", "*unknown", avalue(), [], [], [], "", false, true, false, {}, {}, {}, currentModuleScope, [], (), muBlock([]));               
     


### PR DESCRIPTION
There have been problems reported with the checking of import/extend cycles.
Fixes https://github.com/usethesource/rascal-language-servers/issues/732

The checks on the import/extend graph are made more precise, e.g. self-imports are now also reported and pure extend cycles are better reported.

Also the incremental maintenance of module locations is improved.