### PR TITLE
Using rc70 for faster typechecks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
                 <artifactId>rascal-maven-plugin</artifactId>
                 <version>${rascal-maven.version}</version>
                 <configuration>
-                    <bootstrapRascalVersion>0.41.0-RC68</bootstrapRascalVersion>
+                    <bootstrapRascalVersion>0.41.0-RC70</bootstrapRascalVersion>
                     <parallel>true</parallel>
                     <parallelPreChecks>
                         <pre>${project.basedir}/src/org/rascalmpl/library/Prelude.rsc</pre>


### PR DESCRIPTION
We might even consider tweaking the parallalism of the typechecker now that is faster (and less parallel means less duplicate work)