### PR TITLE
added backward compatibility mode if the new relocatedClasses parameter is missing

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/package/Packager.rsc
@@ -54,7 +54,7 @@ void package(list[loc] srcs, loc bin, loc relocated, loc sourceLookup) {
     rewriteTypeFiles(srcs, bin, relocated, sourceLookup);
 }
 
-void oldPackagelist([loc] srcs, loc bin, loc sourceLookup) {
+void oldPackage(list([loc] srcs, loc bin, loc sourceLookup) {
     packageSourceFiles(srcs, bin);
     rewriteTypeFiles(srcs, bin, bin, sourceLookup);
 }


### PR DESCRIPTION
If a project depends on the Rascal project version with the new packager, which copies to a fresh folder instead of rewriting in-place in target/classes, and _does not_ depend on rascal-maven-plugin which provides the fresh folder parameter `relocatedClasses`, then the maven plugin fails with a stack trace.

This fix runs the old in-place tpl rewriting in target/classes such that projects that do have the new rascal but not yet the new maven plugin, just keep working. Idea by @DavyLandman 

Eventually switching to the new maven plugin has major benefits for the quality of the error messages in the IDE after you've types `mvn install` or `mvn package` once. 