### PR TITLE
work on #2683

### DIFF
--- a/src/org/rascalmpl/interpreter/Evaluator.java
+++ b/src/org/rascalmpl/interpreter/Evaluator.java
@@ -1175,9 +1175,8 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
             for (String mod : names) {
                 if (heap.existsModule(mod)) {
                     var uri = heap.getModuleURI(mod);
-                    assert uri != null : "guaranteed by Import::loadModule";
-                    System.err.println("URI: " + uri);
-                    if (uri != null /* REPL $ module */ && resolverRegistry.exists(vf.sourceLocation(uri))) {
+                    
+                    if (mod.equals(ModuleEnvironment.SHELL_MODULE) || resolverRegistry.exists(vf.sourceLocation(uri))) {
                         // otherwise the file has been renamed or deleted, and we do
                         // not add it to the todo list.
                         onHeap.add(mod);
@@ -1189,8 +1188,10 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
                         extendingModules.addAll(heap.getExtendingModules(mod));
                     }
 
-                    // this module starts with a clean slate
-                    heap.removeModule(heap.getModule(mod));
+                    if (!mod.equals(ModuleEnvironment.SHELL_MODULE)) {
+                        // this module starts with a clean slate
+                        heap.removeModule(heap.getModule(mod));
+                    }
                 }
             }
 
@@ -1324,7 +1325,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
             found.addAll(dependingModules);
             todo.addAll(dependingModules);
         }
-
+        
         return found;
     }
 

--- a/src/org/rascalmpl/semantics/dynamic/Import.java
+++ b/src/org/rascalmpl/semantics/dynamic/Import.java
@@ -197,7 +197,15 @@ public abstract class Import {
 		@Override
 		public Result<IValue> interpret(IEvaluator<Result<IValue>> eval) {
 			String name = Names.fullName(this.getModule().getName());
-      extendCurrentModule(this.getLocation(), name, eval);
+
+      if (!eval.getCurrentModuleEnvironment().getName().equals(ModuleEnvironment.SHELL_MODULE)) {
+        extendCurrentModule(this.getLocation(), name, eval);
+      }
+      else {
+        eval.warning("importing " + name + ", instead of extending.", URIUtil.rootLocation("prompt"));
+        importModule(name, this.getLocation(), eval);
+      }
+
 			return org.rascalmpl.interpreter.result.ResultFactory.nothing();
 		}
 	}


### PR DESCRIPTION
See #2683 . This PR fixes that and the underlying issue of extending the root shell module.

* [x] NPE fixed
* [x] reveals another bug behind it. the root REPL module `$` is not extended again when one of the modules it extends (transitively or not) has changed.
* [x] re-extend does not have a known or satisfactory semantics for the `$` shell module, so this PR changes every `extend <X>` to `import <X>` and prints a warning.