### PR TITLE
applyFileSystemEdits called from a REPL now operates directly on disk

### DIFF
--- a/src/org/rascalmpl/library/util/IDEServicesLibrary.java
+++ b/src/org/rascalmpl/library/util/IDEServicesLibrary.java
@@ -12,7 +12,6 @@
 package org.rascalmpl.library.util;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.function.Function;
 
 import org.rascalmpl.exceptions.RuntimeExceptionFactory;


### PR DESCRIPTION
`applyFileSystemEdits` called from a REPL now operates directly on disk instead of through LSP.

Closes usethesource/rascal-language-servers#844