### PR TITLE
renamed cause keyword parameter to "reason" to comply with the interal definition in RuntimeExceptionFactory

### DIFF
--- a/src/org/rascalmpl/library/lang/json/IO.rsc
+++ b/src/org/rascalmpl/library/lang/json/IO.rsc
@@ -71,14 +71,14 @@ import Exception;
 @synopsis{JSON parse errors have more information than general parse errors}
 @description{
 * `location` is the place where the parsing got stuck (going from left to right).
-* `cause` is a factual diagnosis of what was expected at that position, versus what was found.
+* `reason` is a factual diagnosis of what was expected at that position, versus what was found.
 * `path` is a path query string into the JSON value from the root down to the leaf where the error was detected.
 }
 @benefits{
 * ((NoOffsetParseError)) is for when accurate offset tracking is turned off. Typically this is _on_
 even if `trackOrigins=false`, when we call the json parsers from Rascal.
 }
-data RuntimeException(str cause="", str path="")
+data RuntimeException(str reason="", str path="")
   = ParseError(loc location)
   | NoOffsetParseError(loc location, int line, int column)
   ;


### PR DESCRIPTION


This also resolves a duplicate declaration error with Exception.rsc where `cause` is of type `RuntimeException` and not `str` for the `Java` and `JavaException` constructors.