### PR TITLE
Add overload for summary from TPL location

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Summary.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Summary.rsc
@@ -52,11 +52,8 @@ data PathConfig(
     loc generatedTestResources =|unknown:///|
 );
 
-@doc{
-.Synopsis
-Summary of a Rascal module for use in IDE
-
-.Description
+@synopsis{Summary of a Rascal module for use in IDE}
+@description{
 A `ModuleSummary` summarizes a Rascal module for the benefit of IDE support like
 * Show type of current symbol.
 * Goto definition.
@@ -113,10 +110,7 @@ ModuleSummary makeSummary(str qualifiedModuleName, loc tplLoc) {
     }
 }
 
-@doc{
-.Synopsis
-Make a ModuleSummary.
-}
+@synopsis{Make a ModuleSummary.}
 ModuleSummary makeSummary(str qualifiedModuleName, PathConfig pcfg){
     if(<true, tplLoc> := getTPLReadLoc(qualifiedModuleName, pcfg)){
         return makeSummary(qualifiedModuleName, tplLoc);
@@ -126,34 +120,22 @@ ModuleSummary makeSummary(str qualifiedModuleName, PathConfig pcfg){
     }
 }
 
-@doc{
-.Synopsis
-Get all definitions for a given use.
-}
+@synopsis{Get all definitions for a given use.}
 set[loc] getDefinitions(ModuleSummary summary, loc use){
     return summary.useDef[use] ? {};
 }
 
-@doc{
-.Synopsis
-Get the (pretty printed) type for a given use.
-}
+@synopsis{Get the (pretty printed) type for a given use.}
 str getType(ModuleSummary summary, loc use){
     return summary.locationTypes[use] ? "";
 }
 
-@doc{
-.Synopsis
-Get all definitions for a given definition.
-}
+@synopsis{Get all definitions for a given definition.}
 set[loc] getUses(ModuleSummary s, loc def){
     return invert(s.useDef)[def];
 }
 
-@doc{
-.Synopsis
-Get the doc string for a given definition.
-}
+@synopsis{Get the doc string for a given definition.}
 str getDocForDefinition(loc def){
     try {
         d = readFile(def);


### PR DESCRIPTION
This PR
1. Adds an overload to make a summary given a TPL location.
2. Cleans up the `Summary` module.