### PR TITLE
programmatic uses of doImport forgot to clear lookup caches afterwards. Fixes #2694

### DIFF
--- a/src/org/rascalmpl/interpreter/Evaluator.java
+++ b/src/org/rascalmpl/interpreter/Evaluator.java
@@ -1129,6 +1129,7 @@ public class Evaluator implements IEvaluator<Result<IValue>>, IRascalSuspendTrig
             monitor.jobEnd(LOADING_JOB_CONSTANT, true);
             setMonitor(old);
             setCurrentAST(null);
+            heap.clearLookupChaches();
             heap.writeLoadMessages(getErrorPrinter());
             // the repl is not a persistent file, so errors do not persist either
             rootScope.clearLoadMessages();


### PR DESCRIPTION
This fixes #2694 which was caused by a cached version of the `conditional` constructor which was created while loading an incomplete module `lang::rascal::grammar::definition::Symbols`.

- while loading constructors are searched in the current environment for computing the type of matching patterns
- these lookups end up being cached
- but later new overloaded alternatives are being added
- then normally after and `import` command on the REPL, all the caches are cleared and the new overloads are found.
- but when a main module with a main function is run automatically from the `mvn` command or a normal `java -jar`, then `doImport` is called from the commandline parser code and this top-level function did not clear the intermediate caches.

This fixes this urgent issue by  calling `heap.clearLookupChaches();` when `doImport` is done.

> **Warning** It is unknown if other issues arise from the cache being active while evaluating incomplete modules. At least this categorically fixes any issue caused by the caches _after_ the imports have finished.
