### PR TITLE
Fix/missing dependency check typed var pattern

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
@@ -303,14 +303,10 @@ void collect(current: (FunctionDeclaration) `<FunctionDeclaration decl>`, Collec
 
     c.enterLubScope(decl);
         collect(decl.tags, c);
-        <tpnames, tpbounds> = collectSignature(decl.signature, c);
-        //println("tpnames: <tpnames>");
-        //iprintln("tpbounds:"); iprintln(tpbounds);
-        //
         scope = c.getScope();
         c.setScopeInfo(scope, functionScope(), signatureInfo(signature.\type));
-
-
+        <tpnames, tpbounds> = collectSignature(decl.signature, c);
+       
         dt = defType([signature], AType(Solver s) {
              ft = s.getType(signature);
 
@@ -477,7 +473,7 @@ tuple[set[str], rel[str,Type]] collectSignature(Signature signature, Collector c
             rtU = updateBounds(rt, minB);
             formalsList = [ updateBounds(fm, minB) | fm <- formalsList ];
             kwFormalsList = [ kwf[fieldType = updateBounds(kwf.fieldType, minB)] | kwf <- computeKwFormals(kwFormals, s) ];
-            ft = afunc(rt, formalsList, kwFormalsList);
+            ft = afunc(rtU, formalsList, kwFormalsList);
             //ft = updateBounds(afunc(s.getType(returnType), formalsList, computeKwFormals(kwFormals, s)), minB);
             return ft;
         });

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
@@ -93,7 +93,19 @@ void collect(current: (Pattern) `<Type tp> <Name name>`, Collector c){
         collect(tp, c);
     if(tp is function) c.leaveScope(current);
     
-    c.calculate("typed variable pattern", current, [tp], AType(Solver s){  return s.getType(tp)[alabel=uname]; });
+    functionScopes = c.getScopeInfo(functionScope());
+    if(isEmpty(functionScopes)){
+      throw rascalCheckerInternalError(getLoc(current), "No surrounding function scope found for typed variable pattern");
+    }
+    for(<_, scopeInfo> <- functionScopes){
+        if(signatureInfo(Type returnType) := scopeInfo){
+             c.calculate("typed variable pattern", current, [tp, returnType], AType(Solver s){  return s.getType(tp)[alabel=uname]; });
+           break;
+        } else {
+            throw rascalCheckerInternalError(getLoc(current), "Inconsistent info from function scope: <scopeInfo>");
+        }
+    }
+
     if(!isWildCard(uname)){
        c.push(patternNames, <uname, getLoc(name)>);
        orScopes = c.getScopeInfo(orScope());

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
@@ -92,19 +92,20 @@ void collect(current: (Pattern) `<Type tp> <Name name>`, Collector c){
     if(tp is function) c.enterScope(current);
         collect(tp, c);
     if(tp is function) c.leaveScope(current);
-    
+    calcDeps = [tp];
     functionScopes = c.getScopeInfo(functionScope());
-    if(isEmpty(functionScopes)){
-      throw rascalCheckerInternalError(getLoc(current), "No surrounding function scope found for typed variable pattern");
-    }
-    for(<_, scopeInfo> <- functionScopes){
-        if(signatureInfo(Type returnType) := scopeInfo){
-             c.calculate("typed variable pattern", current, [tp, returnType], AType(Solver s){  return s.getType(tp)[alabel=uname]; });
-           break;
-        } else {
-            throw rascalCheckerInternalError(getLoc(current), "Inconsistent info from function scope: <scopeInfo>");
+    if(!isEmpty(functionScopes)){
+        for(<_, scopeInfo> <- functionScopes){
+            if(signatureInfo(Type returnType) := scopeInfo){
+                calcDeps += returnType;
+                break;
+            } else {
+                throw rascalCheckerInternalError(getLoc(current), "Inconsistent info from function scope: <scopeInfo>");
+            }
         }
     }
+    c.calculate("typed variable pattern", current, calcDeps, AType(Solver s){  return s.getType(tp)[alabel=uname]; });
+ 
 
     if(!isWildCard(uname)){
        c.push(patternNames, <uname, getLoc(name)>);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/Tst5.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/Tst5.rsc
@@ -1,2 +1,83 @@
 module lang::rascalcore::compile::Examples::Tst5
 
+import IO;
+import String;
+import Location;
+import Message;
+import Set;
+import util::Reflective;
+import ParseTree;
+import lang::rascalcore::check::RascalConfig;
+
+import lang::rascalcore::check::Checker;
+import lang::rascal::\syntax::Rascal;
+loc root = |memory://e0711529-477e-4a4c-b44b-44b00157728eXXX|;
+
+PathConfig pcfg = pathConfig(
+    srcs = [root + "src"],
+    bin = root + "bin",
+    libs = []
+);
+// this name matters
+str moduleName = "TestModule612d1";
+
+loc writeModule() {
+    loc moduleLoc = pcfg.srcs[0] + "<moduleName>.rsc";
+    // the spaces before &T seems to matter?
+    writeFile(moduleLoc, 
+        "module TestModule612d1\r\n \r\n    &T \<: int f(&T \<: num _) = 1;"
+    );
+    return moduleLoc;
+}
+
+
+
+set[Message] getErrorMessages(ModuleStatus r)
+    =  { m | m <- getAllMessages(r), m is error };
+
+set[Message] getWarningMessages(ModuleStatus r)
+    = { m | m <- getAllMessages(r), m is warning };
+
+set[Message] getAllMessages(ModuleStatus r)
+	= { m | mname <- r.messages, m <- r.messages[mname] };
+
+bool typecheckModule(loc m) {
+    status = rascalTModelForLocs([m], rascalCompilerConfig(pcfg)[infoModuleChecked=true][verbose=true], dummy_compile1);
+    println("All messages:");
+    iprintln(getAllMessages(status));
+    if (e <- getErrorMessages(status)) {
+        println("Errors typechecking: ");
+        iprintln(getErrorMessages(status));
+        println("❌ Typecheck failed");
+        return false;
+    }
+    else {
+        println("✅ Typecheck success");
+        return true;
+    }
+}
+
+void findCollission(loc l) {
+    m = parseModule(l);
+    locs = [ t.src | /Tree t := m, t.src?];
+    println("Found <size(locs)> locs");
+    locsSet = {*locs};
+    println("Became: <size(locsSet)> locs when putting in set");
+    for (l <- locs) {
+        bool found = false;
+        for (l2 <- locsSet, "<l2>" == "<l>") {
+            found = true;
+        }
+        if (!found) {
+            println("❌ <l> got dropped from set");
+        }
+    }
+}
+
+
+void main() {
+    remove(root, recursive = true);
+    l = writeModule();
+    typecheckModule(l);
+    findCollission(l);
+}


### PR DESCRIPTION
- This is needed for proper execution order
- This is a rather coarse solution. Maybe move this to cases for type parameters?