### PR TITLE
Limit suspension to a single thread

### DIFF
--- a/src/org/rascalmpl/debug/DebugHandler.java
+++ b/src/org/rascalmpl/debug/DebugHandler.java
@@ -40,6 +40,8 @@ public final class DebugHandler implements IDebugHandler {
 	 * Indicates that the evaluator is suspended. Also used for suspending / blocking the evaluator.
 	 */
 	private boolean suspended;
+
+	private long suspendThreadId;
 	
 	private enum DebugStepMode {
 		NO_STEP, STEP_INTO, STEP_OVER, STEP_OUT
@@ -99,6 +101,11 @@ public final class DebugHandler implements IDebugHandler {
 	
 	@Override
 	public void suspended(Object runtime, IntSupplier getCallStackSize, AbstractAST currentAST) {
+		if(isSuspended() && Thread.currentThread().getId() != this.suspendThreadId) {
+			// already suspended by another thread, ignore any suspension
+			return;
+		}
+		
 	    if (isSuspendRequested()) {
 	        updateSuspensionState(getCallStackSize.getAsInt(), currentAST);
 	        getEventTrigger().fireSuspendByClientRequestEvent();			
@@ -291,6 +298,7 @@ public final class DebugHandler implements IDebugHandler {
 	}
 
 	protected synchronized void setSuspended(boolean suspended) {
+	  this.suspendThreadId = Thread.currentThread().getId();
 	  this.suspended = suspended;
 	}
 


### PR DESCRIPTION
This PR is a solution to #2570 

It limit the suspension in the debugger to a single thread only. If a thread is suspended, all other thread continues their execution and skips any suspension request.

This is the more concise and less-impacting solution I found for #2570, as it correct the issue, and still allow debugging code inside web server.