### PR TITLE
Fix/changed-modules-impact-recompilation

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/BasicRascalConfig.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/BasicRascalConfig.rsc
@@ -36,6 +36,7 @@ extend analysis::typepal::TypePal;
 import lang::rascal::\syntax::Rascal;
 import Location;
 import util::SemVer;
+import String;
 
 data IdRole
     = moduleId()

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/BasicRascalConfig.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/BasicRascalConfig.rsc
@@ -31,12 +31,13 @@ module lang::rascalcore::check::BasicRascalConfig
     Basic configuration information as required by TypePal, including IdRole, PathRole, ScopeRole, DefInfo and the like.
     The checker itself is configure in RascalConfig.
 */
-extend analysis::typepal::TypePal;
 
 import lang::rascal::\syntax::Rascal;
 import Location;
 import util::SemVer;
 import String;
+
+extend analysis::typepal::TypePal;
 
 data IdRole
     = moduleId()

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
@@ -62,7 +62,7 @@ ModuleStatus reportSelfImport(rel[loc from, PathRole r, loc to] paths, ModuleSta
     return ms;
 }
 
-ModuleStatus reportCycles(rel[loc from,PathRole r, loc to] paths, rel[loc,loc] extendPlus, ModuleStatus ms){
+ModuleStatus reportCycles(rel[loc from, PathRole r, loc to] paths, rel[loc,loc] extendPlus, ModuleStatus ms){
     extendCycle = { m | <m, m> <- extendPlus };
     if(size(extendCycle) > 0){
         for(mloc <- extendCycle){
@@ -146,8 +146,9 @@ ModuleStatus getImportAndExtendGraph(str qualifiedModuleName, ModuleStatus ms){
 
     <found, tm, ms> = getTModelForModule(qualifiedModuleName, ms, convert=true);
     if(found){
-         ms.paths += tm.paths;
-         ms.strPaths = getStrPaths(ms.paths, pcfg); //<<<<
+        ms.paths += tm.paths;
+        ms.strPaths = getStrPaths(ms.paths, pcfg); //<<<<
+
         allImportsAndExtendsValid = true;
         rel[str, PathRole] localImportsAndExtends = {};
 
@@ -163,7 +164,9 @@ ModuleStatus getImportAndExtendGraph(str qualifiedModuleName, ModuleStatus ms){
                if(m != qualifiedModuleName){
                     localImportsAndExtends += <m, pathRole>;
                }
-               if(isModuleModified(m, timestampInBom, pcfg)){
+               dependencyChanged = !isEmpty(ms.changedModules & range(ms.strPaths[m]));
+               if(dependencyChanged) println("processing BOM of <qualifiedModuleName> and consider <m>, dependencyChanged: <dependencyChanged>");
+               if(dependencyChanged || isModuleModified(m, timestampInBom, pcfg)){
                     allImportsAndExtendsValid = false;
                     ms.status[m] += rsc_changed();
                     ms.status[m] -= {tpl_uptodate(), checked()};
@@ -183,8 +186,7 @@ ModuleStatus getImportAndExtendGraph(str qualifiedModuleName, ModuleStatus ms){
             try {
                 try {
                     mloc = getRascalModuleLocation(qualifiedModuleName, ms);
-                } catch e: {
-                    err = error("Cannot get location for <qualifiedModuleName>: <e>", mloc);
+                } catch Message err: {
                     ms.messages[qualifiedModuleName] = { err };
                     tm = tmodel(modelName=qualifiedModuleName, messages=[ err ]);
                     ms = addTModel(qualifiedModuleName, tm, ms);
@@ -348,8 +350,8 @@ tuple[ModuleStatus, rel[str, PathRole, str]] getModulePathsAsStr(Module m, Modul
         try {
             mloc = getRascalModuleLocation(iname, ms);
             ms.paths += {<m@\loc, imod is \default ? importPath() : extendPath(), mloc>};
-         } catch str msg: {
-            err = error("Cannot get location for <iname>: <msg>", imod@\loc);
+         } catch Message err: {
+            err.src = imod@\loc;
             ms.messages[moduleName] ? {} += { err };
             ms.status[iname] += { rsc_not_found() };
          }
@@ -520,6 +522,7 @@ ModuleStatus doSaveModule(set[str] component, map[str,set[str]] m_imports, map[s
         m1.usesPhysicalLocs = true;
         ms.status[qualifiedModuleName] -= {tpl_saved()};
         ms = addTModel(qualifiedModuleName, m1, ms);
+    // println("TModel for <qualifiedModuleName>:"); iprintln(m1);
     }
     return ms;
 }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
@@ -351,7 +351,7 @@ tuple[ModuleStatus, rel[str, PathRole, str]] getModulePathsAsStr(Module m, Modul
             mloc = getRascalModuleLocation(iname, ms);
             ms.paths += {<m@\loc, imod is \default ? importPath() : extendPath(), mloc>};
          } catch Message err: {
-            err.src = imod@\loc;
+            err.at = imod@\loc;
             ms.messages[moduleName] ? {} += { err };
             ms.status[iname] += { rsc_not_found() };
          }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/ModuleLocations.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/ModuleLocations.rsc
@@ -55,6 +55,14 @@ loc getSearchPathLoc(str filePath, PathConfig pcfg){
     throw "Module with path <filePath> not found"; 
 }
 
+list[Message] getCausesFromPathConfig(PathConfig pcfg){
+    causes = [ info("In srcs", src) | src <- pcfg.srcs ];
+    if(!isEmpty(pcfg.libs)){
+        causes += [ info("In libs", lib) | lib <- pcfg.libs ];
+    }
+    return causes;
+}
+
 @synopsis{Get the location of a named module, search for `src` in srcs and `tpl` in libs}
 loc getRascalModuleLocation(str qualifiedModuleName,  PathConfig pcfg){
     fileName = makeFileName(qualifiedModuleName, extension="rsc");
@@ -72,7 +80,7 @@ loc getRascalModuleLocation(str qualifiedModuleName,  PathConfig pcfg){
             return fileLoc;
         }
     }
-    throw "Module `<qualifiedModuleName>` not found;\n<pcfg>";
+    throw error("Module `<qualifiedModuleName>` not found", |unknown:///|, causes=getCausesFromPathConfig(pcfg));
 }
 
 tuple[str,str] splitFileExtension(str path){

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
@@ -375,19 +375,7 @@ bool rascalReportUnused(loc def, TModel tm){
 }
 
 // Enhance TModel before running Solver by 
-// - adding transitive edges for extend
-// - adding imports via these extends
 TModel rascalPreSolver(map[str,Tree] _namedTrees, TModel m){
-    extendPlus = {<from, to> | <loc from, extendPath(), loc to> <- m.paths}+;
-    m.paths += { <from, extendPath(), to> | <loc from, loc to> <- extendPlus};
-
-    delta = { <from, importPath(), to2> 
-            | <loc from, loc _to1> <- extendPlus, 
-              <loc _to1, importPath(), loc to2> <- m.paths,
-              <from, extendPath(), to2> notin m.paths, 
-              from != to2
-            };
-    m.paths += delta;
     return m;
 }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/TestConfigs.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/TestConfigs.rsc
@@ -236,6 +236,16 @@ public RascalCompilerConfig getRascalWritableCompilerConfig(bool keep=true){
     return rascalCompilerConfig(getRascalWritablePathConfig(keep=keep))[verbose = true][logWrittenFiles=true];
 }
 
+// ---- scratch --------------------------------------------------------------
+
+public PathConfig getScratchProjectPathConfig(bool keep = false) {
+   return makePathConfig([ REPO + "rascal-scratch/src/main/rascal/"  ], [ RASCAL ], keep=keep);
+}
+
+public RascalCompilerConfig getScratchCompilerConfig(bool keep=true){
+    return rascalCompilerConfig(getScratchProjectPathConfig(keep=keep))[verbose = true][logWrittenFiles=true];
+}
+
 // ---- typepal ---------------------------------------------------------------
 
 public PathConfig getTypePalProjectPathConfig(bool keep = false) {

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ChangeScenarioTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ChangeScenarioTests.rsc
@@ -569,6 +569,25 @@ test bool simpleChange(){
     assert checkModuleOK(BLoc);
     return true;
 }
+
+test bool changedExtendedModule(){
+    pcfg = pathConfigForTesting();
+    A = "module A extend B;";
+    B = "module B extend C;";
+    C = "module C";
+    Scratch = "module Scratch import A; import B;";
+    writeModules(A, B, C, Scratch);
+    ALoc = getRascalModuleLocation("A", pcfg);
+    BLoc = getRascalModuleLocation("B", pcfg);
+    CLoc = getRascalModuleLocation("C", pcfg);
+    ScratchLoc = getRascalModuleLocation("Scratch", pcfg);
+    assert checkModuleOK(ScratchLoc);
+    writeModule("module B extend C; int b = 0;");
+    assert checkModuleOK(BLoc);
+    touch(ScratchLoc);
+    return checkModuleOK(ScratchLoc);
+}
+
 @ignore{Can no longer test in this way since all "Checked .." messages are preserved}
 test bool onlyChangedModulesAreReChecked1(){
     clearMemory();


### PR DESCRIPTION
In certain cases changed modules did not lead to recompilation of "downstream" (down in the dependency graph) modules.

The set of changed modules given to the type checker is now used to check whether imports/extends of modules are affected by such changes.