### PR TITLE
Using latest typepal that has a 20% performance increase due to caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
         <dependency>
             <groupId>org.rascalmpl</groupId>
             <artifactId>typepal</artifactId>
-            <version>0.15.2-RC13</version>
+            <version>0.15.2-RC14</version>
            <!-- <scope>provided</scope> for shade plugin it can't be provided. At least the rascal dependency in typepal should be provided -->
            <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
if https://github.com/usethesource/rascal-core-big-tests/actions/runs/18409321630 doesn't show new errors, we can merge this.