### PR TITLE
Add use/def test for syntax field

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/UseDefTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/UseDefTests.rsc
@@ -65,7 +65,17 @@ test bool overloadedField() {
           && useDefOK(mtext, ("n": <1, {3}>)) // check uses of second declaration of n
           ;
 }
-                
+
+test bool syntaxField1() =
+    useDefOK("module Field
+                syntax D = d: N n;
+                syntax N = \"n\";
+                value main(){
+                    x = [D] \"n\";
+                    return x.n;
+                }",
+                ("n": <0, {1}>));
+
 @ignore{to be fixed in typechecker}
 
 test bool kwfield1() =


### PR DESCRIPTION
This PR modifies the tests in two related ways.
1. ~~Check that use/defs are injective, i.e. any use only maps to definitions of overloaded names.~~ Done in #2634 
2. Add a test use/defs of fields of syntax constructors.

~~Closes https://github.com/usethesource/rascal/issues/2632~~