### PR TITLE
Fix module reload in the presence of file delete or rename

### DIFF
--- a/src/org/rascalmpl/exceptions/RascalStackOverflowError.java
+++ b/src/org/rascalmpl/exceptions/RascalStackOverflowError.java
@@ -36,7 +36,7 @@ public class RascalStackOverflowError extends RuntimeException {
         Environment env = deepestEnvironment;
 
         while (env != null) {
-            trace.add(env.getLocation(), env.getName());
+            trace.add(env.getCreatorLocation(), env.getName());
             env = env.getCallerScope();
         }
 

--- a/src/org/rascalmpl/interpreter/env/Environment.java
+++ b/src/org/rascalmpl/interpreter/env/Environment.java
@@ -205,7 +205,7 @@ public class Environment implements IRascalFrame {
 	/**
 	 * @return the location where this environment was created (i.e. call site) for use in tracing
 	 */
-	public ISourceLocation getLocation() {
+	public ISourceLocation getCreatorLocation() {
 		return loc;
 	}
 

--- a/src/org/rascalmpl/interpreter/env/GlobalEnvironment.java
+++ b/src/org/rascalmpl/interpreter/env/GlobalEnvironment.java
@@ -149,11 +149,9 @@ public class GlobalEnvironment {
 		return module;
 	}
 	
-
 	public boolean existsModule(String name) {
 		return moduleEnvironment.containsKey(name);
 	}
-
 	
 	@Override
 	public String toString(){

--- a/src/org/rascalmpl/interpreter/result/AbstractFunction.java
+++ b/src/org/rascalmpl/interpreter/result/AbstractFunction.java
@@ -346,7 +346,7 @@ abstract public class AbstractFunction extends Result<IValue> implements IExtern
 		    if (actualStaticTypes.isOpen()) {
 			    // we have to make the environment hygenic now, because the caller scope
 			    // may have the same type variable names as the current scope
-			    actualStaticTypes = renameType(actualStaticTypes, renamings, env.getLocation());
+			    actualStaticTypes = renameType(actualStaticTypes, renamings, env.getCreatorLocation());
 			}
 
 			

--- a/src/org/rascalmpl/interpreter/result/ConstructorFunction.java
+++ b/src/org/rascalmpl/interpreter/result/ConstructorFunction.java
@@ -79,7 +79,7 @@ public class ConstructorFunction extends NamedFunction {
 		Set<GenericKeywordParameters> kws = callerEnvironment.lookupGenericKeywordParameters(constructorType.getAbstractDataType());
 		IWithKeywordParameters<? extends IConstructor> wkw = value.asWithKeywordParameters();
 		Environment old = ctx.getCurrentEnvt();
-		Environment resultEnv = new Environment(declarationEnvironment, callerEnvironment, callerEnvironment.getLocation(), URIUtil.rootLocation("initializer"), "keyword parameter initializer");
+		Environment resultEnv = new Environment(declarationEnvironment, callerEnvironment, callerEnvironment.getCreatorLocation(), URIUtil.rootLocation("initializer"), "keyword parameter initializer");
 
 		// first we compute the keyword parameters for the abstract data-type:
 		for (GenericKeywordParameters gkw : kws) {

--- a/src/org/rascalmpl/interpreter/result/JavaMethod.java
+++ b/src/org/rascalmpl/interpreter/result/JavaMethod.java
@@ -202,7 +202,7 @@ public class JavaMethod extends NamedFunction {
 				// we have to make the environment hygenic now, because the caller scope
 				// may have the same type variable names as the current scope
 				renamings = new HashMap<>();
-				actualStaticTypes = fastRenameType(actualStaticTypes, renamings, env.getLocation());
+				actualStaticTypes = fastRenameType(actualStaticTypes, renamings, env.getCreatorLocation());
 			}
 			else {
  				renamings = Collections.emptyMap();

--- a/src/org/rascalmpl/interpreter/utils/Profiler.java
+++ b/src/org/rascalmpl/interpreter/utils/Profiler.java
@@ -111,10 +111,10 @@ public class Profiler extends Thread {
 						env = env.getParent();
 					}
 				if (env != null) {
-					Count currentCount = frame.get(env.getLocation());
+					Count currentCount = frame.get(env.getCreatorLocation());
 					if (currentCount == null) {
-						frame.put(env.getLocation(), new Count());
-						names.put(env.getLocation(), env.getName());
+						frame.put(env.getCreatorLocation(), new Count());
+						names.put(env.getCreatorLocation(), env.getName());
 					}
 					else {
 						currentCount.increment();

--- a/src/org/rascalmpl/semantics/dynamic/Import.java
+++ b/src/org/rascalmpl/semantics/dynamic/Import.java
@@ -563,7 +563,7 @@ private static boolean isDeprecated(Module preModule){
         }
       }
       catch (URISyntaxException | ClassNotFoundException | IOException e) {
-        eval.warning("reusing parsers failed during module import: " + e.getMessage(), env.getLocation());
+        eval.warning("reusing parsers failed during module import: " + e.getMessage(), env.getCreatorLocation());
       }
       
       return result;


### PR DESCRIPTION
* [x] don't crash without proper error message during reload if a file has dissappeared
* [x] solve confusing `getLocation` method name on `Environment`
* [x] check for other broken uses of `getLocation`
* [x] clarify error messages for missing modules who were imported or extended before the reloader started.
* [x] manually test happy flow for module reload, directly and indirectly
* [x] manually test reload with missing imports directly from the top level shell  (via file rename)
* [x] manually test reload with missing imports indirectly via imports via imports (via file rename)
