### PR TITLE
Disable source for REPL DAP Stackframe

### DIFF
--- a/src/org/rascalmpl/dap/DebugSocketServer.java
+++ b/src/org/rascalmpl/dap/DebugSocketServer.java
@@ -27,6 +27,8 @@
 package org.rascalmpl.dap;
 
 import engineering.swat.watch.DaemonThreadPool;
+import io.usethesource.vallang.ISourceLocation;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -45,12 +47,14 @@ public class DebugSocketServer {
 
     private final IDEServices services;
     private final ServerSocket serverSocket;
+    private final ISourceLocation promptLocation;
     private volatile @Nullable Socket clientSocket;
     private volatile @Nullable IDebugProtocolClient debugClient;
     private volatile @Nullable ExecutorService threadPool;
 
-    public DebugSocketServer(Evaluator evaluator, IDEServices services){
+    public DebugSocketServer(Evaluator evaluator, IDEServices services, ISourceLocation promptLocation){
         this.services = services;
+        this.promptLocation = promptLocation;
         try {
             serverSocket = new ServerSocket(0);
         } catch (IOException e) {
@@ -92,6 +96,10 @@ public class DebugSocketServer {
 
     public int getPort(){
         return serverSocket.getLocalPort();
+    }
+
+    public ISourceLocation getPromptLocation() {
+        return promptLocation;
     }
 
     public void terminateDebugSession(){

--- a/src/org/rascalmpl/dap/RascalDebugAdapter.java
+++ b/src/org/rascalmpl/dap/RascalDebugAdapter.java
@@ -102,6 +102,7 @@ public class RascalDebugAdapter implements IDebugProtocolServer {
     private final Pattern emptyAuthorityPathPattern = Pattern.compile("^\\w+:/\\w+[^/]");
     private final IDEServices services;
     private final ExecutorService ownExecutor;
+    private final ISourceLocation promptLocation;
     private final ColumnMaps columns;
     private int lineBase = 1;   // Default in DAP
     private int columnBase = 1; // Default in DAP
@@ -109,11 +110,12 @@ public class RascalDebugAdapter implements IDebugProtocolServer {
     public static final ISourceLocation DEBUGGER_LOC = URIUtil.rootLocation("debugger");
 
 
-    public RascalDebugAdapter(DebugHandler debugHandler, Evaluator evaluator, IDEServices services, ExecutorService threadPool) {
+    public RascalDebugAdapter(DebugHandler debugHandler, Evaluator evaluator, IDEServices services, ExecutorService threadPool, ISourceLocation promptLocation) {
         this.debugHandler = debugHandler;
         this.evaluator = evaluator;
         this.services = services;
         this.ownExecutor = threadPool;
+        this.promptLocation = promptLocation;
         this.suspendedState = new SuspendedState(evaluator, services);
         this.breakpointsCollection = new BreakpointsCollection(debugHandler);
 
@@ -369,7 +371,7 @@ public class RascalDebugAdapter implements IDebugProtocolServer {
         StackFrame frame = new StackFrame();
         frame.setId(id);
         frame.setName(name);
-        if(loc != null && !loc.getScheme().equals("prompt")){
+        if(loc != null && !loc.getScheme().equals(promptLocation.getScheme())) {
             var offsets = columns.get(loc);
             var line = shiftLine(loc.getBeginLine());
             var column = shiftColumn(offsets.translateColumn(loc.getBeginLine(), loc.getBeginColumn(), false));

--- a/src/org/rascalmpl/dap/RascalDebugAdapterLauncher.java
+++ b/src/org/rascalmpl/dap/RascalDebugAdapterLauncher.java
@@ -55,7 +55,7 @@ public class RascalDebugAdapterLauncher {
             });
             evaluator.addSuspendTriggerListener(debugHandler);
 
-            RascalDebugAdapter server = new RascalDebugAdapter(debugHandler, evaluator, services, threadPool);
+            RascalDebugAdapter server = new RascalDebugAdapter(debugHandler, evaluator, services, threadPool,socketServer.getPromptLocation());
             Launcher<IDebugProtocolClient> launcher = DSPLauncher.createServerLauncher(server, clientSocket.getInputStream(), clientSocket.getOutputStream());
             server.connect(launcher.getRemoteProxy());
             launcher.startListening();

--- a/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
+++ b/src/org/rascalmpl/repl/rascal/RascalInterpreterREPL.java
@@ -143,7 +143,7 @@ public class RascalInterpreterREPL implements IRascalLanguageProtocol {
      */
     protected Evaluator buildEvaluator(Reader input, PrintWriter stdout, PrintWriter stderr, IDEServices services) {
         var evaluator = ShellEvaluatorFactory.getDefaultEvaluator(input, stdout, stderr, services);
-        debugServer = new DebugSocketServer(evaluator, services);
+        debugServer = new DebugSocketServer(evaluator, services, PROMPT_LOCATION);
         return evaluator;
     }
 


### PR DESCRIPTION
This PR disable source location for the REPL StackFrame in the DAP. Since the source location of this stackframe is `prompt:///`, this causes problem for vscode to display it correctly.

This fix 2 bugs : 
- The REPL stackframe was clickable. When selected, VS Code opened a blank page with an error. Now, the frame is no longer clickable.
- On the first `stackTrace` DAP request, the DAP generated a warning `[WARNING] |prompt:///|: Could not read contents of |prompt:///|`. This is not the case anymore.

