### PR TITLE
Change the behaviour of Step Over for For/While/Switch/Visit

### DIFF
--- a/src/org/rascalmpl/debug/IRascalSuspendTriggerListener.java
+++ b/src/org/rascalmpl/debug/IRascalSuspendTriggerListener.java
@@ -13,7 +13,7 @@ package org.rascalmpl.debug;
 
 import java.util.function.IntSupplier;
 
-import io.usethesource.vallang.ISourceLocation;
+import org.rascalmpl.ast.AbstractAST;
 
 /**
  * Interface for suspending an program interpretation.
@@ -27,6 +27,6 @@ public interface IRascalSuspendTriggerListener {
 	 * @param evaluator the evaluator in charge of interpreting @param context.
 	 * @param currentAST the AST that is causes the suspension.
 	 */
-	public void suspended(Object runtime, IntSupplier getCallStackSize, ISourceLocation currentAST);
+	public void suspended(Object runtime, IntSupplier getCallStackSize, AbstractAST currentAST);
 	
 }

--- a/src/org/rascalmpl/interpreter/Evaluator.java
+++ b/src/org/rascalmpl/interpreter/Evaluator.java
@@ -1581,7 +1581,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
     public void notifyAboutSuspension(AbstractAST currentAST) {
         if (!suspendTriggerListeners.isEmpty() && currentAST.isBreakable()) {
             for (IRascalSuspendTriggerListener listener : suspendTriggerListeners) {
-                listener.suspended(this, () -> getCallStack().size(), currentAST.getLocation());
+                listener.suspended(this, () -> getCallStack().size(), currentAST);
             }
         }
     }


### PR DESCRIPTION
The current behavior of Step Over button on For/While/Switch/Visit is to step over them and not stop on the body of the loop or the case executed.

This PR change this behavior so that Step Over act as current Step In behavior for these Statements.

