### PR TITLE
Fix dozens of doc compilation errors due to persistent module load errors

### DIFF
--- a/src/org/rascalmpl/interpreter/env/GlobalEnvironment.java
+++ b/src/org/rascalmpl/interpreter/env/GlobalEnvironment.java
@@ -324,4 +324,11 @@ public class GlobalEnvironment {
 	public void clearLookupChaches() {
 		moduleEnvironment.values().forEach(ModuleEnvironment::clearLookupCaches);
 	}
+
+	/**
+	 * This is for the tutor and eval; sometimes we do not want to keep seeing old messages
+	 */
+	public void clearModuleLoadMessage() {
+		moduleEnvironment.values().forEach(ModuleEnvironment::clearLoadMessages);
+	}
 }

--- a/src/org/rascalmpl/interpreter/env/ModuleEnvironment.java
+++ b/src/org/rascalmpl/interpreter/env/ModuleEnvironment.java
@@ -133,6 +133,16 @@ public class ModuleEnvironment extends Environment {
 		cachedGeneralKeywordParameters = null;
 		cachedPublicFunctions = null;
 	}
+
+	/**
+	 * This is useful for the tutor and the eval repl where we 
+	 * sometimes need to forget about previous errors without
+	 * actually fixing them. This is not for the real REPL, where
+	 * we _do_ want to be reminded of previous erroneous initializations.
+	 */
+	public void clearLoadMessages() {
+		this.loadMessages.clear();
+	}
 	
 	public void extend(ModuleEnvironment other) {
 		extendNameFlags(other);

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -336,4 +336,8 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
             dirtyModules.add(modName);
         }
     }
+
+    public void clearModuleLoadMessages() {
+        eval.getHeap().clearModuleLoadMessage();
+    }
 }

--- a/src/org/rascalmpl/tutor/lang/rascal/tutor/repl/TutorCommandExecutor.java
+++ b/src/org/rascalmpl/tutor/lang/rascal/tutor/repl/TutorCommandExecutor.java
@@ -142,6 +142,7 @@ public class TutorCommandExecutor {
     public void reset() {
         interpreter.cancelRunningCommandRequested();
         interpreter.cleanEnvironment();
+        interpreter.clearModuleLoadMessages();
         outPrinter.flush();
         outWriter.getBuffer().setLength(0);
         errPrinter.flush();


### PR DESCRIPTION
* One of the first examples in rascal-website is `import Lis;`, demonstrating an import error and how to fix it.
* The new functionality that persists module load errors until fixed, then prints static error messages for every command that follows, relevant or not. The tutor REPL detects the output on stderr and flags a failing code example.
* This made for hundreds of failed code examples in the rascal-website.
* The current fix removes all persistent error messages when the client `reset`s a tutor REPL object.