### PR TITLE
Make breakpoint suspension global

### DIFF
--- a/src/org/rascalmpl/debug/DebugHandler.java
+++ b/src/org/rascalmpl/debug/DebugHandler.java
@@ -106,6 +106,12 @@ public final class DebugHandler implements IDebugHandler {
 	    } 
 	    else {
 	        AbstractAST location = currentAST;
+
+			if (hasBreakpoint(location.getLocation())) {
+				updateSuspensionState(getCallStackSize.getAsInt(), currentAST);
+				getEventTrigger().fireSuspendByBreakpointEvent(location.getLocation());
+			}
+			
 	        switch (getStepMode()) {
 
 	        case STEP_INTO:
@@ -173,12 +179,7 @@ public final class DebugHandler implements IDebugHandler {
 				break;
 
 	        case NO_STEP:
-	            if (hasBreakpoint(location.getLocation())) {
-	                updateSuspensionState(getCallStackSize.getAsInt(), currentAST);
-	                getEventTrigger().fireSuspendByBreakpointEvent(location.getLocation());
-	            }
 	            break;
-
 	        }
 	    }
 


### PR DESCRIPTION
In most of GPL debuggers(Java,Python,...) , breakpoint suspension are global, they are triggered if the execution hit them, and do not depend of the debugger command (step in/out/over).

This is not the case with Rascal. Considering this code with breakpoints on BP1 and BP2: 
```rascal
int bar(int x){
    y = x * 2; // BP 2
    return y;
}

void foo() {
    int x = 10; 
    int y = 20;
    int z = bar(x) + bar(y); // BP 1
    println("The value of z is <z>");
}
```
In the current implementation, a step over command when suspended at BP 1 does not trigger BP 2.

Demo : 

https://github.com/user-attachments/assets/ce82ffc2-a9a8-46db-906a-57e1c326a945

This PR make breakpoint trigger global.

Demo :

https://github.com/user-attachments/assets/0c20e52c-c252-427a-985b-30eec3d1f716





