### PR TITLE
fix broken links caused by removing features only used in rascal-website

### DIFF
--- a/src/org/rascalmpl/tutor/lang/rascal/tutor/Compiler.rsc
+++ b/src/org/rascalmpl/tutor/lang/rascal/tutor/Compiler.rsc
@@ -716,6 +716,10 @@ list[Output] compileMarkdown([/^<prefix:.*>\[<title:[^\]]*>\]\(\(<link:[A-Za-z0-
           u = /^\/assets/ := u ? u : "<p2r><u>";
           return compileMarkdown(["<prefix>[<title>](<u>)<postfix>", *rest], line, offset, pcfg, exec, ind, dtls, sidebar_position=sidebar_position);
         }
+        else if ({str u} := ind["<rootName(pcfg.currentRoot, pcfg.isPackageCourse)>:<removeSpaces(link)>"]) {
+          u = /^\/assets/ := u ? u : "<p2r><u>";
+          return compileMarkdown(["<prefix>[<title>](<u>)<postfix>", *rest], line, offset, pcfg, exec, ind, dtls, sidebar_position=sidebar_position);
+        }
 
         exactLinks = exactShortestLinks(ind, removeSpaces(link));
 
@@ -771,6 +775,10 @@ default list[Output] compileMarkdown([/^<prefix:.*>\(\(<link:[A-Za-z0-9\-\ \t\.\
         else if (str sep <- {"-", "::"}, {str u} := ind["<rootName(pcfg.currentRoot, pcfg.isPackageCourse)>:<fragment(pcfg.currentRoot, pcfg.currentFile[extension=""])><sep><removeSpaces(link)>"]) {
           u = /^\/assets/ := u ? u : "<p2r><u>";
           return compileMarkdown(["<prefix>[<addSpaces(link)>](<u>)<postfix>", *rest], line, offset, pcfg, exec, ind, dtls, sidebar_position=sidebar_position);
+        }
+        else if ({str u} := ind["<rootName(pcfg.currentRoot, pcfg.isPackageCourse)>:<removeSpaces(link)>"]) {
+          u = /^\/assets/ := u ? u : "<p2r><u>";
+          return compileMarkdown(["<prefix>[<title>](<u>)<postfix>", *rest], line, offset, pcfg, exec, ind, dtls, sidebar_position=sidebar_position);
         }
 
         exactLinks = exactShortestLinks(ind, removeSpaces(link));


### PR DESCRIPTION
* this fixes 50 ambiguous references to things like `((AbstractDataType))` which occur in multiple courses of the website. The previous tutor would first try and resolve the reference in the current course before creating an ambiguous reference error.
* So if we are in the "Rascal" course, the code tries `((Rascal:AbstractDataType))` and if that resolves to a unique target, then it goes with that. 
* Otherwise it reports the original ambiguity with solutions.