### PR TITLE
Remote IDEServices: use parameter classes instead of positional parameters

### DIFF
--- a/src/org/rascalmpl/ideservices/IRemoteIDEServices.java
+++ b/src/org/rascalmpl/ideservices/IRemoteIDEServices.java
@@ -26,20 +26,19 @@
  */
 package org.rascalmpl.ideservices;
 
-import java.net.URI;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
-import org.rascalmpl.values.ValueFactoryFactory;
-
-import io.usethesource.vallang.IInteger;
-import io.usethesource.vallang.IList;
-import io.usethesource.vallang.IMap;
-import io.usethesource.vallang.ISourceLocation;
-import io.usethesource.vallang.IString;
-import io.usethesource.vallang.ITuple;
-import io.usethesource.vallang.type.TypeStore;
+import org.rascalmpl.ideservices.jsonrpc.ApplyDocumentsEditsRequest;
+import org.rascalmpl.ideservices.jsonrpc.BrowseRequest;
+import org.rascalmpl.ideservices.jsonrpc.EditRequest;
+import org.rascalmpl.ideservices.jsonrpc.RegisterDebugServerPortRequest;
+import org.rascalmpl.ideservices.jsonrpc.RegisterDiagnosticsRequest;
+import org.rascalmpl.ideservices.jsonrpc.RegisterLocationsRequest;
+import org.rascalmpl.ideservices.jsonrpc.StartDebuggingSessionRequest;
+import org.rascalmpl.ideservices.jsonrpc.UnregisterDiagnosticsRequest;
+import org.rascalmpl.uri.remote.jsonrpc.ISourceLocationRequest;
+import org.rascalmpl.uri.remote.jsonrpc.SourceLocationResponse;
 
 /**
  * This interface exposes functionality from `IDEServices` over IPC.
@@ -47,75 +46,30 @@ import io.usethesource.vallang.type.TypeStore;
  * itself to be run remotely in a nice way.
  */
 public interface IRemoteIDEServices {
+    @JsonRequest
+    CompletableFuture<Void> edit(EditRequest req);
 
     @JsonRequest
-    CompletableFuture<Void> edit(ISourceLocation param, int viewColumn);
+    CompletableFuture<Void> browse(BrowseRequest req);
 
     @JsonRequest
-    CompletableFuture<Void> browse(URI uri, IString title, IInteger viewColumn);
+    CompletableFuture<SourceLocationResponse> resolveProjectLocation(ISourceLocationRequest req);
 
     @JsonRequest
-    CompletableFuture<ISourceLocation> resolveProjectLocation(ISourceLocation param);
+    CompletableFuture<Void> applyDocumentsEdits(ApplyDocumentsEditsRequest req);
 
     @JsonRequest
-    CompletableFuture<Void> applyDocumentsEdits(DocumentEditsParameter edits);
+    CompletableFuture<Void> registerLocations(RegisterLocationsRequest req);
 
     @JsonRequest
-    CompletableFuture<Void> registerLocations(IString scheme, IString authority, ISourceLocation[][] mapping);
+    CompletableFuture<Void> registerDiagnostics(RegisterDiagnosticsRequest req);
 
     @JsonRequest
-    CompletableFuture<Void> registerDiagnostics(RegisterDiagnosticsParameters param);
+    CompletableFuture<Void> unregisterDiagnostics(UnregisterDiagnosticsRequest req);
 
     @JsonRequest
-    CompletableFuture<Void> unregisterDiagnostics(ISourceLocation[] locs);
+    CompletableFuture<Void> startDebuggingSession(StartDebuggingSessionRequest req);
 
     @JsonRequest
-    CompletableFuture<Void> startDebuggingSession(int serverPort);
-
-    @JsonRequest
-    CompletableFuture<Void> registerDebugServerPort(int processID, int serverPort);
-
-    public static class RegisterDiagnosticsParameters {
-        private String messages;
-
-        public RegisterDiagnosticsParameters(IList messages) {
-            this.messages = GsonUtils.base64Encode(messages);
-        }
-
-        public IList getMessages() {
-            return GsonUtils.base64Decode(messages, new TypeStore());
-        }
-    }
-
-    public static class DocumentEditsParameter {
-
-        private String edits;
-
-        public DocumentEditsParameter(IList edits) {
-            this.edits = GsonUtils.base64Encode(edits);
-        }
-
-        public IList getEdits() {
-            return GsonUtils.base64Decode(edits, new TypeStore());
-        }
-    }
-
-    /** 
-     * This function takes a map of type `map[loc, loc]` and converts it to a two-dimensional array of ISourceLocations
-     */
-    public static ISourceLocation[][] mapLocLocToLocArray(IMap mapping) {
-        return mapping.stream()
-                .map(ITuple.class::cast)
-                .map(e -> new ISourceLocation[] { (ISourceLocation) e.get(0), (ISourceLocation) e.get(1)})
-                .toArray(n -> new ISourceLocation[n][2]);
-    }
-
-    /** 
-     * This function takes a two-dimensional array of ISourceLocations and converts it to a map of type `map[loc, loc]`
-     */
-    public static IMap locArrayToMapLocLoc(ISourceLocation[][] mapping) {
-        var vf = ValueFactoryFactory.getValueFactory();
-        return Stream.of(mapping).map(e -> vf.tuple(e[0], e[1])).collect(vf.mapWriter());
-    }
-
+    CompletableFuture<Void> registerDebugServerPort(RegisterDebugServerPortRequest req);
 }

--- a/src/org/rascalmpl/ideservices/RemoteIDEServices.java
+++ b/src/org/rascalmpl/ideservices/RemoteIDEServices.java
@@ -54,12 +54,19 @@ import io.usethesource.vallang.IList;
 import io.usethesource.vallang.IMap;
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IString;
+import io.usethesource.vallang.type.TypeFactory;
+import io.usethesource.vallang.type.TypeStore;
 
 /**
  * This class enables interaction with an implementation of `IDEServices` that (potentially) runs in another thread or process
  */
 public class RemoteIDEServices extends BasicIDEServices {
     private final IRemoteIDEServices server;
+    /**
+     * This TypeStore contains definitions of the `Messages` ADT (for {@link #registerDiagnostics}) and `FileSystemChanges` ADT (for {@link #applyFileSystemEdits}).
+     * (Note: the list in {@link #unregisterDiagnostics} has element type `loc`).
+     */
+    public static final TypeStore ts;
 
     public RemoteIDEServices(int ideServicesPort, PrintWriter stderr, IRascalMonitor monitor, Terminal terminal, ISourceLocation projectRoot) {
         super(stderr, monitor, terminal, projectRoot);
@@ -73,7 +80,7 @@ public class RemoteIDEServices extends BasicIDEServices {
                 .setLocalService(this)
                 .setInput(socket.getInputStream())
                 .setOutput(socket.getOutputStream())
-                .configureGson(GsonUtils.complexAsJsonObject())
+                .configureGson(GsonUtils.complexAsBase64String(ts))
                 .setExecutorService(DaemonThreadPool.buildConstrainedCached("rascal-ide-services", Math.max(2, Math.min(6, Runtime.getRuntime().availableProcessors() - 2))))
                 .create();
 
@@ -82,6 +89,18 @@ public class RemoteIDEServices extends BasicIDEServices {
         } catch (Throwable e) {
             throw new RuntimeException("Error setting up Remote IDE Services connection", e);
         }
+    }
+
+    static {
+        ts = new TypeStore(Messages.ts);
+        var tf = TypeFactory.getInstance();
+
+        // The following should be kept in sync with the Rascal definition in `analysis::diff::edits::FileSystemChanges`
+        var fileSystemChangeType = tf.abstractDataType(ts, "FileSystemChange");
+        tf.constructor(ts, fileSystemChangeType, "removed", tf.sourceLocationType(), "file");
+        tf.constructor(ts, fileSystemChangeType, "created", tf.sourceLocationType(), "file");
+        tf.constructor(ts, fileSystemChangeType, "renamed", tf.sourceLocationType(), "from", tf.sourceLocationType(), "to");
+        tf.constructor(ts, fileSystemChangeType, "modified", tf.sourceLocationType(), "file");
     }
 
     @Override

--- a/src/org/rascalmpl/ideservices/RemoteIDEServices.java
+++ b/src/org/rascalmpl/ideservices/RemoteIDEServices.java
@@ -63,8 +63,10 @@ import io.usethesource.vallang.type.TypeStore;
 public class RemoteIDEServices extends BasicIDEServices {
     private final IRemoteIDEServices server;
     /**
-     * This TypeStore contains definitions of the `Messages` ADT (for {@link #registerDiagnostics}) and `FileSystemChanges` ADT (for {@link #applyFileSystemEdits}).
-     * (Note: the list in {@link #unregisterDiagnostics} has element type `loc`).
+     * This TypeStore contains definitions of the ADTs `Messages` (for {@link #registerDiagnostics}) and `FileSystemChanges` (for {@link #applyFileSystemEdits}).
+     * These definitions must be kept in sync with the Rascal definitions in `Messages` and `analysis::diff::edits::FileSystemChanges`.
+     * 
+     * (Note: the IList in {@link #unregisterDiagnostics} has element type `loc`).
      */
     public static final TypeStore ts;
 
@@ -95,7 +97,6 @@ public class RemoteIDEServices extends BasicIDEServices {
         ts = new TypeStore(Messages.ts);
         var tf = TypeFactory.getInstance();
 
-        // The following should be kept in sync with the Rascal definition in `analysis::diff::edits::FileSystemChanges`
         var fileSystemChangeType = tf.abstractDataType(ts, "FileSystemChange");
         tf.constructor(ts, fileSystemChangeType, "removed", tf.sourceLocationType(), "file");
         tf.constructor(ts, fileSystemChangeType, "created", tf.sourceLocationType(), "file");

--- a/src/org/rascalmpl/ideservices/RemoteIDEServices.java
+++ b/src/org/rascalmpl/ideservices/RemoteIDEServices.java
@@ -26,20 +26,29 @@
  */
 package org.rascalmpl.ideservices;
 
-import engineering.swat.watch.DaemonThreadPool;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.jline.terminal.Terminal;
 import org.rascalmpl.debug.IRascalMonitor;
-import org.rascalmpl.ideservices.IRemoteIDEServices.DocumentEditsParameter;
-import org.rascalmpl.ideservices.IRemoteIDEServices.RegisterDiagnosticsParameters;
+import org.rascalmpl.ideservices.jsonrpc.ApplyDocumentsEditsRequest;
+import org.rascalmpl.ideservices.jsonrpc.BrowseRequest;
+import org.rascalmpl.ideservices.jsonrpc.EditRequest;
+import org.rascalmpl.ideservices.jsonrpc.RegisterDebugServerPortRequest;
+import org.rascalmpl.ideservices.jsonrpc.RegisterDiagnosticsRequest;
+import org.rascalmpl.ideservices.jsonrpc.RegisterLocationsRequest;
+import org.rascalmpl.ideservices.jsonrpc.StartDebuggingSessionRequest;
+import org.rascalmpl.ideservices.jsonrpc.UnregisterDiagnosticsRequest;
+import org.rascalmpl.library.Messages;
 import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.uri.remote.jsonrpc.ISourceLocationRequest;
 
+import engineering.swat.watch.DaemonThreadPool;
 import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.IMap;
@@ -77,18 +86,18 @@ public class RemoteIDEServices extends BasicIDEServices {
 
     @Override
     public void edit(ISourceLocation loc, int viewColumn) {
-        server.edit(loc, viewColumn);
+        server.edit(new EditRequest(loc, viewColumn));
     }
 
     @Override
     public void browse(URI uri, IString title, IInteger viewColumn) {
-        server.browse(uri, title, viewColumn);
+        server.browse(new BrowseRequest(uri, title, viewColumn));
     }
 
     @Override
     public ISourceLocation resolveProjectLocation(ISourceLocation input) {
         try {
-            return server.resolveProjectLocation(input).get(1, TimeUnit.MINUTES);
+            return server.resolveProjectLocation(new ISourceLocationRequest(input)).get(1, TimeUnit.MINUTES).getLocation();
         } catch (TimeoutException e) {
             warning("Error resolving project location", URIUtil.unknownLocation());
         } catch (Throwable e) {}
@@ -97,33 +106,33 @@ public class RemoteIDEServices extends BasicIDEServices {
 
     @Override
     public void startDebuggingSession(int serverPort) {
-        server.startDebuggingSession(serverPort);
+        server.startDebuggingSession(new StartDebuggingSessionRequest(serverPort));
     }
 
     @Override
     public void registerDebugServerPort(int processID, int serverPort) {
-        server.registerDebugServerPort(processID, serverPort);
+        server.registerDebugServerPort(new RegisterDebugServerPortRequest(processID, serverPort));
     }
 
     @Override
     public void applyFileSystemEdits(IList edits) {
-        server.applyDocumentsEdits(new DocumentEditsParameter(edits));
+        server.applyDocumentsEdits(new ApplyDocumentsEditsRequest(edits));
     }
 
     @Override
     public void registerDiagnostics(IList messages, ISourceLocation projectRoot) {
-        server.registerDiagnostics(new RegisterDiagnosticsParameters(messages));
+        server.registerDiagnostics(new RegisterDiagnosticsRequest(messages));
     }
     
     @Override
     public void unregisterDiagnostics(IList resources) {
-        server.unregisterDiagnostics(resources.stream().map(ISourceLocation.class::cast).toArray(ISourceLocation[]::new));
+        server.unregisterDiagnostics(new UnregisterDiagnosticsRequest(resources));
     }
 
     @Override
     public void registerLocations(IString scheme, IString auth, IMap map) {
         // The mappings should be registered both in the REPL itself as well as in the IDE
         super.registerLocations(scheme, auth, map);
-        server.registerLocations(scheme, auth, IRemoteIDEServices.mapLocLocToLocArray(map));
+        server.registerLocations(new RegisterLocationsRequest(scheme, auth, map));
     }
 }

--- a/src/org/rascalmpl/ideservices/jsonrpc/ApplyDocumentsEditsRequest.java
+++ b/src/org/rascalmpl/ideservices/jsonrpc/ApplyDocumentsEditsRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.ideservices.jsonrpc;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.rascalmpl.values.ValueFactoryFactory;
+
+import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.IList;
+
+public class ApplyDocumentsEditsRequest {
+    private final IConstructor[] edits;
+
+    public ApplyDocumentsEditsRequest(IList edits) {
+        this.edits = edits.stream().toArray(IConstructor[]::new);
+    }
+
+    public IList getEdits() {
+        return Stream.of(edits).collect(ValueFactoryFactory.getValueFactory().listWriter());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof ApplyDocumentsEditsRequest && Arrays.deepEquals(edits, ((ApplyDocumentsEditsRequest) obj).edits);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.deepHashCode(edits);
+    }
+}

--- a/src/org/rascalmpl/ideservices/jsonrpc/BrowseRequest.java
+++ b/src/org/rascalmpl/ideservices/jsonrpc/BrowseRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.ideservices.jsonrpc;
+
+import java.net.URI;
+import java.util.Objects;
+
+import io.usethesource.vallang.IInteger;
+import io.usethesource.vallang.IString;
+
+public class BrowseRequest {
+    private final URI uri;
+    private final IString title;
+    private final IInteger viewColumn;
+
+    public BrowseRequest(URI uri, IString title, IInteger viewColumn) {
+        this.uri = uri;
+        this.title = title;
+        this.viewColumn = viewColumn;
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public IString getTitle() {
+        return title;
+    }
+
+    public IInteger getViewColumn() {
+        return viewColumn;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BrowseRequest) {
+            var other = (BrowseRequest) obj;
+            return Objects.equals(uri, other.uri)
+                && Objects.equals(title, other.title)
+                && Objects.equals(viewColumn, other.viewColumn);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri, title, viewColumn);
+    }
+}

--- a/src/org/rascalmpl/ideservices/jsonrpc/EditRequest.java
+++ b/src/org/rascalmpl/ideservices/jsonrpc/EditRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.ideservices.jsonrpc;
+
+import java.util.Objects;
+
+import io.usethesource.vallang.ISourceLocation;
+
+public class EditRequest {
+    private final ISourceLocation loc;
+    private final int viewColumn;
+
+    public EditRequest(ISourceLocation loc, int viewColumn) {
+        this.loc = loc;
+        this.viewColumn = viewColumn;
+    }
+
+    public ISourceLocation getLocation() {
+        return loc;
+    }
+
+    public int getViewColumn() {
+        return viewColumn;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof EditRequest) {
+            var other = (EditRequest) obj;
+            return Objects.equals(loc, other.loc)
+                && viewColumn == other.viewColumn;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(loc, viewColumn);
+    }
+}

--- a/src/org/rascalmpl/ideservices/jsonrpc/RegisterDebugServerPortRequest.java
+++ b/src/org/rascalmpl/ideservices/jsonrpc/RegisterDebugServerPortRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.ideservices.jsonrpc;
+
+import java.util.Objects;
+
+public class RegisterDebugServerPortRequest {
+    private final int processID;
+    private final int serverPort;
+    
+    public RegisterDebugServerPortRequest(int processID, int serverPort) {
+        this.processID = processID;
+        this.serverPort = serverPort;
+    }
+
+    public int getProcessID() {
+        return processID;
+    }
+
+    public int getServerPort() {
+        return serverPort;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof RegisterDebugServerPortRequest) {
+            var other = (RegisterDebugServerPortRequest) obj;
+            return processID == other.processID && serverPort == other.serverPort;
+        }
+        return false;
+    }
+    @Override
+    public int hashCode() {
+        return Objects.hash(processID, serverPort);
+    }
+}

--- a/src/org/rascalmpl/ideservices/jsonrpc/RegisterDiagnosticsRequest.java
+++ b/src/org/rascalmpl/ideservices/jsonrpc/RegisterDiagnosticsRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.ideservices.jsonrpc;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.rascalmpl.values.ValueFactoryFactory;
+
+import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.IList;
+
+public class RegisterDiagnosticsRequest {
+    private final IConstructor[] messages;
+
+    public RegisterDiagnosticsRequest(IList messages) {
+        this.messages = messages.stream().toArray(IConstructor[]::new);
+    }
+
+    public IList getMessages() {
+        return Stream.of(messages).collect(ValueFactoryFactory.getValueFactory().listWriter());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof RegisterDiagnosticsRequest && Arrays.deepEquals(messages, ((RegisterDiagnosticsRequest) obj).messages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.deepHashCode(messages);
+    }
+}

--- a/src/org/rascalmpl/ideservices/jsonrpc/RegisterLocationsRequest.java
+++ b/src/org/rascalmpl/ideservices/jsonrpc/RegisterLocationsRequest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.ideservices.jsonrpc;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.rascalmpl.values.ValueFactoryFactory;
+
+import io.usethesource.vallang.IMap;
+import io.usethesource.vallang.ISourceLocation;
+import io.usethesource.vallang.IString;
+import io.usethesource.vallang.ITuple;
+
+public class RegisterLocationsRequest {
+    private final IString scheme;
+    private final IString authority;
+    private final ISourceLocation[][] mapping;
+    
+    public RegisterLocationsRequest(IString scheme, IString authority, IMap mapping) {
+        this.scheme = scheme;
+        this.authority = authority;
+        this.mapping = mapLocLocToLocArray(mapping);
+    }
+
+    public IString getScheme() {
+        return scheme;
+    }
+
+    public IString getAuthority() {
+        return authority;
+    }
+
+    public IMap getMapping() {
+        return locArrayToMapLocLoc(mapping);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof RegisterLocationsRequest) {
+            var other = (RegisterLocationsRequest) obj;
+            return Objects.equals(scheme, other.scheme)
+                && Objects.equals(authority, other.authority)
+                && Arrays.deepEquals(mapping, other.mapping);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 7 * Objects.hash(scheme, authority)
+            + 13 * Arrays.deepHashCode(mapping);
+    }
+
+    /** 
+     * This function takes a map of type `map[loc, loc]` and converts it to a two-dimensional array of ISourceLocations
+     */
+    private static ISourceLocation[][] mapLocLocToLocArray(IMap mapping) {
+        return mapping.stream()
+            .map(ITuple.class::cast)
+            .map(e -> new ISourceLocation[] { (ISourceLocation) e.get(0), (ISourceLocation) e.get(1)})
+            .toArray(n -> new ISourceLocation[n][2]);
+    }
+
+    /** 
+     * This function takes a two-dimensional array of ISourceLocations and converts it to a map of type `map[loc, loc]`
+     */
+    private static IMap locArrayToMapLocLoc(ISourceLocation[][] mapping) {
+        var vf = ValueFactoryFactory.getValueFactory();
+        return Stream.of(mapping).map(e -> vf.tuple(e[0], e[1])).collect(vf.mapWriter());
+    }
+}

--- a/src/org/rascalmpl/ideservices/jsonrpc/StartDebuggingSessionRequest.java
+++ b/src/org/rascalmpl/ideservices/jsonrpc/StartDebuggingSessionRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.ideservices.jsonrpc;
+
+import java.util.Objects;
+
+public class StartDebuggingSessionRequest {
+    private final int serverPort;
+
+    public StartDebuggingSessionRequest(int serverPort) {
+        this.serverPort = serverPort;
+    }
+
+    public int getServerPort() {
+        return serverPort;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof StartDebuggingSessionRequest && serverPort == ((StartDebuggingSessionRequest) obj).serverPort;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serverPort);
+    }
+}

--- a/src/org/rascalmpl/ideservices/jsonrpc/UnregisterDiagnosticsRequest.java
+++ b/src/org/rascalmpl/ideservices/jsonrpc/UnregisterDiagnosticsRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.ideservices.jsonrpc;
+
+import java.util.Arrays;
+
+import io.usethesource.vallang.IList;
+import io.usethesource.vallang.ISourceLocation;
+
+public class UnregisterDiagnosticsRequest {
+    private final ISourceLocation[] locs;
+
+    public UnregisterDiagnosticsRequest(IList locs) {
+        this.locs = locs.stream().map(ISourceLocation.class::cast).toArray(ISourceLocation[]::new);
+    }
+
+    public ISourceLocation[] getLocations() {
+        return locs;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof UnregisterDiagnosticsRequest && Arrays.deepEquals(locs, ((UnregisterDiagnosticsRequest) obj).locs);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Arrays.deepHashCode(locs);
+    }
+}


### PR DESCRIPTION
This PR introduces container classes for arguments of remote IDEServices calls. This enables forward and backward compatibility, should the API change in the future