### PR TITLE
Define names uniformly

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDataDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDataDeclaration.rsc
@@ -72,7 +72,7 @@ void dataDeclaration(Tags tags, Declaration current, list[Variant] variants, Col
     dt.md5 = normalizedMD5Hash(adtName, dataCounter);
     dataCounter += 1;
     if(!isEmpty(commonKeywordParameterList)) dt.commonKeywordFields = commonKeywordParameterList;
-    c.define(adtName, dataId(), current, dt);
+    c.define(prettyPrintName(userType.name), dataId(), current, dt);
        
     adtParentScope = c.getScope();
     c.enterScope(current);
@@ -142,7 +142,7 @@ void collect(current:(Variant) `<Name name> ( <{TypeArg ","}* arguments> <Keywor
                 fieldType = ta.\type;
                 dt = defType([fieldType], makeFieldType(fieldName, fieldType));
                 dt.md5 = normalizedMD5Hash(currentModuleName, adtName, name, current);
-                c.define(fieldName, fieldId(), ta.name, dt);
+                c.define(prettyPrintName(ta.name), fieldId(), ta.name, dt);
             }
         }
         
@@ -153,7 +153,7 @@ void collect(current:(Variant) `<Name name> ( <{TypeArg ","}* arguments> <Keywor
             kwfType = kwf.\type;
             dt = defType([kwfType], makeKeywordFieldType(fieldName, kwf));
             dt.md5 = normalizedMD5Hash(currentModuleName, adtName, dataCounter, name, consArity, kwfType, fieldName);
-            c.define(fieldName, keywordFieldId(), kwf.name, dt);  
+            c.define(prettyPrintName(kwf.name), keywordFieldId(), kwf.name, dt);  
         }
     
         scope = c.getScope();

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDataDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDataDeclaration.rsc
@@ -72,7 +72,7 @@ void dataDeclaration(Tags tags, Declaration current, list[Variant] variants, Col
     dt.md5 = normalizedMD5Hash(adtName, dataCounter);
     dataCounter += 1;
     if(!isEmpty(commonKeywordParameterList)) dt.commonKeywordFields = commonKeywordParameterList;
-    c.define(prettyPrintName(userType.name), dataId(), current, dt);
+    c.define("<userType.name>", dataId(), current, dt);
        
     adtParentScope = c.getScope();
     c.enterScope(current);
@@ -142,7 +142,7 @@ void collect(current:(Variant) `<Name name> ( <{TypeArg ","}* arguments> <Keywor
                 fieldType = ta.\type;
                 dt = defType([fieldType], makeFieldType(fieldName, fieldType));
                 dt.md5 = normalizedMD5Hash(currentModuleName, adtName, name, current);
-                c.define(prettyPrintName(ta.name), fieldId(), ta.name, dt);
+                c.define("<ta.name>", fieldId(), ta.name, dt);
             }
         }
         
@@ -153,13 +153,13 @@ void collect(current:(Variant) `<Name name> ( <{TypeArg ","}* arguments> <Keywor
             kwfType = kwf.\type;
             dt = defType([kwfType], makeKeywordFieldType(fieldName, kwf));
             dt.md5 = normalizedMD5Hash(currentModuleName, adtName, dataCounter, name, consArity, kwfType, fieldName);
-            c.define(prettyPrintName(kwf.name), keywordFieldId(), kwf.name, dt);  
+            c.define("<kwf.name>", keywordFieldId(), kwf.name, dt);  
         }
     
         scope = c.getScope();
         c.enterScope(current);
             args = "<for(arg <- arguments){><arg is named ? "<arg.\type> <arg.name>" : "<arg>"> <}>";
-            c.defineInScope(adtParentScope, prettyPrintName(name), constructorId(), name, defType(adt + formals + kwFormals + commonKwFormals,
+            c.defineInScope(adtParentScope, "<name>", constructorId(), name, defType(adt + formals + kwFormals + commonKwFormals,
                 AType(Solver s){
                     adtType = s.getType(adt);
                     kwFormalTypes = [kwField(s.getType(kwf.\type)[alabel=prettyPrintName(kwf.name)], prettyPrintName(kwf.name), currentModuleName, kwf.expression) | kwf <- kwFormals /*+ commonKwFormals*/];

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
@@ -92,7 +92,7 @@ void collect(Module current, Collector c){
     if(deprecated){
         c.report(warning(header.name, "Deprecated module %v%v", mname, isEmpty(deprecationMessage) ? "" : ": <deprecationMessage>"));
     }
-    c.define(prettyPrintName(header.name), moduleId(), current, defType(tmod));
+    c.define("<header.name>", moduleId(), current, defType(tmod));
 
     c.push(key_current_module, mname);
     c.enterScope(current);
@@ -175,7 +175,7 @@ void collect(current: (Declaration) `<Tags tags> <Visibility visibility> <Type v
             if(isWildCard(vname)){
                 c.report(warning(var, "Variable names starting with `_` are deprecated; only allowed to suppress warning on unused variables"));
             }
-            c.defineInScope(scope, prettyPrintName(var.name), moduleVariableId(), var.name, dt);
+            c.defineInScope(scope, "<var.name>", moduleVariableId(), var.name, dt);
 
             if(var is initialized){
                 initial = var.initial;
@@ -222,7 +222,7 @@ void collect(current: (Declaration) `<Tags tags> <Visibility visibility> anno <T
     // if(isWildCard(pname)){
     //     c.report(error(name, "Annotation names starting with `_` are deprecated; only allowed to suppress warning on unused variables"));
     // }
-    c.define(prettyPrintName(name), annoId(), current, dt);
+    c.define("<name>", annoId(), current, dt);
     collect(tags, annoType, onType, c);
 }
 
@@ -237,7 +237,7 @@ void collect(current: (KeywordFormal) `<Type kwType> <Name name> = <Expression e
          dt = defType([kwType], makeFieldType(kwformalName, kwType));
     }
     dt.md5 = normalizedMD5Hash(current);
-    c.define(prettyPrintName(name), keywordFormalId(), current, dt);
+    c.define("<name>", keywordFormalId(), current, dt);
     c.calculate("keyword formal", current, [kwType, expression],
         AType(Solver s){
             expType = s.getType(expression);
@@ -416,7 +416,7 @@ void collect(current: (FunctionDeclaration) `<FunctionDeclaration decl>`, Collec
         endUseBoundedTypeParameters(c);
 
         dt.md5 = normalizedMD5Hash(md5Contrib);
-        c.defineInScope(parentScope, prettyPrintName(fname), functionId(), current, dt);
+        c.defineInScope(parentScope, "<fname>", functionId(), current, dt);
     c.leaveScope(decl);
     c.pop(currentFunction);
     if(isEmpty(fstk)){
@@ -589,7 +589,7 @@ private tuple[set[str], rel[str,Type]] computeBoundsAndDefineTypeParams(Signatur
             c.fact(tp, tp.name);
         } else {
             seenInParams += tpname;
-            c.define(prettyPrintName(tp.name), typeVarId(), tp.name,
+            c.define("<tp.name>", typeVarId(), tp.name,
                 defType(toList(typeParamBounds[tpname]), makeBoundDef(tp, typeParamBounds, closed=false)));
             c.fact(tp, tp.name);
         }
@@ -715,7 +715,7 @@ void collect (current: (Declaration) `<Tags tags> <Visibility visibility> alias 
     //     c.report(warning(name, "Alias names starting with `_` are deprecated; only allowed to suppress warning on unused variables"));
     // }
 
-    c.define(prettyPrintName(name), aliasId(), current, defType([base], AType(Solver s) { return s.getType(base); })[md5 = normalizedMD5Hash(md5Contrib4Tags(tags), visibility, name, base)]);
+    c.define("<name>", aliasId(), current, defType([base], AType(Solver s) { return s.getType(base); })[md5 = normalizedMD5Hash(md5Contrib4Tags(tags), visibility, name, base)]);
     c.enterScope(current);
         collect(tags, base, c);
     c.leaveScope(current);
@@ -739,7 +739,7 @@ void collect (current: (Declaration) `<Tags tags> <Visibility visibility> alias 
         append tp.typeVar;
     }
 
-    c.define(prettyPrintName(name), aliasId(), name, defType(typeParams + base, AType(Solver s){
+    c.define("<name>", aliasId(), name, defType(typeParams + base, AType(Solver s){
         bindings = ();
         params = for(int i <- index(typeParams)){
             ptype = s.getType(typeParams[i]);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
@@ -92,7 +92,7 @@ void collect(Module current, Collector c){
     if(deprecated){
         c.report(warning(header.name, "Deprecated module %v%v", mname, isEmpty(deprecationMessage) ? "" : ": <deprecationMessage>"));
     }
-    c.define(mname, moduleId(), current, defType(tmod));
+    c.define(prettyPrintName(header.name), moduleId(), current, defType(tmod));
 
     c.push(key_current_module, mname);
     c.enterScope(current);
@@ -175,7 +175,7 @@ void collect(current: (Declaration) `<Tags tags> <Visibility visibility> <Type v
             if(isWildCard(vname)){
                 c.report(warning(var, "Variable names starting with `_` are deprecated; only allowed to suppress warning on unused variables"));
             }
-            c.defineInScope(scope, vname, moduleVariableId(), var.name, dt);
+            c.defineInScope(scope, prettyPrintName(var.name), moduleVariableId(), var.name, dt);
 
             if(var is initialized){
                 initial = var.initial;
@@ -222,7 +222,7 @@ void collect(current: (Declaration) `<Tags tags> <Visibility visibility> anno <T
     // if(isWildCard(pname)){
     //     c.report(error(name, "Annotation names starting with `_` are deprecated; only allowed to suppress warning on unused variables"));
     // }
-    c.define(pname, annoId(), current, dt);
+    c.define(prettyPrintName(name), annoId(), current, dt);
     collect(tags, annoType, onType, c);
 }
 
@@ -237,7 +237,7 @@ void collect(current: (KeywordFormal) `<Type kwType> <Name name> = <Expression e
          dt = defType([kwType], makeFieldType(kwformalName, kwType));
     }
     dt.md5 = normalizedMD5Hash(current);
-    c.define(kwformalName, keywordFormalId(), current, dt);
+    c.define(prettyPrintName(name), keywordFormalId(), current, dt);
     c.calculate("keyword formal", current, [kwType, expression],
         AType(Solver s){
             expType = s.getType(expression);
@@ -589,7 +589,7 @@ private tuple[set[str], rel[str,Type]] computeBoundsAndDefineTypeParams(Signatur
             c.fact(tp, tp.name);
         } else {
             seenInParams += tpname;
-            c.define(tpname, typeVarId(), tp.name,
+            c.define("<tp.name>", typeVarId(), tp.name,
                 defType(toList(typeParamBounds[tpname]), makeBoundDef(tp, typeParamBounds, closed=false)));
             c.fact(tp, tp.name);
         }
@@ -715,7 +715,7 @@ void collect (current: (Declaration) `<Tags tags> <Visibility visibility> alias 
     //     c.report(warning(name, "Alias names starting with `_` are deprecated; only allowed to suppress warning on unused variables"));
     // }
 
-    c.define(aliasName, aliasId(), current, defType([base], AType(Solver s) { return s.getType(base); })[md5 = normalizedMD5Hash(md5Contrib4Tags(tags), visibility, name, base)]);
+    c.define(prettyPrintName(name), aliasId(), current, defType([base], AType(Solver s) { return s.getType(base); })[md5 = normalizedMD5Hash(md5Contrib4Tags(tags), visibility, name, base)]);
     c.enterScope(current);
         collect(tags, base, c);
     c.leaveScope(current);
@@ -739,7 +739,7 @@ void collect (current: (Declaration) `<Tags tags> <Visibility visibility> alias 
         append tp.typeVar;
     }
 
-    c.define(aliasName, aliasId(), name, defType(typeParams + base, AType(Solver s){
+    c.define(prettyPrintName(name), aliasId(), name, defType(typeParams + base, AType(Solver s){
         bindings = ();
         params = for(int i <- index(typeParams)){
             ptype = s.getType(typeParams[i]);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
@@ -583,13 +583,13 @@ private tuple[set[str], rel[str,Type]] computeBoundsAndDefineTypeParams(Signatur
                 c.use(tpbound.name, {typeVarId()});
             }
         }
-        tpname = "<tp.name>";
+        tpname = prettyPrintName(tp.name);
         if(tpname in seenInParams){
             c.use(tp.name, {typeVarId()});
             c.fact(tp, tp.name);
         } else {
             seenInParams += tpname;
-            c.define("<tp.name>", typeVarId(), tp.name,
+            c.define(prettyPrintName(tp.name), typeVarId(), tp.name,
                 defType(toList(typeParamBounds[tpname]), makeBoundDef(tp, typeParamBounds, closed=false)));
             c.fact(tp, tp.name);
         }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectExpression.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectExpression.rsc
@@ -213,10 +213,7 @@ void collect(current: (Expression) `( <Expression expression> )`, Collector c){
 
 // ---- closure
 
-str closureName(Expression closure){
-    //l = getLoc(closure);
-    return "$CLOSURE_<nextClosure()>"; //"$CLOSURE_<l.begin.line>A<l.offset>";
-}
+str generateClosureName() = "$CLOSURE_<nextClosure()>";
 
 void collect(current: (Expression) `<Type returnType> <Parameters parameters> { <Statement+ statements> }`, Collector c){
     // TODO: experimental check
@@ -242,7 +239,7 @@ void collectClosure(Expression current, Type returnType, Parameters parameters, 
 
         collect(stats, c); // TODO take parameter bounds into account!
 
-        clos_name = closureName(current);
+        clos_name = generateClosureName();
         bool returnsViaAll = returnsViaAllPath(stats, clos_name, c);
         formals = getFormals(parameters);
         kwFormals = getKwFormals(parameters);
@@ -255,7 +252,7 @@ void collectClosure(Expression current, Type returnType, Parameters parameters, 
         alwaysSucceeds = all(pat <- formals, pat is typedVariable && /(Statement) `fail <Target _>;` := stats);
         if(!alwaysSucceeds) dt.canFail = true;
 
-        c.defineInScope(parentScope, clos_name /* Unique string, not derived from `current` */, functionId(), current, dt);
+        c.defineInScope(parentScope, clos_name, functionId(), current, dt);
 
         if(!returnsViaAll && "<returnType>" != "void"){
                 c.report(error(current, "Missing return statement"));

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectExpression.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectExpression.rsc
@@ -255,7 +255,7 @@ void collectClosure(Expression current, Type returnType, Parameters parameters, 
         alwaysSucceeds = all(pat <- formals, pat is typedVariable && /(Statement) `fail <Target _>;` := stats);
         if(!alwaysSucceeds) dt.canFail = true;
 
-        c.defineInScope(parentScope, clos_name, functionId(), current, dt);
+        c.defineInScope(parentScope, clos_name /* Unique string, not derived from `current` */, functionId(), current, dt);
 
         if(!returnsViaAll && "<returnType>" != "void"){
                 c.report(error(current, "Missing return statement"));

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectLiteral.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectLiteral.rsc
@@ -98,7 +98,7 @@ void collect(current: (ConcreteHole) `\< <Sym symbol> <Name name> \>`, Collector
               c.useLub(name, {formalOrPatternFormal(c)});
            } else {
                c.push(patternNames, uname);
-               c.define(uname, formalOrPatternFormal(c), name, defLub([symbol], AType(Solver s) { return s.getType(symbol); }));
+               c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defLub([symbol], AType(Solver s) { return s.getType(symbol); }));
            }
         }
     }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectLiteral.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectLiteral.rsc
@@ -98,7 +98,7 @@ void collect(current: (ConcreteHole) `\< <Sym symbol> <Name name> \>`, Collector
               c.useLub(name, {formalOrPatternFormal(c)});
            } else {
                c.push(patternNames, uname);
-               c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defLub([symbol], AType(Solver s) { return s.getType(symbol); }));
+               c.define("<name>", formalOrPatternFormal(c), name, defLub([symbol], AType(Solver s) { return s.getType(symbol); }));
            }
         }
     }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectOperators.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectOperators.rsc
@@ -620,7 +620,7 @@ void collect(current: (Expression) `<Pattern pat> \<- <Expression expression>`, 
             } else  
                 throw TypeUnavailable();
           
-            c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType(patType));
+            c.define("<name>", formalOrPatternFormal(c), name, defType(patType));
             c.fact(pat, patType);
             c.fact(current, abool());
             return;  

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectOperators.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectOperators.rsc
@@ -620,7 +620,7 @@ void collect(current: (Expression) `<Pattern pat> \<- <Expression expression>`, 
             } else  
                 throw TypeUnavailable();
           
-            c.define("<name>", formalOrPatternFormal(c), name, defType(patType));
+            c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType(patType));
             c.fact(pat, patType);
             c.fact(current, abool());
             return;  

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
@@ -118,7 +118,7 @@ void collect(current: (Pattern) `<Type tp> <Name name>`, Collector c){
                 }
             }
        }
-       c.define(uname, formalOrPatternFormal(c), name, defType(tp));
+       c.define(unescape("<name>"), formalOrPatternFormal(c), name, defType(tp));
     } else {
        c.fact(name, tp);
     }
@@ -137,7 +137,7 @@ void collectAsVarArg(current: (Pattern) `<Type tp> <Name name>`, Collector c){
             });
        } else {
           c.push(patternNames, <uname, getLoc(name)>);
-          c.define(uname, formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ 
+          c.define(unescape("<name>"), formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ 
             res = alist(s.getType(tp))[alabel=uname];
             return res;
              }));
@@ -166,7 +166,7 @@ void collect(current: (Pattern) `<QualifiedName name>`,  Collector c){
        if(!isEmpty(qualifier)) c.report(error(name, "Qualifier not allowed"));
        if(isTopLevelParameter(c)){
           c.fact(current, avalue(alabel=unescape(prettyPrintBaseName(name))));  
-          c.define(base, formalId(), name, defLub([], AType(Solver _) { return avalue(alabel=unescape(prettyPrintBaseName(name))); }));
+          c.define(splitQualifiedName(name)<1>, formalId(), name, defLub([], AType(Solver _) { return avalue(alabel=unescape(prettyPrintBaseName(name))); }));
        } else {
           if(c.isAlreadyDefined(base, name)){
             c.use(name, {variableId(), moduleVariableId(), formalId(), nestedFormalId(), patternVariableId(), constructorId()});
@@ -174,7 +174,7 @@ void collect(current: (Pattern) `<QualifiedName name>`,  Collector c){
           } else {
             tau = c.newTypeVar(name);
             c.fact(name, tau); //<====
-            c.define(base, formalOrPatternFormal(c), name, defLub([], AType(Solver s) { 
+            c.define(splitQualifiedName(name)<1>, formalOrPatternFormal(c), name, defLub([], AType(Solver s) { 
                 return s.getType(tau)[alabel=unescape(prettyPrintBaseName(name))]; 
             }));
           }
@@ -231,7 +231,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
             }
           }   
           
-          c.define(uname, formalOrPatternFormal(c), argName, defType([tp], 
+          c.define(unescape("<argName>"), formalOrPatternFormal(c), argName, defType([tp], 
                AType(Solver s){ return inSet ? aset(s.getType(tp)) : alist(s.getType(tp)); }));     
        } else {
           c.calculate("typed anonymous variable in splice pattern", argName, [tp], 
@@ -254,7 +254,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
            if(isTopLevelParameter(c)){
               c.fact(current, avalue());
               if(!isEmpty(qualifier)) c.report(error(argName, "Qualifier not allowed"));
-              c.define(base, formalId(), argName, defLub([], AType(Solver _) { return avalue(); }));
+              c.define(splitQualifiedName(argName)<1>, formalId(), argName, defLub([], AType(Solver _) { return avalue(); }));
            } else {
               if(c.isAlreadyDefined("<argName>", argName)) {
                   c.use(argName, {variableId(), moduleVariableId(), formalId(), nestedFormalId(), patternVariableId()});
@@ -263,7 +263,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
                   tau = c.newTypeVar(current); // <== argName;
                   c.fact(current, tau);    // <===
                   if(!isEmpty(qualifier)) c.report(error(argName, "Qualifier not allowed"));
-                  c.define(base, formalOrPatternFormal(c), argName, 
+                  c.define(splitQualifiedName(argName)<1>, formalOrPatternFormal(c), argName, 
                             defLub([], AType(Solver s) { 
                             return inSet ? makeSetType(s.getType(tau)) : makeListType(s.getType(tau));}));
               }
@@ -328,7 +328,7 @@ void collect(current: (Pattern) `<Name name> : <Pattern pattern>`, Collector c){
     } else {
         c.push(patternNames, <uname, getLoc(name)>);
         scope = c.getScope();
-        c.define(uname, formalOrPatternFormal(c), name, 
+        c.define(unescape("<name>"), formalOrPatternFormal(c), name, 
                  defLub([pattern], AType(Solver s) { 
                     try{
                         return s.getType(pattern);
@@ -357,7 +357,7 @@ void collect(current: (Pattern) `<Type tp> <Name name> : <Pattern pattern>`, Col
                 }
             }
         }   
-        c.define(uname, formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ return s.getType(tp); }));
+        c.define(unescape("<name>"), formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ return s.getType(tp); }));
     }
 }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
@@ -50,7 +50,7 @@ void collect(RegExp regExp, Collector c){
     if( (RegExp)`\<<Name name>\>` := regExp){
         c.use(name, variableRoles);
     } else if ((RegExp)`\<<Name name>:<NamedRegExp* regexps>\>` := regExp){
-        c.define("<name>", formalOrPatternFormal(c), name, defType(astr()));
+        c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType(astr()));
         collect(name, regexps, c);
     }
     c.fact(regExp, astr());
@@ -88,7 +88,7 @@ void collect(current: (Pattern) `[ <{Pattern ","}* elements0> ]`, Collector c){
 // ---- typed variable pattern
             
 void collect(current: (Pattern) `<Type tp> <Name name>`, Collector c){
-    uname = unescape("<name>");
+    uname = prettyPrintName(name);
     if(tp is function) c.enterScope(current);
         collect(tp, c);
     if(tp is function) c.leaveScope(current);
@@ -118,14 +118,14 @@ void collect(current: (Pattern) `<Type tp> <Name name>`, Collector c){
                 }
             }
        }
-       c.define(unescape("<name>"), formalOrPatternFormal(c), name, defType(tp));
+       c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType(tp));
     } else {
        c.fact(name, tp);
     }
 }
 
 void collectAsVarArg(current: (Pattern) `<Type tp> <Name name>`, Collector c){
-    uname = unescape("<name>");
+    uname = prettyPrintName(name);
     
     if(!isWildCard(uname)){
        if(inPatternNames(uname, c)){
@@ -137,7 +137,7 @@ void collectAsVarArg(current: (Pattern) `<Type tp> <Name name>`, Collector c){
             });
        } else {
           c.push(patternNames, <uname, getLoc(name)>);
-          c.define(unescape("<name>"), formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ 
+          c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ 
             res = alist(s.getType(tp))[alabel=uname];
             return res;
              }));
@@ -166,7 +166,7 @@ void collect(current: (Pattern) `<QualifiedName name>`,  Collector c){
        if(!isEmpty(qualifier)) c.report(error(name, "Qualifier not allowed"));
        if(isTopLevelParameter(c)){
           c.fact(current, avalue(alabel=unescape(prettyPrintBaseName(name))));  
-          c.define(splitQualifiedName(name)<1>, formalId(), name, defLub([], AType(Solver _) { return avalue(alabel=unescape(prettyPrintBaseName(name))); }));
+          c.define(prettyPrintName(name.names[-1]), formalId(), name, defLub([], AType(Solver _) { return avalue(alabel=unescape(prettyPrintBaseName(name))); }));
        } else {
           if(c.isAlreadyDefined(base, name)){
             c.use(name, {variableId(), moduleVariableId(), formalId(), nestedFormalId(), patternVariableId(), constructorId()});
@@ -174,7 +174,7 @@ void collect(current: (Pattern) `<QualifiedName name>`,  Collector c){
           } else {
             tau = c.newTypeVar(name);
             c.fact(name, tau); //<====
-            c.define(splitQualifiedName(name)<1>, formalOrPatternFormal(c), name, defLub([], AType(Solver s) { 
+            c.define(prettyPrintName(name.names[-1]), formalOrPatternFormal(c), name, defLub([], AType(Solver s) { 
                 return s.getType(tau)[alabel=unescape(prettyPrintBaseName(name))]; 
             }));
           }
@@ -215,7 +215,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
     if(argument is typedVariable){
        tp = argument.\type;
        argName = argument.name;
-       uname = unescape("<argName>");
+       uname = prettyPrintName(argName);
        
        if(!isWildCard(uname)){
           if(!inPatternNames(uname, c)){
@@ -231,7 +231,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
             }
           }   
           
-          c.define(unescape("<argName>"), formalOrPatternFormal(c), argName, defType([tp], 
+          c.define(prettyPrintName(argName), formalOrPatternFormal(c), argName, defType([tp], 
                AType(Solver s){ return inSet ? aset(s.getType(tp)) : alist(s.getType(tp)); }));     
        } else {
           c.calculate("typed anonymous variable in splice pattern", argName, [tp], 
@@ -254,7 +254,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
            if(isTopLevelParameter(c)){
               c.fact(current, avalue());
               if(!isEmpty(qualifier)) c.report(error(argName, "Qualifier not allowed"));
-              c.define(splitQualifiedName(argName)<1>, formalId(), argName, defLub([], AType(Solver _) { return avalue(); }));
+              c.define(prettyPrintName(argName.names[-1]), formalId(), argName, defLub([], AType(Solver _) { return avalue(); }));
            } else {
               if(c.isAlreadyDefined("<argName>", argName)) {
                   c.use(argName, {variableId(), moduleVariableId(), formalId(), nestedFormalId(), patternVariableId()});
@@ -263,7 +263,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
                   tau = c.newTypeVar(current); // <== argName;
                   c.fact(current, tau);    // <===
                   if(!isEmpty(qualifier)) c.report(error(argName, "Qualifier not allowed"));
-                  c.define(splitQualifiedName(argName)<1>, formalOrPatternFormal(c), argName, 
+                  c.define(prettyPrintName(argName.names[-1]), formalOrPatternFormal(c), argName, 
                             defLub([], AType(Solver s) { 
                             return inSet ? makeSetType(s.getType(tau)) : makeListType(s.getType(tau));}));
               }
@@ -322,13 +322,13 @@ void collect(current: (Pattern) `<Pattern expression> ( <{Pattern ","}* argument
 // ---- variable becomes pattern
 
 void collect(current: (Pattern) `<Name name> : <Pattern pattern>`, Collector c){
-    uname = unescape("<name>");
+    uname = prettyPrintName(name);
     if(inPatternNames(uname, c)){
         c.useLub(name, variableRoles);
     } else {
         c.push(patternNames, <uname, getLoc(name)>);
         scope = c.getScope();
-        c.define(unescape("<name>"), formalOrPatternFormal(c), name, 
+        c.define(prettyPrintName(name), formalOrPatternFormal(c), name, 
                  defLub([pattern], AType(Solver s) { 
                     try{
                         return s.getType(pattern);
@@ -342,7 +342,7 @@ void collect(current: (Pattern) `<Name name> : <Pattern pattern>`, Collector c){
 // ---- typed variable becomes
 
 void collect(current: (Pattern) `<Type tp> <Name name> : <Pattern pattern>`, Collector c){
-    uname = unescape("<name>");
+    uname = prettyPrintName(name);
     c.fact(current, tp);
     c.fact(name, tp);
     collect(tp, pattern, c);
@@ -357,7 +357,7 @@ void collect(current: (Pattern) `<Type tp> <Name name> : <Pattern pattern>`, Col
                 }
             }
         }   
-        c.define(unescape("<name>"), formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ return s.getType(tp); }));
+        c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ return s.getType(tp); }));
     }
 }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
@@ -50,7 +50,7 @@ void collect(RegExp regExp, Collector c){
     if( (RegExp)`\<<Name name>\>` := regExp){
         c.use(name, variableRoles);
     } else if ((RegExp)`\<<Name name>:<NamedRegExp* regexps>\>` := regExp){
-        c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType(astr()));
+        c.define("<name>", formalOrPatternFormal(c), name, defType(astr()));
         collect(name, regexps, c);
     }
     c.fact(regExp, astr());
@@ -118,7 +118,7 @@ void collect(current: (Pattern) `<Type tp> <Name name>`, Collector c){
                 }
             }
        }
-       c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType(tp));
+       c.define("<name>", formalOrPatternFormal(c), name, defType(tp));
     } else {
        c.fact(name, tp);
     }
@@ -137,7 +137,7 @@ void collectAsVarArg(current: (Pattern) `<Type tp> <Name name>`, Collector c){
             });
        } else {
           c.push(patternNames, <uname, getLoc(name)>);
-          c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ 
+          c.define("<name>", formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ 
             res = alist(s.getType(tp))[alabel=uname];
             return res;
              }));
@@ -166,7 +166,7 @@ void collect(current: (Pattern) `<QualifiedName name>`,  Collector c){
        if(!isEmpty(qualifier)) c.report(error(name, "Qualifier not allowed"));
        if(isTopLevelParameter(c)){
           c.fact(current, avalue(alabel=unescape(prettyPrintBaseName(name))));  
-          c.define(prettyPrintName(name.names[-1]), formalId(), name, defLub([], AType(Solver _) { return avalue(alabel=unescape(prettyPrintBaseName(name))); }));
+          c.define("<name.names[-1]>", formalId(), name, defLub([], AType(Solver _) { return avalue(alabel=unescape(prettyPrintBaseName(name))); }));
        } else {
           if(c.isAlreadyDefined(base, name)){
             c.use(name, {variableId(), moduleVariableId(), formalId(), nestedFormalId(), patternVariableId(), constructorId()});
@@ -174,7 +174,7 @@ void collect(current: (Pattern) `<QualifiedName name>`,  Collector c){
           } else {
             tau = c.newTypeVar(name);
             c.fact(name, tau); //<====
-            c.define(prettyPrintName(name.names[-1]), formalOrPatternFormal(c), name, defLub([], AType(Solver s) { 
+            c.define("<name.names[-1]>", formalOrPatternFormal(c), name, defLub([], AType(Solver s) { 
                 return s.getType(tau)[alabel=unescape(prettyPrintBaseName(name))]; 
             }));
           }
@@ -231,7 +231,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
             }
           }   
           
-          c.define(prettyPrintName(argName), formalOrPatternFormal(c), argName, defType([tp], 
+          c.define("<argName>", formalOrPatternFormal(c), argName, defType([tp], 
                AType(Solver s){ return inSet ? aset(s.getType(tp)) : alist(s.getType(tp)); }));     
        } else {
           c.calculate("typed anonymous variable in splice pattern", argName, [tp], 
@@ -254,7 +254,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
            if(isTopLevelParameter(c)){
               c.fact(current, avalue());
               if(!isEmpty(qualifier)) c.report(error(argName, "Qualifier not allowed"));
-              c.define(prettyPrintName(argName.names[-1]), formalId(), argName, defLub([], AType(Solver _) { return avalue(); }));
+              c.define("<argName.names[-1]>", formalId(), argName, defLub([], AType(Solver _) { return avalue(); }));
            } else {
               if(c.isAlreadyDefined("<argName>", argName)) {
                   c.use(argName, {variableId(), moduleVariableId(), formalId(), nestedFormalId(), patternVariableId()});
@@ -263,7 +263,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
                   tau = c.newTypeVar(current); // <== argName;
                   c.fact(current, tau);    // <===
                   if(!isEmpty(qualifier)) c.report(error(argName, "Qualifier not allowed"));
-                  c.define(prettyPrintName(argName.names[-1]), formalOrPatternFormal(c), argName, 
+                  c.define("<argName.names[-1]>", formalOrPatternFormal(c), argName, 
                             defLub([], AType(Solver s) { 
                             return inSet ? makeSetType(s.getType(tau)) : makeListType(s.getType(tau));}));
               }
@@ -328,7 +328,7 @@ void collect(current: (Pattern) `<Name name> : <Pattern pattern>`, Collector c){
     } else {
         c.push(patternNames, <uname, getLoc(name)>);
         scope = c.getScope();
-        c.define(prettyPrintName(name), formalOrPatternFormal(c), name, 
+        c.define("<name>", formalOrPatternFormal(c), name, 
                  defLub([pattern], AType(Solver s) { 
                     try{
                         return s.getType(pattern);
@@ -357,7 +357,7 @@ void collect(current: (Pattern) `<Type tp> <Name name> : <Pattern pattern>`, Col
                 }
             }
         }   
-        c.define(prettyPrintName(name), formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ return s.getType(tp); }));
+        c.define("<name>", formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ return s.getType(tp); }));
     }
 }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectStatement.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectStatement.rsc
@@ -293,7 +293,7 @@ void collect(current: (Statement) `<Label label> while( <{Expression ","}+ condi
         loopName = "";
         if(label is \default){
             loopName = prettyPrintName(label.name);
-            c.define(loopName, labelId(), label.name, defType(avoid()));
+            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
         }
         c.setScopeInfo(c.getScope(), loopScope(), loopInfo(loopName, [])); // record appends in body, initially []
         condList = [cond | Expression cond <- conditions];
@@ -339,7 +339,7 @@ void collect(current: (Statement) `<Label label> do <Statement body> while ( <Ex
         loopName = "";
         if(label is \default){
             loopName = prettyPrintName(label.name);
-            c.define(loopName, labelId(), label.name, defType(avoid()));
+            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
         }
         c.setScopeInfo(c.getScope(), loopScope(), loopInfo(loopName, [])); // appends in body
         c.require("do statement", current, [body, condition], void (Solver s){ checkConditions([condition], s); });
@@ -361,7 +361,7 @@ void collect(current: (Statement) `<Label label> for( <{Expression ","}+ conditi
         loopName = "";
         if(label is \default){
             loopName = prettyPrintName(label.name);
-            c.define(loopName, labelId(), label.name, defType(avoid()));
+            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
         }
         c.setScopeInfo(c.getScope(), loopScope(), loopInfo(loopName, [])); // appends in body
         condList = [cond | Expression cond <- conditions];
@@ -715,7 +715,7 @@ private void checkAssignment(Statement current, (Assignable) `<QualifiedName nam
             if(c.isAlreadyDefined("<name>", name)){
                 c.use(name, variableRoles);
             } else {
-                c.define(base, variableId(), name, defLub([statement],
+                c.define(splitQualifiedName(name)<1>, variableId(), name, defLub([statement],
                     AType(Solver s){
                         // TODO: this seemingly redundant call is needed; suspicion: the interpreter does not
                         // handle the combination of return and possible exception thrown by s.getType properly
@@ -728,7 +728,7 @@ private void checkAssignment(Statement current, (Assignable) `<QualifiedName nam
              if(c.isAlreadyDefined("<name>", name)){
                 c.use(name, variableRoles);
             } else {
-                c.define(base, variableId(), name, defLub([statement, name],  AType(Solver s){
+                c.define(splitQualifiedName(name)<1>, variableId(), name, defLub([statement, name],  AType(Solver s){
                     return computeAssignmentRhsType(statement, s.getType(name), operator, s.getType(statement), s);
                 }));
             }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectStatement.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectStatement.rsc
@@ -87,7 +87,7 @@ void collect(current: (Statement) `<Label label> <Visit vst>`, Collector c){
         scope = c.getScope();
         c.setScopeInfo(scope, visitOrSwitchScope(), visitOrSwitchInfo(vst.subject, true));
         if(label is \default){
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
         }
         c.require("non-void", vst.subject, [], makeNonVoidRequirement(vst.subject, "Subject of visit"));
         c.fact(current, vst.subject);
@@ -453,7 +453,7 @@ void collect(current:(Statement) `continue <Target target>;`, Collector c){
 void collect(current: (Statement) `<Label label> if( <{Expression ","}+ conditions> ) <Statement thenPart>`,  Collector c){
     c.enterCompositeScope([conditions, thenPart]); // thenPart may refer to variables defined in conditions
         if(label is \default){
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
         }
         condList = [cond | Expression cond <- conditions];
         c.fact(current, avalue());
@@ -605,7 +605,7 @@ void collect(current: (Catch) `catch <Pattern pattern>: <Statement body>`, Colle
 void collect(current: (Statement) `<Label label> { <Statement+ statements> }`, Collector c){
     c.enterScope(current);
         if(label is \default){
-           c.define("<label.name>", labelId(), label.name, defType(avoid()));
+           c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
         }
         stats = [ s | Statement s <- statements ];
         c.calculate("non-empty block statement", current, [stats[-1]],  AType(Solver s) { return s.getType(stats[-1]); } );
@@ -715,7 +715,7 @@ private void checkAssignment(Statement current, (Assignable) `<QualifiedName nam
             if(c.isAlreadyDefined("<name>", name)){
                 c.use(name, variableRoles);
             } else {
-                c.define(splitQualifiedName(name)<1>, variableId(), name, defLub([statement],
+                c.define(prettyPrintName(name.names[-1]), variableId(), name, defLub([statement],
                     AType(Solver s){
                         // TODO: this seemingly redundant call is needed; suspicion: the interpreter does not
                         // handle the combination of return and possible exception thrown by s.getType properly
@@ -728,7 +728,7 @@ private void checkAssignment(Statement current, (Assignable) `<QualifiedName nam
              if(c.isAlreadyDefined("<name>", name)){
                 c.use(name, variableRoles);
             } else {
-                c.define(splitQualifiedName(name)<1>, variableId(), name, defLub([statement, name],  AType(Solver s){
+                c.define(prettyPrintName(name.names[-1]), variableId(), name, defLub([statement, name],  AType(Solver s){
                     return computeAssignmentRhsType(statement, s.getType(name), operator, s.getType(statement), s);
                 }));
             }
@@ -1042,7 +1042,7 @@ private AType computeDefaultAssignableType(Statement current, AType receiverType
     return receiverType;
 }
 
-set[str] getNames(Statement s) = {"<nm>" | /QualifiedName nm := s};
+set[str] getNames(Statement s) = {prettyPrintName(nm) | /QualifiedName nm := s};
 
 private void checkAssignment(Statement current, constructor: (Assignable) `<Name name> ( <{Assignable ","}+ arguments> )` , str operator, Statement rhs, Collector c){
     c.report(error(current, "Constructor assignable is not supported by the compiler"));
@@ -1092,11 +1092,11 @@ private void checkAssignment(Statement current, receiver: (Assignable) `\< <{Ass
    }
 
    names = getReceiver(receiver, c);
-   flatNames = ["<nm>" | nm <- names];
+   flatNames = [prettyPrintName(nm) | nm <- names];
    elms = [elm | elm <- elements];
    namesInRhs = getNames(rhs);
    taus = [c.newTypeVar(nm) | nm <- names];
-   for(int i <- index(names), flatNames[i] notin namesInRhs){c.define("<names[i]>", variableId(), names[i], defLub([rhs], makeDef(i)));}
+   for(int i <- index(names), flatNames[i] notin namesInRhs){c.define(prettyPrintName(names[i]), variableId(), names[i], defLub([rhs], makeDef(i)));}
 
    for(name <- names) c.useLub(name, variableRoles);
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectStatement.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectStatement.rsc
@@ -87,7 +87,7 @@ void collect(current: (Statement) `<Label label> <Visit vst>`, Collector c){
         scope = c.getScope();
         c.setScopeInfo(scope, visitOrSwitchScope(), visitOrSwitchInfo(vst.subject, true));
         if(label is \default){
-            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
+            c.define("<label.name>", labelId(), label.name, defType(avoid()));
         }
         c.require("non-void", vst.subject, [], makeNonVoidRequirement(vst.subject, "Subject of visit"));
         c.fact(current, vst.subject);
@@ -115,7 +115,7 @@ void collect(current: (Expression) `<Label label> <Visit vst>`, Collector c){
         scope = c.getScope();
         c.setScopeInfo(scope, visitOrSwitchScope(), visitOrSwitchInfo(vst.subject, true));
         if(label is \default){
-            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
+            c.define("<label.name>", labelId(), label.name, defType(avoid()));
         }
         c.calculate("visit", current, [vst.subject],
             AType(Solver s){
@@ -293,7 +293,7 @@ void collect(current: (Statement) `<Label label> while( <{Expression ","}+ condi
         loopName = "";
         if(label is \default){
             loopName = prettyPrintName(label.name);
-            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
+            c.define("<label.name>", labelId(), label.name, defType(avoid()));
         }
         c.setScopeInfo(c.getScope(), loopScope(), loopInfo(loopName, [])); // record appends in body, initially []
         condList = [cond | Expression cond <- conditions];
@@ -339,7 +339,7 @@ void collect(current: (Statement) `<Label label> do <Statement body> while ( <Ex
         loopName = "";
         if(label is \default){
             loopName = prettyPrintName(label.name);
-            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
+            c.define("<label.name>", labelId(), label.name, defType(avoid()));
         }
         c.setScopeInfo(c.getScope(), loopScope(), loopInfo(loopName, [])); // appends in body
         c.require("do statement", current, [body, condition], void (Solver s){ checkConditions([condition], s); });
@@ -361,7 +361,7 @@ void collect(current: (Statement) `<Label label> for( <{Expression ","}+ conditi
         loopName = "";
         if(label is \default){
             loopName = prettyPrintName(label.name);
-            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
+            c.define("<label.name>", labelId(), label.name, defType(avoid()));
         }
         c.setScopeInfo(c.getScope(), loopScope(), loopInfo(loopName, [])); // appends in body
         condList = [cond | Expression cond <- conditions];
@@ -453,7 +453,7 @@ void collect(current:(Statement) `continue <Target target>;`, Collector c){
 void collect(current: (Statement) `<Label label> if( <{Expression ","}+ conditions> ) <Statement thenPart>`,  Collector c){
     c.enterCompositeScope([conditions, thenPart]); // thenPart may refer to variables defined in conditions
         if(label is \default){
-            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
+            c.define("<label.name>", labelId(), label.name, defType(avoid()));
         }
         condList = [cond | Expression cond <- conditions];
         c.fact(current, avalue());
@@ -472,7 +472,7 @@ void collect(current: (Statement) `<Label label> if( <{Expression ","}+ conditio
 void collect(current: (Statement) `<Label label> if( <{Expression ","}+ conditions> ) <Statement thenPart> else <Statement elsePart>`,  Collector c){
     c.enterCompositeScope([conditions, thenPart]);   // thenPart may refer to variables defined in conditions; elsePart may not
         if(label is \default){
-            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
+            c.define("<label.name>", labelId(), label.name, defType(avoid()));
         }
         condList = [cond | cond <- conditions];
 
@@ -495,7 +495,7 @@ void collect(current: (Statement) `<Label label> if( <{Expression ","}+ conditio
 void collect(current: (Statement) `<Label label> switch ( <Expression e> ) { <Case+ cases> }`, Collector c){
     c.enterScope(current);
         if(label is \default){
-            c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
+            c.define("<label.name>", labelId(), label.name, defType(avoid()));
         }
         scope = c.getScope();
         c.setScopeInfo(scope, visitOrSwitchScope(), visitOrSwitchInfo(e, false));
@@ -605,7 +605,7 @@ void collect(current: (Catch) `catch <Pattern pattern>: <Statement body>`, Colle
 void collect(current: (Statement) `<Label label> { <Statement+ statements> }`, Collector c){
     c.enterScope(current);
         if(label is \default){
-           c.define(prettyPrintName(label.name), labelId(), label.name, defType(avoid()));
+           c.define("<label.name>", labelId(), label.name, defType(avoid()));
         }
         stats = [ s | Statement s <- statements ];
         c.calculate("non-empty block statement", current, [stats[-1]],  AType(Solver s) { return s.getType(stats[-1]); } );
@@ -715,7 +715,7 @@ private void checkAssignment(Statement current, (Assignable) `<QualifiedName nam
             if(c.isAlreadyDefined("<name>", name)){
                 c.use(name, variableRoles);
             } else {
-                c.define(prettyPrintName(name.names[-1]), variableId(), name, defLub([statement],
+                c.define("<name.names[-1]>", variableId(), name, defLub([statement],
                     AType(Solver s){
                         // TODO: this seemingly redundant call is needed; suspicion: the interpreter does not
                         // handle the combination of return and possible exception thrown by s.getType properly
@@ -728,7 +728,7 @@ private void checkAssignment(Statement current, (Assignable) `<QualifiedName nam
              if(c.isAlreadyDefined("<name>", name)){
                 c.use(name, variableRoles);
             } else {
-                c.define(prettyPrintName(name.names[-1]), variableId(), name, defLub([statement, name],  AType(Solver s){
+                c.define("<name.names[-1]>", variableId(), name, defLub([statement, name],  AType(Solver s){
                     return computeAssignmentRhsType(statement, s.getType(name), operator, s.getType(statement), s);
                 }));
             }
@@ -1096,7 +1096,7 @@ private void checkAssignment(Statement current, receiver: (Assignable) `\< <{Ass
    elms = [elm | elm <- elements];
    namesInRhs = getNames(rhs);
    taus = [c.newTypeVar(nm) | nm <- names];
-   for(int i <- index(names), flatNames[i] notin namesInRhs){c.define(prettyPrintName(names[i]), variableId(), names[i], defLub([rhs], makeDef(i)));}
+   for(int i <- index(names), flatNames[i] notin namesInRhs){c.define("<names[i]>", variableId(), names[i], defLub([rhs], makeDef(i)));}
 
    for(name <- names) c.useLub(name, variableRoles);
 
@@ -1202,7 +1202,7 @@ void collect(current: (Statement) `<Type varType> <{Variable ","}+ variables>;`,
     scope = c.getScope();
     c.enterScope(current); // wrap in extra scope to isolate variables declared in complex (function) types
         for(var <- variables){
-            c.defineInScope(scope, prettyPrintName(var.name), variableId(), var.name, defType([varType], makeGetSyntaxType(varType)));
+            c.defineInScope(scope, "<var.name>", variableId(), var.name, defType([varType], makeGetSyntaxType(varType)));
 
             if(var is initialized){
                 initial = var.initial;

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
@@ -181,7 +181,7 @@ void collect(current: (Prod) `<ProdModifier* modifiers> <Name name> : <Sym* syms
         qualName = "<SyntaxDefinition sd := adt ? sd.defined.nonterminal : "???">_<uname>";
 
          // Define the constructor
-        c.defineInScope(adtParentScope, prettyPrintName(name), constructorId(), name, defType([current],
+        c.defineInScope(adtParentScope, "<name>", constructorId(), name, defType([current],
             AType(Solver s){
                 ptype = s.getType(current);
                 if(aprod(AProduction cprod) := ptype){

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
@@ -82,7 +82,7 @@ void declareSyntax(SyntaxDefinition current, SyntaxRole syntaxRole, IdRole idRol
         syndefCounter += 1;
 
         // Define the syntax symbol itself and all labelled alternatives as constructors
-        c.define(adtName, idRole, current, dt);
+        c.define(nonterminalType.adtName, idRole, current, dt);
 
         adtParentScope = c.getScope();
         c.enterScope(current);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
@@ -160,13 +160,15 @@ void collect(current: (Prod) `<ProdModifier* modifiers> <Name name> : <Sym* syms
     symbols = [sym | sym <- syms, !(sym is empty)];
 
     if(<Tree adt, _, _, loc adtParentScope> := c.top(currentAdt)){
+        uname = prettyPrintName(name);
+
         // Compute the production type
         c.calculate("named production", current, adt + symbols,
             AType(Solver s) {
                 try {
                     return s.getType(current);
                  } catch _: {
-                    res = aprod(computeProd(current, unescape("<name>"), s.getType(adt), modifiers, symbols, s) /* no labels on assoc groups [label=unescape("<name>")]*/);
+                    res = aprod(computeProd(current, uname, s.getType(adt), modifiers, symbols, s) /* no labels on assoc groups [label=unescape("<name>")]*/);
                     return res;
                  }
             });
@@ -176,10 +178,10 @@ void collect(current: (Prod) `<ProdModifier* modifiers> <Name name> : <Sym* syms
         } else {
             println("*** Collect: <adt> is not a SyntaxDefinition ***");
         }
-        qualName = "<SyntaxDefinition sd := adt ? sd.defined.nonterminal : "???">_<unescape("<name>")>";
+        qualName = "<SyntaxDefinition sd := adt ? sd.defined.nonterminal : "???">_<uname>";
 
          // Define the constructor
-        c.defineInScope(adtParentScope, unescape("<name>"), constructorId(), name, defType([current],
+        c.defineInScope(adtParentScope, prettyPrintName(name), constructorId(), name, defType([current],
             AType(Solver s){
                 ptype = s.getType(current);
                 if(aprod(AProduction cprod) := ptype){
@@ -187,7 +189,7 @@ void collect(current: (Prod) `<ProdModifier* modifiers> <Name name> : <Sym* syms
                         s.fact(syms, ptype);
                     }
                     def = cprod.def;
-                    fields = [ ((inLexicalAdt && isLexicalAType(stp)) ? astr() : stp)[alabel=tsym.alabel?"anonymous<unescape("<name>")>"] 
+                    fields = [ ((inLexicalAdt && isLexicalAType(stp)) ? astr() : stp)[alabel=tsym.alabel?"anonymous<uname>"] 
                              | sym <- symbols,
                                !isTerminalSym(sym),
                                tsym := s.getType(sym),
@@ -197,11 +199,11 @@ void collect(current: (Prod) `<ProdModifier* modifiers> <Name name> : <Sym* syms
 
                     def = \start(sdef) := def ? sdef : def;
                     //def = \start(sdef) := def ? sdef : unset(def, "alabel");
-                    return acons(def, fields, [], alabel=unescape("<name>"));
+                    return acons(def, fields, [], alabel=uname);
                  } else throw "Unexpected type of production: <ptype>";
             })[md5=normalizedMD5Hash(adt, current)]);
         beginUseTypeParameters(c,closed=true);
-            c.push(currentAlternative, <adt, "<name>", syms>);
+            c.push(currentAlternative, <adt, uname, syms>);
                 collect(symbols, c);
             c.pop(currentAlternative);
         endUseTypeParameters(c);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectType.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectType.rsc
@@ -518,7 +518,7 @@ void collect(current:(Sym) `& <Nonterminal n>`, Collector c){
             c.use(n, {typeVarId() });
             //println("Use <pname> at <current@\loc>");
         } else {
-            c.define(prettyPrintName("<n>"), typeVarId(), n, defType(aparameter(pname,treeType, closed=closed)));
+            c.define("<n>", typeVarId(), n, defType(aparameter(pname,treeType, closed=closed)));
             //println("Define <pname> at <current@\loc>");
         }
         c.fact(current, n);
@@ -572,7 +572,7 @@ void collect(current:(Sym) `<Sym symbol> <NonterminalLabel n>`, Collector c){
     }
 
     // TODO require symbol is nonterminal
-    c.define(prettyPrintName("<n>"), fieldId(), n, defType([symbol],
+    c.define("<n>", fieldId(), n, defType([symbol],
         AType(Solver s){
             res = s.getType(symbol)[alabel=un];
           return res;
@@ -812,7 +812,7 @@ void collect(current:(TypeVar) `& <Name n>`, Collector c){
             } else {
                 throw "collect TypeVar: currentAdt not found";
             }
-            c.define(prettyPrintName(n), typeVarId(), n, defType(aparameter(pname, bound, closed=closed)));
+            c.define("<n>", typeVarId(), n, defType(aparameter(pname, bound, closed=closed)));
         }
         c.calculate("type parameter without bound", current, [n], AType (Solver s) { return s.getType(n)[closed=closed]; });
         return;
@@ -850,7 +850,7 @@ void collect(current: (TypeVar) `& <Name n> \<: <Type tp>`, Collector c){
             c.use(n, {typeVarId() });
             //if(debugTP)println("Use <pname> at <current@\loc>");
         } else {
-            c.define(prettyPrintName(n), typeVarId(), n, defTypeCall([getLoc(tp)], AType(Solver s) {return aparameter(pname,s.getType(tp), closed=closed); }));
+            c.define("<n>", typeVarId(), n, defTypeCall([getLoc(tp)], AType(Solver s) {return aparameter(pname,s.getType(tp), closed=closed); }));
             //if(debugTP)println("Define <pname> at <current@\loc>");
         }
         c.fact(current, n);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectType.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectType.rsc
@@ -563,7 +563,7 @@ void collect(current:(Sym) `start [ <Nonterminal n> ]`, Collector c){
 }
 
 void collect(current:(Sym) `<Sym symbol> <NonterminalLabel n>`, Collector c){
-    un = unescape("<n>");
+    un = prettyPrintName("<n>");
     md5Contrib = [];
     if(!isEmpty(c.getStack(currentAlternative)) && <SyntaxDefinition adt, str cname, syms> := c.top(currentAlternative)){
         md5Contrib += [adt.defined, cname, syms];
@@ -572,7 +572,7 @@ void collect(current:(Sym) `<Sym symbol> <NonterminalLabel n>`, Collector c){
     }
 
     // TODO require symbol is nonterminal
-    c.define(unescape("<n>"), fieldId(), n, defType([symbol],
+    c.define(prettyPrintName("<n>"), fieldId(), n, defType([symbol],
         AType(Solver s){
             res = s.getType(symbol)[alabel=un];
           return res;

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectType.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectType.rsc
@@ -518,7 +518,7 @@ void collect(current:(Sym) `& <Nonterminal n>`, Collector c){
             c.use(n, {typeVarId() });
             //println("Use <pname> at <current@\loc>");
         } else {
-            c.define(pname, typeVarId(), n, defType(aparameter(pname,treeType, closed=closed)));
+            c.define(prettyPrintName("<n>"), typeVarId(), n, defType(aparameter(pname,treeType, closed=closed)));
             //println("Define <pname> at <current@\loc>");
         }
         c.fact(current, n);
@@ -572,7 +572,7 @@ void collect(current:(Sym) `<Sym symbol> <NonterminalLabel n>`, Collector c){
     }
 
     // TODO require symbol is nonterminal
-    c.define(un, fieldId(), n, defType([symbol],
+    c.define(unescape("<n>"), fieldId(), n, defType([symbol],
         AType(Solver s){
             res = s.getType(symbol)[alabel=un];
           return res;
@@ -812,7 +812,7 @@ void collect(current:(TypeVar) `& <Name n>`, Collector c){
             } else {
                 throw "collect TypeVar: currentAdt not found";
             }
-            c.define(pname, typeVarId(), n, defType(aparameter(pname, bound, closed=closed)));
+            c.define(prettyPrintName(n), typeVarId(), n, defType(aparameter(pname, bound, closed=closed)));
         }
         c.calculate("type parameter without bound", current, [n], AType (Solver s) { return s.getType(n)[closed=closed]; });
         return;
@@ -850,7 +850,7 @@ void collect(current: (TypeVar) `& <Name n> \<: <Type tp>`, Collector c){
             c.use(n, {typeVarId() });
             //if(debugTP)println("Use <pname> at <current@\loc>");
         } else {
-            c.define(pname, typeVarId(), n, defTypeCall([getLoc(tp)], AType(Solver s) {return aparameter(pname,s.getType(tp), closed=closed); }));
+            c.define(prettyPrintName(n), typeVarId(), n, defTypeCall([getLoc(tp)], AType(Solver s) {return aparameter(pname,s.getType(tp), closed=closed); }));
             //if(debugTP)println("Define <pname> at <current@\loc>");
         }
         c.fact(current, n);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/NameUtils.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/NameUtils.rsc
@@ -50,7 +50,9 @@ public str prettyPrintName(Name nm){
 }
 
 public str prettyPrintName(str nm){
-    return replaceFirst(nm, "\\", "");
+    // In general, `nm` could be the string representation of a qualified name,
+    // which may contain multiple backslashes, all of which need to be removed.
+    return replaceAll(nm, "\\", "");
 }
 
 public str prettyPrintBaseName(QualifiedName qn){

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/RascalConfig.rsc
@@ -56,6 +56,9 @@ import String;
 
 str parserPackage = "org.rascalmpl.core.library.lang.rascalcore.grammar.tests.generated_parsers";
 
+// Define the normalization function to be used in `define` and `defineInScope`
+str rascalNormalizeName(str name) = prettyPrintName(name);
+
 //Define the name overloading that is allowed
 bool rascalMayOverload(set[loc] defs, map[loc, Define] defines){
     set[IdRole] roles = { defines[def].idRole | def <- defs };
@@ -644,6 +647,8 @@ RascalCompilerConfig rascalCompilerConfig(PathConfig pcfg,
         isAcceptableSimple            = rascalIsAcceptableSimple,
         isAcceptableQualified         = rascalIsAcceptableQualified,
         isAcceptablePath              = rascalIsAcceptablePath,
+
+        normalizeName                 = rascalNormalizeName,
 
         mayOverload                   = rascalMayOverload,
 


### PR DESCRIPTION
### Summary

This PR is part of a small project to make use-defs more precise. In particular, this PR prepares the typechecker by making the computation (of names) of defs uniform across all calls of `define`/`defineInScope`.

### Code changes

Primary changes:
  - Each call of `define`/`defineInScope` is now performed with a name that **hasn't** been de-escaped yet.
  - De-escaping of names is now the responsibility of `define`/`defineInScope` by configuring the existing `normalizeName` keyword parameter of Typepal with a pretty-print function.

Secondary changes:
  - De-escaping in the direct vicinity of call sites of `define`/`defineInScope` was added in a few places to make sure the names before and after those calls are consistently de-escaped, too.
  - Calls of `unescape` were replaced with `prettyPrintName`.

Most calls of `define` now look like this: `define("<x>", ...)`, where `x` is a `Name`. In the next PR (after changes to Typepal), each such call will be changed to `define(x, ...)`. The string representation of `x` is then computed inside `define`. (Same for `defineInScope`.)

### Behavior changes ⚠️

Before this PR, calls of `define` were performed with a de-escaped name. As the default implementation of `normalizeName` acts as the identity function for de-escaped names, `orgName` and `nname` would be the same on [these lines](https://github.com/usethesource/typepal/blob/7e9dc12dded978ef431d418ed83b862809c5cdd3/src/analysis/typepal/Collector.rsc#L270-L271) inside `define`. (Same for `defineInScope`.)

After this PR, this is no longer the case: `orgName` will be the string representation of the `Name` tree, while `nname` is its de-escaped version. My impression is that this might actually be the intended semantics of `orgName`? Regardless, I have tried to check the usage sites of `orgName`, and I think this change is fine, but I might have missed something.