### PR TITLE
Preparing anno to kw param quickfix for inclusion in VScode

### DIFF
--- a/.project
+++ b/.project
@@ -27,8 +27,6 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>rascal_eclipse.rascal_nature</nature>
-		<nature>rascal_eclipse.tutor_nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>

--- a/src/org/rascalmpl/library/lang/rascal/upgrade/UpgradeAnnotationsToKeywordParameters.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/upgrade/UpgradeAnnotationsToKeywordParameters.rsc
@@ -12,7 +12,7 @@ list[Message] report(Tree m)
   + [info("found annotation catch", e.src) | /(Catch) `catch NoSuchAnnotation(<Pattern e>) : <Statement body>` := m]
   ;
 
-Tree update(Tree m) =
+&T <: Tree update(&T <: Tree m) =
   top-down visit(m) {
     case (Declaration) `<Tags tags> <Visibility _> anno <Type t> <Name adt>@<Name name>;` 
       => (Declaration) `<Tags tags> 

--- a/src/org/rascalmpl/library/lang/rascal/upgrade/UpgradeBase.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/upgrade/UpgradeBase.rsc
@@ -49,7 +49,7 @@ void updatePathConfig(PathConfig pcfg) {
 }
 
 list[FileSystemChange] editsPathConfig(PathConfig pcfg) 
-  = [editsFolder(root) | root <- pcfg.srcs];
+  = [*editsFolder(root) | root <- pcfg.srcs];
 
 void updateFolder(loc root) {
   set[loc] ms = find(root, "rsc");
@@ -79,8 +79,8 @@ list[FileSystemChange] editsFolder(loc root) {
         list[TextEdit] edits  = treeDiff(oldTree, newTree);
         return changed(m, edits);
       }
-      catch ParseError(l): {
-        warning("parse error in <l>, skipped", l);
+      catch ParseError(loc l): {
+        warning("parse error at <l>, skipped <m>!", l);
         return changed(m, []);
       }
   }, label="Upgrading annotations in <root>");

--- a/src/org/rascalmpl/library/lang/rascal/upgrade/UpgradeBase.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/upgrade/UpgradeBase.rsc
@@ -33,7 +33,7 @@ list[Message] report(loc root) {
    
 list[Message] reportFor(loc l) {
   try {
-    return report(parse(#start[Module], l)); 
+    return report(parseModuleWithSpaces(l)); 
   } catch ParseError(loc r) :
     return [warning("parse error in Rascal file",r)];
 }
@@ -58,7 +58,7 @@ void updateFolder(loc root) {
     for (loc m <- ms) {
       try {
         step(m.file, 1);
-        writeFile(m, "<update(parse(#start[Module], m))>");
+        writeFile(m, "<update(parseModuleWithSpaces(m))>");
       }
       catch ParseError(l): {
         println("parse error in <l>, skipped");
@@ -74,14 +74,14 @@ list[FileSystemChange] editsFolder(loc root) {
 
   return loopJob(ms, FileSystemChange (loc m) {
       try {
-        start[Module] oldTree = parse(#start[Module], m);
-        start[Module] newTree = update(oldTree);
-        list[TextEdit] edits  = treeDiff(oldTree, newTree);
-        return changed(m, edits);
+          start[Module] oldTree = parseModuleWithSpaces(m);
+          start[Module] newTree = update(oldTree);
+          list[TextEdit] edits  = treeDiff(oldTree, newTree);
+          return changed(m, edits);
       }
       catch ParseError(loc l): {
-        warning("parse error at <l>, skipped <m>!", l);
-        return changed(m, []);
+          warning("parse error at <l>, skipped <m>!", l);
+          return changed(m, []);
       }
   }, label="Upgrading annotations in <root>");
 }

--- a/src/org/rascalmpl/library/lang/rascal/upgrade/UpgradeBase.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/upgrade/UpgradeBase.rsc
@@ -10,6 +10,7 @@ import Exception;
 import util::Reflective;
 import Set;
 import util::Monitor;
+import analysis::diff::edits::HiFiTreeDiff;
 
 list[Message] reportForProject(loc projectRoot)
   = reportForPathConfig(getProjectPathConfig(projectRoot));
@@ -47,6 +48,9 @@ void updatePathConfig(PathConfig pcfg) {
   }
 }
 
+list[FileSystemChange] editsPathConfig(PathConfig pcfg) 
+  = [editsFolder(root) | root <- pcfg.srcs];
+
 void updateFolder(loc root) {
   set[loc] ms = find(root, "rsc");
 
@@ -65,9 +69,26 @@ void updateFolder(loc root) {
   }, totalWork=size(ms));
 }
 
+list[FileSystemChange] editsFolder(loc root) {
+  set[loc] ms = find(root, "rsc");
+
+  return loopJob(ms, FileSystemChange (loc m) {
+      try {
+        start[Module] oldTree = parse(#start[Module], m);
+        start[Module] newTree = update(oldTree);
+        list[TextEdit] edits  = treeDiff(oldTree, newTree);
+        return changed(m, edits);
+      }
+      catch ParseError(l): {
+        warning("parse error in <l>, skipped", l);
+        return changed(m, []);
+      }
+  }, label="Upgrading annotations in <root>");
+}
+
 @synopsis{Definition to override in an extending module for reporting on a specific upgrade refactoring.}
 default list[Message] report(Tree _) = [];
 
 @synopsis{Definition to override in an extending module for implementing a specific upgrade refactoring.}
-default Tree update(Tree m) = m;
+default &T <: Tree update(&T <: Tree m) = m;
 


### PR DESCRIPTION
- **prepare the annotation to kw field rewriter for inclusion in the IDE by calling treeDiff**
- this only calls the existing rewriting visit without changing anything about it. It has been applied on the standard library, the checker, the compiler, the tutor and all libraries we publish.
- this is the first real application of `treeDiff` so ample testing required, but we can do that in the VScode extension because the integration of the edits with the commands is also interesting to test a bit deeper.
- this uses a progress bar to loop over all the rascal source files in a project. interesting to see how it looks in VScode
