### PR TITLE
The key in ModuleMessages is now always a physical location

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc
@@ -587,7 +587,7 @@ list[ModuleMessages] check(list[loc] moduleLocs, RascalCompilerConfig compilerCo
 list[ModuleMessages] reportModuleMessages(ModuleStatus ms){
     moduleIds = domain(ms.moduleLocs);
     messagesNoModule = {*ms.messages[mid] | MODID mid <- ms.messages, (mid notin moduleIds || mid notin ms.moduleLocs)} + toSet(ms.pathConfig.messages);
-    msgs = [ program(mid, (ms.messages[mid] ? {}) + messagesNoModule) | MODID mid <- moduleIds ];
+    msgs = [ program(ms.moduleLocs[mid], (ms.messages[mid] ? {}) + messagesNoModule) | MODID mid <- moduleIds ];
     if(isEmpty(msgs) && !isEmpty(messagesNoModule)){
         msgs = [ program(|unknown:///|, messagesNoModule) ];
     }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/compile/Examples/A.rsc
@@ -26,4 +26,6 @@ POSSIBILITY OF SUCH DAMAGE.
 }
 module  lang::rascalcore::compile::Examples::A
  
-extend   lang::rascalcore::compile::Examples::B;                
+data X1 = z();
+// anno int X1@xz;
+// int doY(X1 x) = x@xz;        


### PR DESCRIPTION
Fixes https://github.com/usethesource/rascal-language-servers/issues/1108