### PR TITLE
Fixed incorrect rewriting of  m_imports[imp]? 

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
@@ -389,7 +389,7 @@ tuple[map[MODID,TModel], ModuleStatus] prepareForCompilation(set[MODID] componen
             if(hasProperty(imp, ms, parse_error()) || hasNotProperty(imp, ms, checked())){
                 dependencies_ok = false;
                 cause = hasProperty(imp, ms, rsc_not_found()) ? "module not found" : "due to syntax error";
-                ms.messages[m] = (ms.messages[imp] ? {}) + error("<imp in m_imports[imp] ? "Imported" : "Extended"> module <imp> could not be checked (<cause>)", m);
+                ms.messages[m] = (ms.messages[imp] ? {}) + error("<imp in m_imports ? "Imported" : "Extended"> module <imp> could not be checked (<cause>)", m);
             }
         }
         if(!dependencies_ok){


### PR DESCRIPTION
Fixed incorrect rewtiting of m_imports[imp]? 
Initial: m_imports[imp]? 
Incorrect:  imp in m_imports[imp]
Correct:  imp in m_imports

Note: accidentally code remains type correct