### PR TITLE
Implemented capabilities API on VFS

### DIFF
--- a/src/org/rascalmpl/uri/IExternalResolverRegistry.java
+++ b/src/org/rascalmpl/uri/IExternalResolverRegistry.java
@@ -26,8 +26,6 @@
  */
 package org.rascalmpl.uri;
 
-import io.usethesource.vallang.ISourceLocation;
-
 public interface IExternalResolverRegistry extends ISourceLocationInputOutput, ILogicalSourceLocationResolver, ISourceLocationWatcher {
     @Override
     default String scheme() {
@@ -44,8 +42,9 @@ public interface IExternalResolverRegistry extends ISourceLocationInputOutput, I
         return false;
     }
 
-    boolean supportsLogical(ISourceLocation loc);
-    boolean supportsWatch(ISourceLocation loc);
-    boolean supportsGetCharset(ISourceLocation loc);
+    boolean supportsGetCharset(String scheme);
+    boolean supportsInput(String scheme);
+    boolean supportsWatch(String scheme);
     boolean supportsOutput(String scheme);
+    boolean supportsLogical(String scheme);
 }

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -473,7 +473,7 @@ public class URIResolverRegistry {
 					return result;
 				}
 			}
-			if (externalRegistry.supportsInput(scheme)) {
+			if (externalRegistry != null && externalRegistry.supportsInput(scheme)) {
 				return externalRegistry;
 			}
 		}
@@ -506,7 +506,7 @@ public class URIResolverRegistry {
 					return result;
 				}
 			}
-			if (externalRegistry.supportsOutput(scheme)) {
+			if (externalRegistry != null && externalRegistry.supportsOutput(scheme)) {
 				return externalRegistry;
 			}
 		}
@@ -999,7 +999,7 @@ public class URIResolverRegistry {
 		uri = safeResolve(uri);
 		ISourceLocationInput resolver = getInputResolver(uri.getScheme());
 
-		if (resolver == null || (resolver == externalRegistry && !externalRegistry.supportsGetCharset(uri.getScheme()))) {
+		if (resolver == null || (externalRegistry != null && resolver == externalRegistry && !externalRegistry.supportsGetCharset(uri.getScheme()))) {
 			throw new UnsupportedSchemeException(uri.getScheme());
 		}
 

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -142,8 +142,8 @@ public class URIResolverRegistry {
 				registry = new RemoteExternalResolverRegistry(remoteResolverRegistryPort);
 			}
 			this.externalRegistry = registry;
-			if (registry.hasWatchCapability()) {
-				watchers.setExternalRegistry(registry, registry::supportsWatch);
+			if (registry.anyWatchSupported()) {
+				watchers.setExternalRegistry(registry, l -> this.externalRegistry.supportsWatch(l.getScheme()));
 			}
 		}
 	}
@@ -404,10 +404,13 @@ public class URIResolverRegistry {
 			loc = resolveAndFixOffsets(loc, resolver, map.values());
 		}
 		
-		if (externalRegistry != null && externalRegistry.supportsLogical(loc)) {
+		if (externalRegistry != null && original != null) {
 			try {
-				var externalResult = resolveAndFixOffsets(loc == null ? original : loc, externalRegistry, Collections.emptyList());
-				return externalResult == null ? loc : externalResult;
+				var externalResolve = loc == null ? original : loc;
+				if (externalRegistry.supportsLogical(externalResolve.getScheme())) {
+					var externalResult = resolveAndFixOffsets(externalResolve, externalRegistry, Collections.emptyList());
+					return externalResult == null ? loc : externalResult;
+				}
 			} catch (IOException e) {
 				// Ignore remote IO errors
 			}
@@ -470,7 +473,9 @@ public class URIResolverRegistry {
 					return result;
 				}
 			}
-			return externalRegistry;
+			if (externalRegistry.supportsInput(scheme)) {
+				return externalRegistry;
+			}
 		}
 		return result;
 	}
@@ -994,7 +999,7 @@ public class URIResolverRegistry {
 		uri = safeResolve(uri);
 		ISourceLocationInput resolver = getInputResolver(uri.getScheme());
 
-		if (resolver == null || (resolver == externalRegistry && !externalRegistry.supportsGetCharset(uri))) {
+		if (resolver == null || (resolver == externalRegistry && !externalRegistry.supportsGetCharset(uri.getScheme()))) {
 			throw new UnsupportedSchemeException(uri.getScheme());
 		}
 

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -142,7 +142,9 @@ public class URIResolverRegistry {
 				registry = new RemoteExternalResolverRegistry(remoteResolverRegistryPort);
 			}
 			this.externalRegistry = registry;
-			watchers.setExternalRegistry(registry);
+			if (registry.hasWatchCapability()) {
+				watchers.setExternalRegistry(registry, registry::supportsWatch);
+			}
 		}
 	}
 
@@ -402,7 +404,7 @@ public class URIResolverRegistry {
 			loc = resolveAndFixOffsets(loc, resolver, map.values());
 		}
 		
-		if (externalRegistry != null) {
+		if (externalRegistry != null && externalRegistry.supportsLogical(loc)) {
 			try {
 				var externalResult = resolveAndFixOffsets(loc == null ? original : loc, externalRegistry, Collections.emptyList());
 				return externalResult == null ? loc : externalResult;
@@ -499,7 +501,9 @@ public class URIResolverRegistry {
 					return result;
 				}
 			}
-			return externalRegistry;
+			if (externalRegistry.supportsOutput(scheme)) {
+				return externalRegistry;
+			}
 		}
 		return result;
 	}
@@ -990,7 +994,7 @@ public class URIResolverRegistry {
 		uri = safeResolve(uri);
 		ISourceLocationInput resolver = getInputResolver(uri.getScheme());
 
-		if (resolver == null) {
+		if (resolver == null || (resolver == externalRegistry && !externalRegistry.supportsGetCharset(uri))) {
 			throw new UnsupportedSchemeException(uri.getScheme());
 		}
 

--- a/src/org/rascalmpl/uri/remote/RascalFileSystemServices.java
+++ b/src/org/rascalmpl/uri/remote/RascalFileSystemServices.java
@@ -40,6 +40,8 @@ import org.rascalmpl.uri.ISourceLocationWatcher;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.uri.remote.jsonrpc.BooleanResponse;
+import org.rascalmpl.uri.remote.jsonrpc.CapabilitiesResponse;
+import org.rascalmpl.uri.remote.jsonrpc.Capability;
 import org.rascalmpl.uri.remote.jsonrpc.CopyRequest;
 import org.rascalmpl.uri.remote.jsonrpc.DirectoryEntry;
 import org.rascalmpl.uri.remote.jsonrpc.DirectoryListingResponse;
@@ -241,5 +243,14 @@ public class RascalFileSystemServices implements IRemoteResolverRegistryServer {
 
             return new SourceLocationResponse(resolved);
         });
+    }
+
+    @Override
+    public CompletableFuture<CapabilitiesResponse> capabilities() {
+        return CompletableFuture.completedFuture(
+            new CapabilitiesResponse(
+                Capability.full(), Capability.full(), Capability.full(), Capability.full()
+            )
+        );
     }
 }

--- a/src/org/rascalmpl/uri/remote/RascalFileSystemServices.java
+++ b/src/org/rascalmpl/uri/remote/RascalFileSystemServices.java
@@ -246,10 +246,12 @@ public class RascalFileSystemServices implements IRemoteResolverRegistryServer {
     }
 
     @Override
-    public CompletableFuture<CapabilitiesResponse> capabilities() {
-        return CompletableFuture.completedFuture(
+    public CompletableFuture<CapabilitiesResponse> serverCapabilities() {
+        return async(() -> 
             new CapabilitiesResponse(
-                Capability.full(), Capability.full(), Capability.full(), Capability.full()
+                Capability.full(), Capability.full(), 
+                Capability.full(), Capability.full(),
+                Capability.full()
             )
         );
     }

--- a/src/org/rascalmpl/uri/remote/RemoteExternalResolverRegistry.java
+++ b/src/org/rascalmpl/uri/remote/RemoteExternalResolverRegistry.java
@@ -122,8 +122,11 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
             var newClient = startClient();
             if (!remote.compareAndSet(null, newClient.getRight())) {
                 newClient.getLeft().close();
+                return;
             }
+            currentCapabilities.set(newClient.getRight().serverCapabilities());
             firstConnectionEstablished = true;
+
         } catch (RuntimeException | IOException e) {
             CompletableFuture.delayedExecutor(nextTimeout.toMillis(), TimeUnit.MILLISECONDS, exec).execute(() -> {
                 var newTimeout = nextTimeout.plusMillis(10);
@@ -313,7 +316,6 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
         clientLauncher.startListening();
         var remote = clientLauncher.getRemoteProxy();
 
-        currentCapabilities.set(remote.serverCapabilities());
 
         inputStream.connect(remote);
         outputStream.connect(remote);
@@ -359,7 +361,7 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
         if (cap.isUnsupported()) {
             return false;
         }
-        if (cap.isFullSupport()) {
+        if (cap.isFullySupported()) {
             return true;
         }
         // we only care for the first part of the `possible+chained+scheme`

--- a/src/org/rascalmpl/uri/remote/RemoteExternalResolverRegistry.java
+++ b/src/org/rascalmpl/uri/remote/RemoteExternalResolverRegistry.java
@@ -137,6 +137,7 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
 
     private void scheduleReconnect(IRemoteResolverRegistryServer oldServer) {
         if (remote.compareAndSet(oldServer, null)) {
+            currentCapabilities.set(null);
             CompletableFuture.runAsync(() -> connect(Duration.ofMillis(10)), exec);
         }
     }
@@ -312,7 +313,7 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
         clientLauncher.startListening();
         var remote = clientLauncher.getRemoteProxy();
 
-        currentCapabilities.set(remote.capabilities());
+        currentCapabilities.set(remote.serverCapabilities());
 
         inputStream.connect(remote);
         outputStream.connect(remote);
@@ -320,18 +321,18 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
     }
 
     @Override
-    public boolean supportsGetCharset(ISourceLocation loc) {
-        return supportsCapability(CapabilitiesResponse::getGetCharset, loc.getScheme());
+    public boolean supportsGetCharset(String scheme) {
+        return supportsCapability(CapabilitiesResponse::getGetCharset, scheme);
     }
 
     @Override
-    public boolean supportsLogical(ISourceLocation loc) {
-        return supportsCapability(CapabilitiesResponse::getLogical, loc.getScheme());
+    public boolean supportsLogical(String scheme) {
+        return supportsCapability(CapabilitiesResponse::getLogical, scheme);
     }
 
     @Override
-    public boolean supportsWatch(ISourceLocation loc) {
-        return supportsCapability(CapabilitiesResponse::getWatch, loc.getScheme());
+    public boolean supportsWatch(String scheme) {
+        return supportsCapability(CapabilitiesResponse::getWatch, scheme);
     }
 
     @Override
@@ -339,7 +340,16 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
         return supportsCapability(CapabilitiesResponse::getOutput, scheme);
     }
 
-    public boolean hasWatchCapability() {
+    @Override
+    public boolean supportsInput(String scheme) {
+        return supportsCapability(CapabilitiesResponse::getInput, scheme);
+    }
+
+    /**
+     * Check if the remote server supports a watch, even if it's partial
+     * @return
+     */
+    public boolean anyWatchSupported() {
         return !getCapability(CapabilitiesResponse::getWatch).isUnsupported();
     }
 
@@ -352,6 +362,8 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
         if (cap.isFullSupport()) {
             return true;
         }
+        // we only care for the first part of the `possible+chained+scheme`
+        // the nested schemes are for the downstream consumer.
         return cap.getOnlyForSchemes().contains(getFirstSchemePart(scheme));
     }
 
@@ -385,10 +397,9 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
             }
         }
         try {
-            return caps.thenApply(field)
-                .thenApply(c -> c == null ? Capability.unsupported() : c)
-                .get(1, TimeUnit.MINUTES);
-        } catch (TimeoutException e) {
+            return caps.thenApply(field).get(1, TimeUnit.MINUTES);
+        } 
+        catch (TimeoutException e) {
             return Capability.unsupported();
         }
         catch (InterruptedException e) {

--- a/src/org/rascalmpl/uri/remote/RemoteExternalResolverRegistry.java
+++ b/src/org/rascalmpl/uri/remote/RemoteExternalResolverRegistry.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -60,6 +61,8 @@ import org.rascalmpl.uri.FileAttributes;
 import org.rascalmpl.uri.IExternalResolverRegistry;
 import org.rascalmpl.uri.ISourceLocationWatcher;
 import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.uri.remote.jsonrpc.CapabilitiesResponse;
+import org.rascalmpl.uri.remote.jsonrpc.Capability;
 import org.rascalmpl.uri.remote.jsonrpc.CopyRequest;
 import org.rascalmpl.uri.remote.jsonrpc.DirectoryEntry;
 import org.rascalmpl.uri.remote.jsonrpc.ISourceLocationRequest;
@@ -90,6 +93,7 @@ import io.usethesource.vallang.ISourceLocation;
  */
 public class RemoteExternalResolverRegistry implements IExternalResolverRegistry, IRemoteResolverRegistryClient {
     private final AtomicReference<IRemoteResolverRegistryServer> remote = new AtomicReference<>(null);
+    private final AtomicReference<CompletableFuture<CapabilitiesResponse>> currentCapabilities = new AtomicReference<>(null);
     private static final ExecutorService exec = NamedThreadPool.cachedDaemon("rascal-remote-resolver-registry");
 
     private final Map<WatchSubscriptionKey, Watchers> watchers = new ConcurrentHashMap<>();
@@ -308,9 +312,92 @@ public class RemoteExternalResolverRegistry implements IExternalResolverRegistry
         clientLauncher.startListening();
         var remote = clientLauncher.getRemoteProxy();
 
+        currentCapabilities.set(remote.capabilities());
+
         inputStream.connect(remote);
         outputStream.connect(remote);
         return Pair.of(socket, remote);
+    }
+
+    @Override
+    public boolean supportsGetCharset(ISourceLocation loc) {
+        return supportsCapability(CapabilitiesResponse::getGetCharset, loc.getScheme());
+    }
+
+    @Override
+    public boolean supportsLogical(ISourceLocation loc) {
+        return supportsCapability(CapabilitiesResponse::getLogical, loc.getScheme());
+    }
+
+    @Override
+    public boolean supportsWatch(ISourceLocation loc) {
+        return supportsCapability(CapabilitiesResponse::getWatch, loc.getScheme());
+    }
+
+    @Override
+    public boolean supportsOutput(String scheme) {
+        return supportsCapability(CapabilitiesResponse::getOutput, scheme);
+    }
+
+    public boolean hasWatchCapability() {
+        return !getCapability(CapabilitiesResponse::getWatch).isUnsupported();
+    }
+
+
+    private boolean supportsCapability(Function<CapabilitiesResponse, Capability> field, String scheme) {
+        var cap = getCapability(field);
+        if (cap.isUnsupported()) {
+            return false;
+        }
+        if (cap.isFullSupport()) {
+            return true;
+        }
+        return cap.getOnlyForSchemes().contains(getFirstSchemePart(scheme));
+    }
+
+    private static String getFirstSchemePart(String scheme) {
+        var end = scheme.indexOf('+');
+        if (end > 0) {
+            return scheme.substring(0, end);
+        }
+        return scheme;
+    }
+
+
+    private Capability getCapability(Function<CapabilitiesResponse, Capability> field) {
+        var caps = currentCapabilities.get();
+        if (caps == null) {
+            var stop = System.currentTimeMillis() + Duration.ofMinutes(1).toMillis();
+            while (System.currentTimeMillis() <= stop) {
+                caps = currentCapabilities.get();
+                if (caps != null) {
+                    break;
+                }
+                try {
+                    Thread.sleep(1);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (caps == null) {
+                return Capability.unsupported();
+            }
+        }
+        try {
+            return caps.thenApply(field)
+                .thenApply(c -> c == null ? Capability.unsupported() : c)
+                .get(1, TimeUnit.MINUTES);
+        } catch (TimeoutException e) {
+            return Capability.unsupported();
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return Capability.unsupported();
+        }
+        catch (ExecutionException e) {
+            return Capability.unsupported();
+        }
     }
 
     private static <T, U> U call(ThrowingFunction<T, CompletableFuture<U>, IOException> function, T argument) throws IOException {

--- a/src/org/rascalmpl/uri/remote/jsonrpc/CapabilitiesResponse.java
+++ b/src/org/rascalmpl/uri/remote/jsonrpc/CapabilitiesResponse.java
@@ -24,28 +24,55 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package org.rascalmpl.uri;
+package org.rascalmpl.uri.remote.jsonrpc;
 
-import io.usethesource.vallang.ISourceLocation;
+import java.util.Objects;
 
-public interface IExternalResolverRegistry extends ISourceLocationInputOutput, ILogicalSourceLocationResolver, ISourceLocationWatcher {
-    @Override
-    default String scheme() {
-        throw new UnsupportedOperationException("'scheme' is not supported for external resolvers");
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+public class CapabilitiesResponse {
+    /**
+     * Are the `/watch/` apis supported
+     */
+    private final @Nullable Capability watch;
+    /**
+     * Are the `/output/` apis supported
+     */
+    private final @Nullable Capability output;
+    /**
+     * Are the `/logical/` apis supported
+     */
+    private final @Nullable Capability logical;
+    /**
+     * Is the `/getCharset` api supported
+     */
+    private final @Nullable Capability getCharset;
+
+    public CapabilitiesResponse(@Nullable Capability watch, @Nullable Capability output, @Nullable Capability logical,
+        @Nullable Capability getCharset) {
+        this.watch = watch;
+        this.output = output;
+        this.logical = logical;
+        this.getCharset = getCharset;
+    }
+    public @Nullable Capability getGetCharset() {
+        return getCharset;
+    }
+
+    public @Nullable Capability getLogical() {
+        return logical;
+    }
+    public @Nullable Capability getWatch() {
+        return watch;
+    }
+
+    public Capability getOutput() {
+        return output;
     }
 
     @Override
-    default String authority() {
-        throw new UnsupportedOperationException("`authority` is not supported for external resolvers");
+    public int hashCode() {
+        return Objects.hash(watch, output, logical, getCharset);
     }
-
-    @Override
-    default boolean supportsHost() {
-        return false;
-    }
-
-    boolean supportsLogical(ISourceLocation loc);
-    boolean supportsWatch(ISourceLocation loc);
-    boolean supportsGetCharset(ISourceLocation loc);
-    boolean supportsOutput(String scheme);
 }

--- a/src/org/rascalmpl/uri/remote/jsonrpc/CapabilitiesResponse.java
+++ b/src/org/rascalmpl/uri/remote/jsonrpc/CapabilitiesResponse.java
@@ -62,6 +62,7 @@ public class CapabilitiesResponse {
         this.getCharset = getCharset;
     }
 
+    /** as GSON will set null fields, but we don't want this in our code, we replace them by unsupported in the getter */
     private static Capability replaceNull(@Nullable Capability cap) {
         return cap == null ? Capability.unsupported() : cap;
     }

--- a/src/org/rascalmpl/uri/remote/jsonrpc/CapabilitiesResponse.java
+++ b/src/org/rascalmpl/uri/remote/jsonrpc/CapabilitiesResponse.java
@@ -33,46 +33,73 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class CapabilitiesResponse {
     /**
-     * Are the `/watch/` apis supported
+     * Are the `/input/` APIs supported, null is a shorthand a capability of level for{@link CapabilityLevel#UNSUPPORTED}.
      */
-    private final @Nullable Capability watch;
+    private final @Nullable Capability input;
     /**
-     * Are the `/output/` apis supported
+     * Are the `/output/` APIs supported, null is a shorthand a capability of level for{@link CapabilityLevel#UNSUPPORTED}.
      */
     private final @Nullable Capability output;
     /**
-     * Are the `/logical/` apis supported
+     * Are the `/watch/` APIs supported, null is a shorthand a capability of level for{@link CapabilityLevel#UNSUPPORTED}
+     */
+    private final @Nullable Capability watch;
+    /**
+     * Are the `/logical/` APIs supported, null is a shorthand a capability of level for{@link CapabilityLevel#UNSUPPORTED}
      */
     private final @Nullable Capability logical;
     /**
-     * Is the `/getCharset` api supported
+     * Is the `/getCharset` API supported, null is a shorthand a capability of level for{@link CapabilityLevel#UNSUPPORTED}
      */
     private final @Nullable Capability getCharset;
 
-    public CapabilitiesResponse(@Nullable Capability watch, @Nullable Capability output, @Nullable Capability logical,
+    public CapabilitiesResponse(@Nullable Capability input, @Nullable Capability watch, @Nullable Capability output, @Nullable Capability logical,
         @Nullable Capability getCharset) {
+        this.input = input;
         this.watch = watch;
         this.output = output;
         this.logical = logical;
         this.getCharset = getCharset;
     }
-    public @Nullable Capability getGetCharset() {
-        return getCharset;
+
+    private static Capability replaceNull(@Nullable Capability cap) {
+        return cap == null ? Capability.unsupported() : cap;
     }
 
-    public @Nullable Capability getLogical() {
-        return logical;
+
+    public Capability getGetCharset() {
+        return replaceNull(getCharset);
     }
-    public @Nullable Capability getWatch() {
-        return watch;
+
+    public Capability getLogical() {
+        return replaceNull(logical);
+    }
+    public Capability getWatch() {
+        return replaceNull(watch);
+    }
+
+    public Capability getInput() {
+        return replaceNull(input);
     }
 
     public Capability getOutput() {
-        return output;
+        return replaceNull(output);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(watch, output, logical, getCharset);
+        return Objects.hash(input, output, watch, logical, getCharset);
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof CapabilitiesResponse)) {
+            return false;
+        }
+        CapabilitiesResponse other = (CapabilitiesResponse) obj;
+        return Objects.equals(input, other.input) && Objects.equals(output, other.output)
+            && Objects.equals(watch, other.watch) && Objects.equals(logical, other.logical)
+            && Objects.equals(getCharset, other.getCharset);
+    }
+
 }

--- a/src/org/rascalmpl/uri/remote/jsonrpc/Capability.java
+++ b/src/org/rascalmpl/uri/remote/jsonrpc/Capability.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018-2026, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.uri.remote.jsonrpc;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A capability means that this feature is at least partially supported (namely only for specific schemes) and if full supported, no scheme limits are set
+ */
+public class Capability {
+    private final CapabilityLevel level;
+    private final Set<String> onlyForSchemes;
+
+    public Capability(CapabilityLevel level, @Nullable String[] onlyForSchemes) {
+        this.level = level;
+        this.onlyForSchemes = onlyForSchemes == null ? Collections.emptySet() : Set.of(onlyForSchemes);
+        if (level == CapabilityLevel.PARTIAL && this.onlyForSchemes.isEmpty()) {
+            throw new IllegalArgumentException("Partial support should always include a list of the schemes that have support");
+        }
+        else if (level != CapabilityLevel.PARTIAL && !this.onlyForSchemes.isEmpty()) {
+            throw new IllegalArgumentException("onlyForSchemes is only valid if the level is PARTIAL");
+        }
+    }
+
+    public static Capability full() {
+        return new Capability(CapabilityLevel.FULL, null);
+    }
+
+    public static Capability partial(String[] onlyForSchemes) {
+        return new Capability(CapabilityLevel.PARTIAL, onlyForSchemes);
+    }
+
+    public static Capability unsupported() {
+        return new Capability(CapabilityLevel.UNSUPPORTED, null);
+    }
+
+    public Set<String> getOnlyForSchemes() {
+        return onlyForSchemes;
+    }
+
+    public boolean isFullSupport() {
+        return level == CapabilityLevel.FULL;
+
+    }
+
+    public boolean isPartial() {
+        return level == CapabilityLevel.PARTIAL;
+    }
+
+    public boolean isUnsupported() {
+        return level == CapabilityLevel.UNSUPPORTED;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Capability) {
+            var other = (Capability)obj;
+            return other.level ==level 
+                && Objects.equals(other.onlyForSchemes, onlyForSchemes);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(level, onlyForSchemes);
+    }
+
+}
+ 

--- a/src/org/rascalmpl/uri/remote/jsonrpc/Capability.java
+++ b/src/org/rascalmpl/uri/remote/jsonrpc/Capability.java
@@ -31,15 +31,16 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
 /**
- * A capability means that this feature is at least partially supported (namely only for specific schemes) and if full supported, no scheme limits are set
+ * A server can report is capability, either as being not supported, partially supported (for a specific set of schemes) or fully supported.
  */
 public class Capability {
-    private final CapabilityLevel level;
-    private final Set<String> onlyForSchemes;
+    private final @NonNull CapabilityLevel level;
+    private final @NonNull Set<String> onlyForSchemes;
 
-    public Capability(CapabilityLevel level, @Nullable String[] onlyForSchemes) {
+    public Capability(@NonNull CapabilityLevel level, @Nullable String[] onlyForSchemes) {
         this.level = level;
         this.onlyForSchemes = onlyForSchemes == null ? Collections.emptySet() : Set.of(onlyForSchemes);
         if (level == CapabilityLevel.PARTIAL && this.onlyForSchemes.isEmpty()) {

--- a/src/org/rascalmpl/uri/remote/jsonrpc/Capability.java
+++ b/src/org/rascalmpl/uri/remote/jsonrpc/Capability.java
@@ -34,15 +34,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
 /**
- * A server can report is capability, either as being not supported, partially supported (for a specific set of schemes) or fully supported.
+ * A server can report its capability, either as being not supported, partially supported (for a specific set of schemes) or fully supported.
  */
 public class Capability {
     private final @NonNull CapabilityLevel level;
-    private final @NonNull Set<String> onlyForSchemes;
+    private final @Nullable Set<String> onlyForSchemes;
 
-    public Capability(@NonNull CapabilityLevel level, @Nullable String[] onlyForSchemes) {
+    public Capability(@NonNull CapabilityLevel level, @Nullable Set<String> onlyForSchemes) {
         this.level = level;
-        this.onlyForSchemes = onlyForSchemes == null ? Collections.emptySet() : Set.of(onlyForSchemes);
+        this.onlyForSchemes = onlyForSchemes == null ? Collections.emptySet() : Set.copyOf(onlyForSchemes);
         if (level == CapabilityLevel.PARTIAL && this.onlyForSchemes.isEmpty()) {
             throw new IllegalArgumentException("Partial support should always include a list of the schemes that have support");
         }
@@ -55,7 +55,7 @@ public class Capability {
         return new Capability(CapabilityLevel.FULL, null);
     }
 
-    public static Capability partial(String[] onlyForSchemes) {
+    public static Capability partial(Set<String> onlyForSchemes) {
         return new Capability(CapabilityLevel.PARTIAL, onlyForSchemes);
     }
 
@@ -64,15 +64,15 @@ public class Capability {
     }
 
     public Set<String> getOnlyForSchemes() {
-        return onlyForSchemes;
+        return onlyForSchemes == null ? Collections.emptySet() : Set.copyOf(onlyForSchemes);
     }
 
-    public boolean isFullSupport() {
+    public boolean isFullySupported() {
         return level == CapabilityLevel.FULL;
 
     }
 
-    public boolean isPartial() {
+    public boolean isPartiallySupported() {
         return level == CapabilityLevel.PARTIAL;
     }
 

--- a/src/org/rascalmpl/uri/remote/jsonrpc/CapabilityLevel.java
+++ b/src/org/rascalmpl/uri/remote/jsonrpc/CapabilityLevel.java
@@ -23,7 +23,8 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- */package org.rascalmpl.uri.remote.jsonrpc;
+ */
+package org.rascalmpl.uri.remote.jsonrpc;
 
 /**
  * The level of support for a specific feature

--- a/src/org/rascalmpl/uri/remote/jsonrpc/CapabilityLevel.java
+++ b/src/org/rascalmpl/uri/remote/jsonrpc/CapabilityLevel.java
@@ -23,29 +23,37 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
+ */package org.rascalmpl.uri.remote.jsonrpc;
+
+/**
+ * The level of support for a specific feature
  */
-package org.rascalmpl.uri;
+public enum CapabilityLevel {
+    UNSUPPORTED(0),
+    /**
+     * Only a subset of the schemes are supported, but they have full support
+     */
+    PARTIAL(1),
+    /**
+     * All schemes have this support
+     */
+    FULL(2);
 
-import io.usethesource.vallang.ISourceLocation;
+    private final int value;
 
-public interface IExternalResolverRegistry extends ISourceLocationInputOutput, ILogicalSourceLocationResolver, ISourceLocationWatcher {
-    @Override
-    default String scheme() {
-        throw new UnsupportedOperationException("'scheme' is not supported for external resolvers");
+    private CapabilityLevel(int value) {
+        this.value = value;
     }
 
-    @Override
-    default String authority() {
-        throw new UnsupportedOperationException("`authority` is not supported for external resolvers");
+    public int getValue() {
+        return value;
     }
 
-    @Override
-    default boolean supportsHost() {
-        return false;
+    public static CapabilityLevel forValue(int val) {
+        var result = CapabilityLevel.values();
+        if (val < 0 || val >= result.length) {
+            throw new IllegalArgumentException("Invalid value for CapabilityLevel: " + val);
+        }
+        return result[val];
     }
-
-    boolean supportsLogical(ISourceLocation loc);
-    boolean supportsWatch(ISourceLocation loc);
-    boolean supportsGetCharset(ISourceLocation loc);
-    boolean supportsOutput(String scheme);
 }

--- a/src/org/rascalmpl/uri/vfs/IRemoteResolverRegistryServer.java
+++ b/src/org/rascalmpl/uri/vfs/IRemoteResolverRegistryServer.java
@@ -59,8 +59,8 @@ public interface IRemoteResolverRegistryServer {
      * The server can mark certain APIs as not, partially, or fully supported.
      * The client will call this function as soon as the connection is estabilished.
      */
-    @JsonRequest("capabilities")
-    CompletableFuture<CapabilitiesResponse> capabilities();
+    @JsonRequest()
+    CompletableFuture<CapabilitiesResponse> serverCapabilities();
 
     @JsonRequest("input/readFile")
     CompletableFuture<LocationContentResponse> readFile(ISourceLocationRequest req);
@@ -98,7 +98,7 @@ public interface IRemoteResolverRegistryServer {
     @JsonRequest("input/isReadable")
     CompletableFuture<BooleanResponse> isReadable(ISourceLocationRequest req);
 
-    @JsonRequest("getCharset")
+    @JsonRequest()
     CompletableFuture<StringResponse> getCharset(ISourceLocationRequest req);
     
     @JsonRequest("output/setLastModified")

--- a/src/org/rascalmpl/uri/vfs/IRemoteResolverRegistryServer.java
+++ b/src/org/rascalmpl/uri/vfs/IRemoteResolverRegistryServer.java
@@ -33,6 +33,7 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 import org.rascalmpl.uri.FileAttributes;
 import org.rascalmpl.uri.remote.jsonrpc.BooleanResponse;
+import org.rascalmpl.uri.remote.jsonrpc.CapabilitiesResponse;
 import org.rascalmpl.uri.remote.jsonrpc.CopyRequest;
 import org.rascalmpl.uri.remote.jsonrpc.DirectoryEntry;
 import org.rascalmpl.uri.remote.jsonrpc.DirectoryListingResponse;
@@ -53,6 +54,14 @@ import org.rascalmpl.uri.remote.jsonrpc.WriteFileRequest;
  */
 @JsonSegment("rascal/vfs")
 public interface IRemoteResolverRegistryServer {
+
+    /**
+     * The server can mark certain APIs as not, partially, or fully supported.
+     * The client will call this function as soon as the connection is estabilished.
+     */
+    @JsonRequest("capabilities")
+    CompletableFuture<CapabilitiesResponse> capabilities();
+
     @JsonRequest("input/readFile")
     CompletableFuture<LocationContentResponse> readFile(ISourceLocationRequest req);
 

--- a/src/org/rascalmpl/uri/watch/WatchRegistry.java
+++ b/src/org/rascalmpl/uri/watch/WatchRegistry.java
@@ -74,6 +74,7 @@ public class WatchRegistry {
     public final ReferenceQueue<? super Consumer<ISourceLocationChanged>> clearedReferences = new ReferenceQueue<>();
     private final UnaryOperator<ISourceLocation> resolver;
     private volatile @Nullable ISourceLocationWatcher externalRegistry;
+    private volatile @Nullable Predicate<ISourceLocation> externalRegistryWatchSupport;
 
     public WatchRegistry(URIResolverRegistry reg, UnaryOperator<ISourceLocation> resolver) {
         this.reg = reg;
@@ -85,12 +86,13 @@ public class WatchRegistry {
     public void registerNative(String scheme, ISourceLocationWatcher watcher) {
         watchers.put(scheme, watcher);
     }
-    public void setExternalRegistry(ISourceLocationWatcher externalRegistry) {
+    public void setExternalRegistry(ISourceLocationWatcher externalRegistry, Predicate<ISourceLocation> externalRegistryWatchSupport) {
         this.externalRegistry = externalRegistry;
+        this.externalRegistryWatchSupport = externalRegistryWatchSupport;
     }
 
     public boolean hasExternalRegistry() {
-        return externalRegistry != null;
+        return externalRegistry != null && externalRegistryWatchSupport != null;
     }
 
     private ISourceLocation safeResolve(ISourceLocation loc) {
@@ -122,7 +124,7 @@ public class WatchRegistry {
         else if (hasResolvers.test(resolvedLoc)) {
             startSimulatedWatch(loc, recursive, callback, resolvedLoc);
         }
-        else if (hasExternalRegistry()) {
+        else if (hasExternalRegistry() && externalRegistryWatchSupport.test(resolvedLoc)) {
             externalRegistry.watch(resolvedLoc, callback, recursive);
         }
     }


### PR DESCRIPTION
This API adds a capability feature to the remote VFS feature that was added in #2641 

It allows servers to communicate that some parts of the VFS are not or partially supported.