### PR TITLE
Slicing out of bound modification

### DIFF
--- a/src/org/rascalmpl/interpreter/result/ElementResult.java
+++ b/src/org/rascalmpl/interpreter/result/ElementResult.java
@@ -233,7 +233,7 @@ public class ElementResult<T extends IValue> extends Result<T> {
 				firstIndex = Math.max(firstIndex+len, 0);
 			}
 			else{
-				firstIndex = Math.min(firstIndex, len-1);
+				firstIndex = Math.min(firstIndex, len);
 			}
 		}
 		if(end != null){
@@ -244,6 +244,10 @@ public class ElementResult<T extends IValue> extends Result<T> {
 			else{
 				endIndex = Math.min(endIndex, len);
 			}
+		}
+		
+		if(firstIndex == len && endIndex<firstIndex){
+			firstIndex = len - 1;
 		}
 		
 		if(second == null){

--- a/src/org/rascalmpl/library/lang/rascal/tests/basic/Lists.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/basic/Lists.rsc
@@ -246,6 +246,13 @@ test bool sliceSecondNegative(list[int] L) {
   return S == makeSlice(L, 0, size(L) - incr, size(L));
 }
 
+test bool sliceOutOfBoundIndex1() { L = [0,1,2,3,4,5,6,7,8,9]; return L[..] == [0,1,2,3,4,5,6,7,8,9];}
+test bool sliceOutOfBoundIndex2() { L = [0,1,2,3,4,5,6,7,8,9]; return L[10..] == [];}
+test bool sliceOutOfBoundIndex3() { L = [0,1,2,3,4,5,6,7,8,9]; return L[10..10] == [];}
+test bool sliceOutOfBoundIndex4() { L = [0,1,2,3,4,5,6,7,8,9]; return L[10..-11] == [9,8,7,6,5,4,3,2,1];}
+test bool sliceOutOfBoundIndex5() { L = [0,1,2,3,4,5,6,7,8,9]; return L[-15..-11] == [];}
+test bool sliceOutOfBoundIndex6() { L = [0,1,2,3,4,5,6,7,8,9]; return L[10..-5] == [9,8,7,6];}
+
 test bool assignSlice1() { L = [0,1,2,3,4,5,6,7,8,9]; L[..] = [10,20]; return L == [10,20,10,20,10,20,10,20,10,20];}
 test bool assignSlice2() { L = [0,1,2,3,4,5,6,7,8,9]; L[2..] = [10,20]; return   L == [0,1,10,20,10,20,10,20,10,20];}
 test bool assignSlice3() { L = [0,1,2,3,4,5,6,7,8,9]; L[2..6] = [10,20]; return L == [0,1,10,20,10,20,6,7,8,9];}


### PR DESCRIPTION
This change is linked to [this issue](https://github.com/usethesource/rascal/issues/2370#issuecomment-3228210108)
The documentation change is defined in [this PR](https://github.com/usethesource/rascal-website/pull/75)

This change allow the slicing to be out of bound and work with negative index.

With `L = [0,1,2,3,4,5,6,7,8,9];` :
| | This PR | Rascal v0.41.3 |
|-|-|-|
|`L[..-11]`| `[]` |`[1]`|
|`L[10..-5]`| `[9,8,7,6]` |Interpreter Failure|
|`L[-11..]`| `[0,1,2,3,4,5,6,7,8,9]` |Interpreter Failure|


Fixes #2370