### PR TITLE
Fixed type-incorrect Gson configuration methods

### DIFF
--- a/src/org/rascalmpl/ideservices/GsonUtils.java
+++ b/src/org/rascalmpl/ideservices/GsonUtils.java
@@ -216,7 +216,7 @@ public class GsonUtils {
      * This configurtion should only be used for serialization; deserialization requires a {@link TypeStore).
      */
     public static Consumer<GsonBuilder> complexAsBase64String() {
-        return builder -> complexAsBase64String(new TypeStore());
+        return complexAsBase64String(new TypeStore());
     }
 
     /**
@@ -236,7 +236,7 @@ public class GsonUtils {
      * This configurtion should only be used for serialization; deserialization requires a {@link TypeStore).
      */
     public static Consumer<GsonBuilder> complexAsString() {
-        return builder -> complexAsString(new TypeStore());
+        return complexAsString(new TypeStore());
     }
 
     /**


### PR DESCRIPTION
This caused UI tests to fail in `rascal-lsp`'s [CI](https://github.com/usethesource/rascal-language-servers/actions/runs/21472115272/job/61847007633?pr=957).