### PR TITLE
fix type-check of implode test while bootstrapping

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
@@ -233,7 +233,7 @@ void collect(current: (Prod) `<ProdModifier* modifiers> <Name name> : <Sym* syms
                         s.fact(syms, ptype);
                     }
                     def = cprod.def;
-                    fields = [ (isLexicalAType(stp) ? astr() : stp)[alabel=tsym.alabel?"anonymous<unescape("<name>")>"] 
+                    fields = [ tsym[alabel=tsym.alabel?"anonymous<unescape("<name>")>"] 
                              | sym <- symbols,
                                !isTerminalSym(sym),
                                tsym := s.getType(sym),

--- a/src/org/rascalmpl/library/lang/rascal/syntax/tests/ImplodeTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/syntax/tests/ImplodeTests.rsc
@@ -1,7 +1,7 @@
 @license{
   Copyright (c) 2009-2015 CWI
   All rights reserved. This program and the accompanying materials
-  are made available under the terms of the Eclipse Public License v1.0
+  are made available under the terms of the Eclipse License v1.0
   which accompanies this distribution, and is available at
   http://www.eclipse.org/legal/epl-v10.html
 }
@@ -12,21 +12,29 @@ import lang::rascal::\syntax::tests::ImplodeTestGrammar;
 import ParseTree;
 import Exception;
 
-public data Num(loc src=|unknown:///|, map[int,list[str]] comments = ());
-public data Exp(loc src=|unknown:///|, map[int,list[str]] comments = ()) = id(str name);
-public Exp number(Num::\int("0")) = Exp::number(Num::\int("01"));
+data Num(loc src=|unknown:///|, map[int,list[str]] comments = ())
+  = \int(str val)
+  ;
 
-public data Number(loc src=|unknown:///|, map[int,list[str]] comments = ());
-public data Expr(loc src=|unknown:///|, map[int,list[str]] comments = ()) = id(str name);
-public Expr number(Number::\int("0")) = Expr::number(Number::\int("02"));
+data Exp(loc src=|unknown:///|, map[int,list[str]] comments = ()) 
+  = id(str name)
+  | number(Num number)
+  | eq(Exp lhs, Exp rhs)
+  ;
 
-public Exp implodeExp(str s) = implode(#Exp, parseExp(s));
-public Exp implodeExpLit1() = implode(#Exp, expLit1());
-public Exp implodeExpLit2() = implode(#Exp, expLit2());
+Exp number(Num::\int("0")) = Exp::number(Num::\int("01"));
 
-public Expr implodeExpr(str s) = implode(#Expr, parseExp(s));
-public Expr implodeExprLit1() = implode(#Expr, exprLit1());
-public Expr implodeExprLit2() = implode(#Expr, exprLit2());
+data Number(loc src=|unknown:///|, map[int,list[str]] comments = ());
+data Expr(loc src=|unknown:///|, map[int,list[str]] comments = ()) = id(str name);
+Expr number(Number::\int("0")) = Expr::number(Number::\int("02"));
+
+Exp implodeExp(str s) = implode(#Exp, parseExp(s));
+Exp implodeExpLit1() = implode(#Exp, expLit1());
+Exp implodeExpLit2() = implode(#Exp, expLit2());
+
+Expr implodeExpr(str s) = implode(#Expr, parseExp(s));
+Expr implodeExprLit1() = implode(#Expr, exprLit1());
+Expr implodeExprLit2() = implode(#Expr, exprLit2());
 
 
 // ---- test1 ----


### PR DESCRIPTION
* [x] stop emulating `ParseTree::implode` function behaviour with constructor shapes (which is not a language feature (yet)), mainly this means no more `str` for lexical parameters of generated constructors, but just the type that it is.
* [x] bring back support for the prefix notation for lexical and context-free syntax rules (which is different). Is an effect of step 1. 
* [x] fix the `ImplodeTests` by adding missing manual constructor definitions
* [ ] fix consequences downstream