### PR TITLE
Use daemon threads to prevent blocking shutdown

### DIFF
--- a/src/org/rascalmpl/dap/DebugSocketServer.java
+++ b/src/org/rascalmpl/dap/DebugSocketServer.java
@@ -26,11 +26,11 @@
  */
 package org.rascalmpl.dap;
 
+import engineering.swat.watch.DaemonThreadPool;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.debug.TerminatedEventArguments;
@@ -67,7 +67,7 @@ public class DebugSocketServer {
                     Socket newClient = serverSocket.accept();
                     if(clientSocket == null || clientSocket.isClosed()){
                         clientSocket = newClient;
-                        threadPool = Executors.newCachedThreadPool();
+                        threadPool = DaemonThreadPool.buildConstrainedCached("rascal-debug", Math.max(2, Math.min(6, Runtime.getRuntime().availableProcessors() - 2)));
                         debugClient = RascalDebugAdapterLauncher.start(evaluator, clientSocket, this, services, threadPool);
                     } else {
                         newClient.close();

--- a/src/org/rascalmpl/ideservices/RemoteIDEServices.java
+++ b/src/org/rascalmpl/ideservices/RemoteIDEServices.java
@@ -65,7 +65,7 @@ public class RemoteIDEServices extends BasicIDEServices {
                 .setInput(socket.getInputStream())
                 .setOutput(socket.getOutputStream())
                 .configureGson(GsonUtils::configureGson)
-                .setExecutorService(DaemonThreadPool.buildConstrainedCached("rascal-ide-services", Runtime.getRuntime().availableProcessors()))
+                .setExecutorService(DaemonThreadPool.buildConstrainedCached("rascal-ide-services", Math.max(2, Math.min(6, Runtime.getRuntime().availableProcessors() - 2))))
                 .create();
 
                 clientLauncher.startListening();

--- a/src/org/rascalmpl/shell/RascalCompile.java
+++ b/src/org/rascalmpl/shell/RascalCompile.java
@@ -1,17 +1,16 @@
 package org.rascalmpl.shell;
 
+import engineering.swat.watch.DaemonThreadPool;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.file.Files;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -120,7 +119,7 @@ public class RascalCompile extends AbstractCommandlineTool {
 
 		// a cachedThreadPool lazily spins-up threads, but eagerly cleans them up
 		// this might help with left-over threads to get more memory and finish sooner.
-		final ExecutorService exec = Executors.newCachedThreadPool();
+		final ExecutorService exec = DaemonThreadPool.buildConstrainedCached("rascal-compile", parAmount);
 		
 		// the for loop eagerly spawns `parAmount` workers, one for each chunk
 		List<Future<Integer>> workers = new ArrayList<>(parAmount);


### PR DESCRIPTION
- Partially fixes a hanging REPL after pressing Ctrl+D. Tested using local snapshot versions of Rascal and Rascal LSP (other half of https://github.com/usethesource/rascal-language-servers/pull/911).
- Pre-emptively replaces some other thread pools by daemon pools.
