### PR TITLE
Feat/reduced call overhead java functions

### DIFF
--- a/src/org/rascalmpl/interpreter/result/AbstractFunction.java
+++ b/src/org/rascalmpl/interpreter/result/AbstractFunction.java
@@ -408,21 +408,17 @@ abstract public class AbstractFunction extends Result<IValue> implements IExtern
 	
 	protected IValue[] computeVarArgsActuals(IValue[] actuals, Type formals) {
 		int arity = formals.getArity();
-		IValue[] newActuals = new IValue[arity];
-		int i;
 		
 		if (formals.getArity() == actuals.length && actuals[actuals.length - 1].getType().isSubtypeOf(formals.getFieldType(formals.getArity() - 1))) {
 			// variable length argument is provided as a list
 			return actuals;
 		}
 
+		IValue[] newActuals = new IValue[arity];
+		int i;
+
 		for (i = 0; i < arity - 1; i++) {
 			newActuals[i] = actuals[i];
-		}
-		
-		Type lub = TF.voidType();
-		for (int j = i; j < actuals.length; j++) {
-			lub = lub.lub(actuals[j].getType());
 		}
 		
 		IListWriter list = vf.listWriter();


### PR DESCRIPTION
This PR is intended to resolve the 10% time spend in looking up tuple types in the typefactor. This was run on every java method call, and since our std-lib is full of them, this has quite an influence on for example the typechecker.

Better benchmarks to follow.