### PR TITLE
ColumnMaps now can invalidate the cache if the file has changed

### DIFF
--- a/src/org/rascalmpl/util/locations/ColumnMaps.java
+++ b/src/org/rascalmpl/util/locations/ColumnMaps.java
@@ -51,11 +51,11 @@ public class ColumnMaps {
         currentEntries = Caffeine.newBuilder()
             .expireAfterAccess(Duration.ofMinutes(10))
             .softValues()
-            .<ISourceLocation, LineColumnOffsetMap>removalListener((k, ignored1, ignored2) -> {
-                if (ignored2 != RemovalCause.REPLACED) {
+            .<ISourceLocation, LineColumnOffsetMap>removalListener((loc, ignored, cause) -> {
+                if (cause != RemovalCause.REPLACED) {
                     // this does not create a race because removals are only reported 
                     // after a while
-                    unwatch(k);
+                    unwatch(loc);
                 }
             })
             .build(l -> {


### PR DESCRIPTION
This fixes an issue found in #2430 and also reported in https://github.com/usethesource/rascal-language-servers/issues/764

Closes https://github.com/usethesource/rascal-language-servers/issues/764