### PR TITLE
added missing conversion of list[loc] to OS paths separated by File.pathSeparator. 

### DIFF
--- a/src/org/rascalmpl/library/util/ShellExec.java
+++ b/src/org/rascalmpl/library/util/ShellExec.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.uri.URIResolverRegistry;
@@ -33,6 +34,7 @@ import io.usethesource.vallang.IString;
 import io.usethesource.vallang.ITuple;
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.IValueFactory;
+import io.usethesource.vallang.type.TypeFactory;
 
 public class ShellExec {
 	private static Map<IInteger, Process> runningProcesses = new ConcurrentHashMap<>();
@@ -53,6 +55,8 @@ public class ShellExec {
 	}
 
 	private IString toString(IValue o) {
+		var TF = TypeFactory.getInstance();
+
 		try {
 			if (o.getType().isSourceLocation()) {
 				ISourceLocation p = URIResolverRegistry.getInstance().logicalToPhysical((ISourceLocation) o);
@@ -63,6 +67,22 @@ public class ShellExec {
 				}
 
 				return vf.string(new File(p.getURI()).getAbsolutePath());
+			}
+			else if (o.getType().isSubtypeOf(TF.listType(TF.sourceLocationType()))) {
+				// a list of loc becomes a path with OS-specific path separators
+				return vf.string(((IList) o).stream()
+					.map(this::toString)
+					.map(IString::getValue)
+					.collect(Collectors.joining(File.pathSeparator))
+				);
+			}
+			else if (o.getType().isSubtypeOf(TF.setType(TF.sourceLocationType()))) {
+				// a set of loc becomes a path with OS-specific path separators
+				return vf.string(((IList) o).stream()
+					.map(this::toString)
+					.map(IString::getValue)
+					.collect(Collectors.joining(File.pathSeparator))
+				);
 			}
 			else if (o.getType().isString()) {
 				return (IString) o;

--- a/src/org/rascalmpl/library/util/ShellExec.rsc
+++ b/src/org/rascalmpl/library/util/ShellExec.rsc
@@ -26,7 +26,8 @@ in the underlying system's search path.
 
 The arguments to `args` given are all converted to strings before passing them into the command.
 Special treatment is given to `loc` arguments, which are first resolved to `file:///` schemes and
-then printed to OS-specific absolute path names.
+then printed to OS-specific absolute path names. Also `list[loc]` and set[loc] are treated by
+converting to OS-specific path strings, separated by Java's `File.pathSeparator`. 
 
 For environment variables in `envVars` the same treatment is given to convert values to strings.
 }


### PR DESCRIPTION
* [x] This was breaking the  abstraction of `createProcess` if your process needed a search path as a parameter. 
* [x] This also mirrors the behavior of Rascals main argument parser which maps a OS-specific search path back to a list[loc] by splitting on File.pathSeparator.