### PR TITLE
Fix build machine name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,6 @@ jobs:
           jobs: |
             tests (macos-latest)
             tests (windows-latest)
-            test-linux
           ttl: 15
 
       - name: Deploy


### PR DESCRIPTION
Fix name of test job. Fixes failing test runs like https://github.com/usethesource/rascal/actions/runs/17912099515