### PR TITLE
remove chain rule removal from constructor generator for syntax rules

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
@@ -153,9 +153,6 @@ private bool isTerminalSym((Sym) `(<Sym symbol1> <Sym symbol2>)`) = isTerminalSy
 private bool isTerminalSym((Sym) `()`) = true;
 private default bool isTerminalSym(Sym s) =  s is characterClass || s is literal || s is caseInsensitiveLiteral;
 
-private AType removeChainRule(aprod(prod(AType adt1,[AType adt2]))) = adt2 when isNonTerminalAType(adt2);
-private default AType removeChainRule(AType t) = t;
-
 void collect(current: (Prod) `<ProdModifier* modifiers> <Name name> : <Sym* syms>`, Collector c){
     symbols = [sym | sym <- syms, !(sym is empty)];
 
@@ -192,7 +189,7 @@ void collect(current: (Prod) `<ProdModifier* modifiers> <Name name> : <Sym* syms
                                !isTerminalSym(sym),
                                tsym := s.getType(sym),
                                isNonTerminalAType(tsym),
-                               stp := getSyntaxType(removeChainRule(tsym), s)
+                               stp := getSyntaxType(tsym, s)
                              ];
 
                     def = \start(sdef) := def ? sdef : def;


### PR DESCRIPTION
This could have let to very subtle bugs. Chain rules are important for the type system, and they can't be removed. The reason is that chain-rules do not lead to sub-types or substitutability of a tree with/without the chain node. So removing a chain application will break the type system.