### PR TITLE
Fix/wrong module name

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
@@ -99,7 +99,22 @@ void collect(Module current, Collector c){
         collect(header, body, c);
     c.leaveScope(current);
 }
+// CodeActions for incorrect module name
 
+list[CodeAction] moduleNameProposal(QualifiedName moduleName, str proposedName)
+    =
+    [ action(
+        title="Replace by `<proposedName>`", 
+        edits=[changed([replace(moduleName.src, proposedName)])]
+      )
+    ];
+
+FailMessage moduleNameMessage(loc mloc, QualifiedName qualifiedModuleName, str mname, PathConfig pcfg){
+    proposal = getRascalModuleName(mloc, pcfg);
+    msg = error(qualifiedModuleName, "Module name `%v` is incompatible with its file location: %v", mname, mloc.top);
+    msg.fixes = moduleNameProposal(qualifiedModuleName, proposal);
+    return msg;
+}
 void checkModuleName(loc mloc, QualifiedName qualifiedModuleName, Collector c){
     pcfgVal = c.getStack(key_pathconfig);
     if([PathConfig pcfg] := pcfgVal){
@@ -107,10 +122,10 @@ void checkModuleName(loc mloc, QualifiedName qualifiedModuleName, Collector c){
         try {
             mloc1 = getRascalModuleLocation(mname, pcfg);
             if(mloc.scheme != mloc1.scheme || mloc.authority != mloc1.authority || mloc.path != mloc1.path){
-                c.report(error(qualifiedModuleName, "Module name `%v` is incompatible with its file location %v", mname, mloc));
+                c.report(moduleNameMessage(mloc1, qualifiedModuleName, mname, pcfg));
             }
-        } catch str e: {
-            c.report(error(qualifiedModuleName, "Module name `%v` is incompatible with its file location: %v", mname, e));
+        } catch error(e, l, causes=causes): {
+            c.report(moduleNameMessage(mloc, qualifiedModuleName, mname, pcfg));
         }
     } else if(isEmpty(pcfgVal)){
         return;

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
@@ -110,9 +110,11 @@ list[CodeAction] moduleNameProposal(QualifiedName moduleName, str proposedName)
     ];
 
 FailMessage moduleNameMessage(loc mloc, QualifiedName qualifiedModuleName, str mname, PathConfig pcfg){
-    proposal = getRascalModuleName(mloc, pcfg);
     msg = error(qualifiedModuleName, "Module name `%v` is incompatible with its file location: %v", mname, mloc.top);
-    msg.fixes = moduleNameProposal(qualifiedModuleName, proposal);
+    try {
+        proposal = getRascalModuleName(mloc, pcfg);
+        msg.fixes = moduleNameProposal(qualifiedModuleName, proposal);
+    } catch _: /* ignore any exceptions */;
     return msg;
 }
 void checkModuleName(loc mloc, QualifiedName qualifiedModuleName, Collector c){

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/DeclarationTCTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/DeclarationTCTests.rsc
@@ -47,6 +47,32 @@ test bool shadowingDeclaration2() = checkOK("N = 1; {int N = 2; N == 2;}; N == 1
 
 test bool shadowingDeclaration3() = checkOK("int N = 3; int N := 3;");
 
+// Module name in module declaration
+test bool moduleNameAndPlaceOK1(){
+	loc mloc = writeModule("module MMM");
+	return checkModuleOK(mloc);
+}
+
+test bool moduleNameAndPlaceOK2(){
+	loc mloc = writeModule("module testing::MMM");
+	return checkModuleOK(mloc);
+}
+
+test bool moduleNameNotOK1(){
+	loc mloc = writeModule("module MMM", altName="M");
+	return unexpectedDeclarationInModule(mloc);
+}
+
+test bool moduleNameNotOK2(){
+	loc mloc = writeModule("module MMM", altPath="a/b/c");
+	return unexpectedDeclarationInModule(mloc);
+}
+
+test bool moduleNameNotOK3(){
+	loc mloc = writeModule("module MMM", altName="M", altPath="a/b/c");
+	return unexpectedDeclarationInModule(mloc);
+}
+
 // Variable declaration in imported module
 
 test bool PrivateVarDeclarationNotVisible(){ 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/StaticTestingUtils.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/StaticTestingUtils.rsc
@@ -67,7 +67,7 @@ bool matches(str subject, str pat){
 
 tuple[str,str] extractModuleNameAndBody(str moduleText){
 	txt = trim(moduleText);
-	if(/module\s*<nm:[A-Z][A-Za-z0-9:]*>\s*<body:.*$>/s := txt){
+	if(/module\s*<nm:[A-Za-z0-9:]*>\s*<body:.*$>/s := txt){
 		return <nm, body>;
 	}
 	throw "Cannot extract module name from <moduleText>";
@@ -88,9 +88,13 @@ void clearMemory() {
 str cleanName(str name)
 	= name[0] == "\\" ? name[1..] : name;
 
-loc writeModule(str moduleText){
+loc writeModule(str moduleText, str altName="", str altPath=""){
 	<mname, mbody> = extractModuleNameAndBody(moduleText);
-    mloc = testModulesRoot +  "<cleanName(mname)>.rsc";
+	if(altName?){
+		mname = altName;
+	}
+	mname = replaceAll(mname, "::", "/");
+    mloc = testModulesRoot +  altPath + "<cleanName(mname)>.rsc";
     writeFile(mloc, moduleText);
     return mloc;
 }
@@ -475,7 +479,8 @@ list[str] unexpectedDeclarationMsgs = [
 	"Non-well-formed _ type, labels must be distinct",
 	"Self import not allowed",
 	"Extend cycle not allowed",
-	"Mixed import/extend cycle not allowed"
+	"Mixed import/extend cycle not allowed",
+	"Module name _ is incompatible with its file location"
 ];
 
 bool unexpectedDeclarationInModule(str moduleText, PathConfig pathConfig = getDefaultTestingPathConfig())


### PR DESCRIPTION
The existing handling of incorrect module names was broken and has been fixed.

In addition a fix is generated (based on the file location) to replace the erroneous module name

Fixes #2773