### PR TITLE
Clean-up of jsonrpc test output

### DIFF
--- a/test/org/rascalmpl/test/rpc/IValueOverJsonTests.java
+++ b/test/org/rascalmpl/test/rpc/IValueOverJsonTests.java
@@ -103,7 +103,7 @@ public class IValueOverJsonTests {
 
     @After
     public void teardown() throws IOException {
-        exec.shutdownNow();
+        exec.shutdown();
         if (is0 != null) {
             is0.close();
         }


### PR DESCRIPTION
The `IValueOverJsonTests` test output contained stack traces related to misalignment during shutdown of the test class. This PR adds an explicit thread pool to the test class that is shutdown before the streams are closed.

Additionally, the way in which both thread launchers are configured is now aligned, and a private field was made static.