### PR TITLE
Fix missing port registering for debugger

### DIFF
--- a/src/org/rascalmpl/ideservices/RemoteIDEServices.java
+++ b/src/org/rascalmpl/ideservices/RemoteIDEServices.java
@@ -100,6 +100,11 @@ public class RemoteIDEServices extends BasicIDEServices {
     }
 
     @Override
+    public void registerDebugServerPort(int processID, int serverPort) {
+        server.registerDebugServerPort(processID, serverPort);
+    }
+
+    @Override
     public void applyFileSystemEdits(IList edits) {
         server.applyDocumentsEdits(new DocumentEditsParameter(edits));
     }


### PR DESCRIPTION
With the new RemoteIDEService, the debugger port was not registered at startup (and so it was not possible to launch debugger in VSCode).