### PR TITLE
Add the callerEnvironement as Scope in default parameter computation

### DIFF
--- a/src/org/rascalmpl/interpreter/result/ConstructorFunction.java
+++ b/src/org/rascalmpl/interpreter/result/ConstructorFunction.java
@@ -79,8 +79,8 @@ public class ConstructorFunction extends NamedFunction {
 		Set<GenericKeywordParameters> kws = callerEnvironment.lookupGenericKeywordParameters(constructorType.getAbstractDataType());
 		IWithKeywordParameters<? extends IConstructor> wkw = value.asWithKeywordParameters();
 		Environment old = ctx.getCurrentEnvt();
-		Environment resultEnv = new Environment(declarationEnvironment, URIUtil.rootLocation("initializer"), "keyword parameter initializer");
-		
+		Environment resultEnv = new Environment(declarationEnvironment, callerEnvironment, callerEnvironment.getLocation(), URIUtil.rootLocation("initializer"), "keyword parameter initializer");
+
 		// first we compute the keyword parameters for the abstract data-type:
 		for (GenericKeywordParameters gkw : kws) {
 			// for hygiene's sake, each list of generic params needs to be evaluated in its declaring environment


### PR DESCRIPTION
This PR add the caller environment as Scope when computing default keyword parameters.

This caused issues in the debugger, because the default parameter are computed on access and the stack size of the evaluator could be inferior during the computation of the default compared to the current evaluator state.

