### PR TITLE
Adding target/classes directory of opened dependencies to the libs

### DIFF
--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -640,6 +640,7 @@ public class PathConfig {
                 if (mode == RascalConfigMode.INTERPRETER) {
                     messages.append(MavenMessages.info("Redirected: " + art.getCoordinate() + " to: " + projectLoc, art));
                 }
+                libs.append(URIUtil.correctLocation("target", libProjectName, ""));
                 addProjectAndItsDependencies(mode, srcs, libs, messages, projectLoc);
             }
             else {


### PR DESCRIPTION
Adding target/classes of dependencies that are currently open in VS Code to the libs of the PathConfig to allow cross-project linking of Java classes.

Fixes usethesource/rascal-language-servers#111