### PR TITLE
Updating dependencies to may 2026 released versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,14 +18,14 @@ jobs:
     if: ${{ !(github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[maven-release-plugin]')) }}
     runs-on: ubicloud-standard-4
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # - uses: s4u/maven-settings-action@v3.1.0
       #   if: ${{ env.IS_OWN_PR != '' }}
       #   with:
       #     servers: '[{"id": "usethesource-gh", "username":"github", "password": "${{ secrets.MAVEN_MIRROR_PASSWORD }}"}]'
       #     mirrors: '[{"id": "usethesource-gh", "name": "uts mirror", "mirrorOf": "usethesource", "url": "${{ secrets.MAVEN_MIRROR_URL }}"}]'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: 'temurin'
@@ -34,7 +34,7 @@ jobs:
       - name: Run Tests
         run: mvn -B -Drascal.compile.skip -Drascal.tutor.skip -Drascal.test.memory=14 test
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         continue-on-error: true # sometimes this one fails, that shouldn't stop a build
         with:
           fail_ci_if_error: false
@@ -44,7 +44,7 @@ jobs:
       - name: Publish Test Report on github action
         if: ${{ always() && github.event_name != 'pull_request' }} # to bad this doesn't work nicely with external pull requests
         continue-on-error: true # sometimes this one fails, that shouldn't stop a build
-        uses: scacap/action-surefire-report@v1
+        uses: ScalableCapital/action-surefire-report@v2
         with:
           check_name: "Test Report - ${{ runner.os }}"
 
@@ -71,9 +71,9 @@ jobs:
       #     servers: '[{"id": "usethesource-gh", "username":"github", "password": "${{ secrets.MAVEN_MIRROR_PASSWORD }}"}]'
       #     mirrors: '[{"id": "usethesource-gh", "name": "uts mirror", "mirrorOf": "usethesource", "url": "${{ secrets.MAVEN_MIRROR_URL }}"}]'
       
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: 'temurin'
@@ -102,7 +102,7 @@ jobs:
 
       - name: Making sure test have succeeded in the parallel jobs
         if: startsWith(github.ref, 'refs/tags/')
-        uses: yogeshlonkar/wait-for-jobs@v0
+        uses: yogeshlonkar/wait-for-jobs@v1
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           jobs: |
@@ -123,7 +123,7 @@ jobs:
           ssh-private-key: ${{ secrets.RELEASE_SSH_PRIVATE_KEY }}
 
       - name: Prepare Draft Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true
@@ -158,14 +158,14 @@ jobs:
     env:
       MAVEN_OPTS: "-Xmx512M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # - uses: s4u/maven-settings-action@v3.1.0
       #   if: ${{ env.IS_OWN_PR != '' }}
       #   with:
       #     servers: '[{"id": "usethesource-gh", "username":"github", "password": "${{ secrets.MAVEN_MIRROR_PASSWORD }}"}]'
       #     mirrors: '[{"id": "usethesource-gh", "name": "uts mirror", "mirrorOf": "usethesource", "url": "${{ secrets.MAVEN_MIRROR_URL }}"}]'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: 'temurin'
@@ -176,7 +176,7 @@ jobs:
         # single quotes to help windows deal with argument splitting
         run: mvn -B '-Drascal.compile.skip' '-Drascal.tutor.skip' '-Drascal.test.memory=2' test
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         continue-on-error: true # sometimes this one fails, that shouldn't stop a build
         with:
           token: e8b4481a-d178-4148-a4ff-502906390512
@@ -184,7 +184,7 @@ jobs:
       - name: Publish Test Report on github action
         if: ${{ always() && github.event_name != 'pull_request' }} # to bad this doesn't work nicely with external pull requests
         continue-on-error: true # sometimes this one fails, that shouldn't stop a build
-        uses: scacap/action-surefire-report@v1
+        uses: ScalableCapital/action-surefire-report@v2
         with:
           check_name: "Test Report - ${{ runner.os }}"
 
@@ -195,14 +195,14 @@ jobs:
     env:
       MAVEN_OPTS: "-Xmx512M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # - uses: s4u/maven-settings-action@v3.1.0
       #   if: ${{ env.IS_OWN_PR != '' }}
       #   with:
       #     servers: '[{"id": "usethesource-gh", "username":"github", "password": "${{ secrets.MAVEN_MIRROR_PASSWORD }}"}]'
       #     mirrors: '[{"id": "usethesource-gh", "name": "uts mirror", "mirrorOf": "usethesource", "url": "${{ secrets.MAVEN_MIRROR_URL }}"}]'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: 'temurin'
@@ -215,7 +215,7 @@ jobs:
       - name: Run Tests
         run: mvn -B -Pcompiler-tests -Drascal.compile.skip -Drascal.tutor.skip -Drascal.test.memory=10 test
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         continue-on-error: true # sometimes this one fails, that shouldn't stop a build
         with:
           fail_ci_if_error: false
@@ -225,7 +225,7 @@ jobs:
       - name: Publish Test Report on github action
         if: ${{ always() && github.event_name != 'pull_request' }} # to bad this doesn't work nicely with external pull requests
         continue-on-error: true # sometimes this one fails, that shouldn't stop a build
-        uses: scacap/action-surefire-report@v1
+        uses: ScalableCapital/action-surefire-report@v2
         with:
           check_name: "Compiler Test Report"
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven-version>3.9.12</maven-version>
+        <maven-version>3.9.16</maven-version>
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>3</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
@@ -487,22 +487,22 @@
         <dependency> <!-- needed by commons-compress for compressed+...://...zst -->
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.5.7-6</version>
+            <version>1.5.7-9</version>
         </dependency>
         <dependency> <!-- needed by commons-compress for compressed+...://...xz -->
             <groupId>org.tukaani</groupId>
             <artifactId>xz</artifactId>
-            <version>1.11</version>
+            <version>1.12</version>
         </dependency>
         <dependency> <!-- used for base32 encoding in IO and String, needed anyway for commons-compress -->
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.20.0</version>
+            <version>1.22.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.13.2</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency> <!-- line reader/completion/history support -->
             <groupId>org.jline</groupId>
@@ -537,12 +537,12 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.21.2</version>
+            <version>1.22.2</version>
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>
@@ -557,7 +557,7 @@
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
-            <version>78.1</version>
+            <version>78.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -588,12 +588,12 @@
         <dependency> <!-- file watch support -->
             <groupId>engineering.swat</groupId>
             <artifactId>java-watch</artifactId>
-            <version>0.9.6</version>
+            <version>0.9.7</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lsp4j</groupId>
             <artifactId>org.eclipse.lsp4j.debug</artifactId>
-            <version>0.24.0</version>
+            <version>1.0.0</version>
         </dependency>
     </dependencies>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <exec.mainClass>org.rascalmpl.shell.RascalShell</exec.mainClass>
         <rascal.test.memory>3</rascal.test.memory>
         <maven.compiler.release>11</maven.compiler.release>
-        <rascal-maven.version>0.30.7</rascal-maven.version>
+        <rascal-maven.version>0.31.0</rascal-maven.version>
         <jline.version>3.29.0</jline.version> <!-- do not upgrade unless https://github.com/jline/jline3/issues/1445 is solved-->
     </properties>
 
@@ -90,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -116,12 +116,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.5.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <compilerArgument>-parameters</compilerArgument> <!-- make sure parameters are compiled by name into the jar -->
                 </configuration>
@@ -211,7 +211,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.0</version>
                 <configuration>
                     <filesets>
                         <fileset>
@@ -228,7 +228,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.6</version>
                 <executions>
                     <execution>
                         <id>default-test</id>
@@ -261,7 +261,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <goals>
@@ -280,7 +280,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -296,7 +296,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.3.1</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <arguments>-Drascal.compile.skip -Drascal.tutor.skip -DskipTests</arguments>
@@ -305,7 +305,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.5.0</version>
+                <version>2.7.1</version>
                 <executions>
                     <execution>
                         <id>download-licenses</id>
@@ -318,7 +318,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.2</version>
                 <dependencies>
                     <dependency> <!-- correctly shade multiple log4j2 depencneis -->
                         <groupId>org.apache.logging.log4j</groupId>
@@ -397,7 +397,7 @@
             <plugin><!-- make sure users are using recent versions of maven -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>


### PR DESCRIPTION
I've updated dependencies where possible.

The only not updated dependency is jline, and this is due to https://github.com/jline/jline3/issues/1445 not fixed completely yet.