### PR TITLE
More precise use-defs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,7 +458,7 @@
         <dependency>
             <groupId>org.rascalmpl</groupId>
             <artifactId>typepal</artifactId>
-            <version>0.17.0-BOOT2</version>
+            <version>0.17.0-RC3</version>
            <!-- <scope>provided</scope> for shade plugin it can't be provided. At least the rascal dependency in typepal should be provided -->
            <scope>compile</scope>
         </dependency>

--- a/src/org/rascalmpl/compiler/lang/rascalcore/agrammar/definition/Symbols.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/agrammar/definition/Symbols.rsc
@@ -133,6 +133,16 @@ public AType defsym2AType(Sym sym, SyntaxRole sr) {
   }
 }
 
+public Tree defsym2IdTree(Sym sym) = top-down-break visit (sym) {
+  case lang::rascal::\syntax::Rascal::nonterminal(Nonterminal n): return n;
+  case \parametrized(Nonterminal n, _): return n;
+  case \start(Nonterminal n): return n;
+  default: {
+    iprintln(sym);
+    throw "defsym2IdTree, missed a case <sym>";
+  }
+};
+
 public list[AType] args2ATypes(Sym* args) {
   return [sym2AType(s) | Sym s <- args];
 }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDataDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDataDeclaration.rsc
@@ -72,7 +72,7 @@ void dataDeclaration(Tags tags, Declaration current, list[Variant] variants, Col
     dt.md5 = normalizedMD5Hash(adtName, dataCounter);
     dataCounter += 1;
     if(!isEmpty(commonKeywordParameterList)) dt.commonKeywordFields = commonKeywordParameterList;
-    c.define("<userType.name>", dataId(), current, dt);
+    c.define(userType.name, dataId(), current, dt);
        
     adtParentScope = c.getScope();
     c.enterScope(current);
@@ -142,7 +142,7 @@ void collect(current:(Variant) `<Name name> ( <{TypeArg ","}* arguments> <Keywor
                 fieldType = ta.\type;
                 dt = defType([fieldType], makeFieldType(fieldName, fieldType));
                 dt.md5 = normalizedMD5Hash(currentModuleName, adtName, name, current);
-                c.define("<ta.name>", fieldId(), ta.name, dt);
+                c.define(ta.name, fieldId(), ta.name, dt);
             }
         }
         
@@ -153,13 +153,13 @@ void collect(current:(Variant) `<Name name> ( <{TypeArg ","}* arguments> <Keywor
             kwfType = kwf.\type;
             dt = defType([kwfType], makeKeywordFieldType(fieldName, kwf));
             dt.md5 = normalizedMD5Hash(currentModuleName, adtName, dataCounter, name, consArity, kwfType, fieldName);
-            c.define("<kwf.name>", keywordFieldId(), kwf.name, dt);  
+            c.define(kwf.name, keywordFieldId(), kwf.name, dt);  
         }
     
         scope = c.getScope();
         c.enterScope(current);
             args = "<for(arg <- arguments){><arg is named ? "<arg.\type> <arg.name>" : "<arg>"> <}>";
-            c.defineInScope(adtParentScope, "<name>", constructorId(), name, defType(adt + formals + kwFormals + commonKwFormals,
+            c.defineInScope(adtParentScope, name, constructorId(), name, defType(adt + formals + kwFormals + commonKwFormals,
                 AType(Solver s){
                     adtType = s.getType(adt);
                     kwFormalTypes = [kwField(s.getType(kwf.\type)[alabel=prettyPrintName(kwf.name)], prettyPrintName(kwf.name), currentModuleName, kwf.expression) | kwf <- kwFormals /*+ commonKwFormals*/];

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectDeclaration.rsc
@@ -92,7 +92,7 @@ void collect(Module current, Collector c){
     if(deprecated){
         c.report(warning(header.name, "Deprecated module %v%v", mname, isEmpty(deprecationMessage) ? "" : ": <deprecationMessage>"));
     }
-    c.define("<header.name>", moduleId(), current, defType(tmod));
+    c.define(header.name, moduleId(), current, defType(tmod));
 
     c.push(key_current_module, mname);
     c.enterScope(current);
@@ -192,7 +192,7 @@ void collect(current: (Declaration) `<Tags tags> <Visibility visibility> <Type v
             if(isWildCard(vname)){
                 c.report(warning(var, "Variable names starting with `_` are deprecated; only allowed to suppress warning on unused variables"));
             }
-            c.defineInScope(scope, "<var.name>", moduleVariableId(), var.name, dt);
+            c.defineInScope(scope, var.name, moduleVariableId(), var.name, dt);
 
             if(var is initialized){
                 initial = var.initial;
@@ -238,7 +238,7 @@ void collect(current: (Declaration) `<Tags tags> <Visibility visibility> anno <T
     // if(isWildCard(pname)){
     //     c.report(error(name, "Annotation names starting with `_` are deprecated; only allowed to suppress warning on unused variables"));
     // }
-    c.define("<name>", annoId(), current, dt);
+    c.define(name, annoId(), current, dt);
     collect(tags, annoType, onType, c);
 }
 
@@ -253,7 +253,7 @@ void collect(current: (KeywordFormal) `<Type kwType> <Name name> = <Expression e
          dt = defType([kwType], makeFieldType(kwformalName, kwType));
     }
     dt.md5 = normalizedMD5Hash(current);
-    c.define("<name>", keywordFormalId(), current, dt);
+    c.define(name, keywordFormalId(), current, dt);
     c.calculate("keyword formal", current, [kwType, expression],
         AType(Solver s){
             expType = s.getType(expression);
@@ -432,7 +432,7 @@ void collect(current: (FunctionDeclaration) `<FunctionDeclaration decl>`, Collec
         endUseBoundedTypeParameters(c);
 
         dt.md5 = normalizedMD5Hash(md5Contrib);
-        c.defineInScope(parentScope, "<fname>", functionId(), current, dt);
+        c.defineInScope(parentScope, fname, functionId(), current, dt);
     c.leaveScope(decl);
     c.pop(currentFunction);
     if(isEmpty(fstk)){
@@ -617,7 +617,7 @@ private tuple[set[str], rel[str,Type]] computeBoundsAndDefineTypeParams(Signatur
             c.fact(tp, tp.name);
         } else {
             seenInParams += tpname;
-            c.define("<tp.name>", typeVarId(), tp.name,
+            c.define(tp.name, typeVarId(), tp.name,
                 defType(toList(typeParamBounds[tpname]), makeBoundDef(tp, typeParamBounds, closed=false)));
             c.fact(tp, tp.name);
         }
@@ -761,7 +761,7 @@ void collect (current: (Declaration) `<Tags tags> <Visibility visibility> alias 
     //     c.report(warning(name, "Alias names starting with `_` are deprecated; only allowed to suppress warning on unused variables"));
     // }
 
-    c.define("<name>", aliasId(), current, defType([base], AType(Solver s) { return s.getType(base); })[md5 = normalizedMD5Hash(md5Contrib4Tags(tags), visibility, name, base)]);
+    c.define(name, aliasId(), current, defType([base], AType(Solver s) { return s.getType(base); })[md5 = normalizedMD5Hash(md5Contrib4Tags(tags), visibility, name, base)]);
     c.enterScope(current);
         collect(tags, base, c);
     c.leaveScope(current);
@@ -785,7 +785,7 @@ void collect (current: (Declaration) `<Tags tags> <Visibility visibility> alias 
         append tp.typeVar;
     }
 
-    c.define("<name>", aliasId(), name, defType(typeParams + base, AType(Solver s){
+    c.define(name, aliasId(), name, defType(typeParams + base, AType(Solver s){
         bindings = ();
         params = for(int i <- index(typeParams)){
             ptype = s.getType(typeParams[i]);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectLiteral.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectLiteral.rsc
@@ -98,7 +98,7 @@ void collect(current: (ConcreteHole) `\< <Sym symbol> <Name name> \>`, Collector
               c.useLub(name, {formalOrPatternFormal(c)});
            } else {
                c.push(patternNames, uname);
-               c.define("<name>", formalOrPatternFormal(c), name, defLub([symbol], AType(Solver s) { return s.getType(symbol); }));
+               c.define(name, formalOrPatternFormal(c), name, defLub([symbol], AType(Solver s) { return s.getType(symbol); }));
            }
         }
     }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectOperators.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectOperators.rsc
@@ -620,7 +620,7 @@ void collect(current: (Expression) `<Pattern pat> \<- <Expression expression>`, 
             } else  
                 throw TypeUnavailable();
           
-            c.define("<name>", formalOrPatternFormal(c), name, defType(patType));
+            c.define(name, formalOrPatternFormal(c), name, defType(patType));
             c.fact(pat, patType);
             c.fact(current, abool());
             return;  

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
@@ -50,7 +50,7 @@ void collect(RegExp regExp, Collector c){
     if( (RegExp)`\<<Name name>\>` := regExp){
         c.use(name, variableRoles);
     } else if ((RegExp)`\<<Name name>:<NamedRegExp* regexps>\>` := regExp){
-        c.define("<name>", formalOrPatternFormal(c), name, defType(astr()));
+        c.define(name, formalOrPatternFormal(c), name, defType(astr()));
         collect(name, regexps, c);
     }
     c.fact(regExp, astr());
@@ -109,7 +109,7 @@ void collect(current: (Pattern) `<Type tp> <Name name>`, Collector c){
                 }
             }
        }
-       c.define("<name>", formalOrPatternFormal(c), name, defType(tp));
+       c.define(name, formalOrPatternFormal(c), name, defType(tp));
     } else {
         c.fact(name, tp);
         //c.calculate("variable <name>", name, [tp], AType(Solver s) { return s.getType(tp); });
@@ -129,7 +129,7 @@ void collectAsVarArg(current: (Pattern) `<Type tp> <Name name>`, Collector c){
             });
        } else {
           c.push(patternNames, <uname, getLoc(name)>);
-          c.define("<name>", formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ 
+          c.define(name, formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ 
             res = alist(s.getType(tp))[alabel=uname];
             return res;
              }));
@@ -158,7 +158,7 @@ void collect(current: (Pattern) `<QualifiedName name>`,  Collector c){
        if(!isEmpty(qualifier)) c.report(error(name, "Qualifier not allowed"));
        if(isTopLevelParameter(c)){
           c.fact(current, avalue(alabel=unescape(prettyPrintBaseName(name))));  
-          c.define("<name.names[-1]>", formalId(), name, defLub([], AType(Solver _) { return avalue(alabel=unescape(prettyPrintBaseName(name))); }));
+          c.define(name.names[-1], formalId(), name, defLub([], AType(Solver _) { return avalue(alabel=unescape(prettyPrintBaseName(name))); }));
        } else {
           if(c.isAlreadyDefined(base, name)){
             c.use(name, {variableId(), moduleVariableId(), formalId(), nestedFormalId(), patternVariableId(), constructorId()});
@@ -166,7 +166,7 @@ void collect(current: (Pattern) `<QualifiedName name>`,  Collector c){
           } else {
             tau = c.newTypeVar(name);
             c.fact(name, tau); //<====
-            c.define("<name.names[-1]>", formalOrPatternFormal(c), name, defLub([], AType(Solver s) { 
+            c.define(name.names[-1], formalOrPatternFormal(c), name, defLub([], AType(Solver s) { 
                 return s.getType(tau)[alabel=unescape(prettyPrintBaseName(name))]; 
             }));
           }
@@ -223,7 +223,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
             }
           }   
           
-          c.define("<argName>", formalOrPatternFormal(c), argName, defType([tp], 
+          c.define(argName, formalOrPatternFormal(c), argName, defType([tp], 
                AType(Solver s){ return inSet ? aset(s.getType(tp)) : alist(s.getType(tp)); }));     
        } else {
           c.calculate("typed anonymous variable in splice pattern", argName, [tp], 
@@ -246,7 +246,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
            if(isTopLevelParameter(c)){
               c.fact(current, avalue());
               if(!isEmpty(qualifier)) c.report(error(argName, "Qualifier not allowed"));
-              c.define("<argName.names[-1]>", formalId(), argName, defLub([], AType(Solver _) { return avalue(); }));
+              c.define(argName.names[-1], formalId(), argName, defLub([], AType(Solver _) { return avalue(); }));
            } else {
               if(c.isAlreadyDefined("<argName>", argName)) {
                   c.use(argName, {variableId(), moduleVariableId(), formalId(), nestedFormalId(), patternVariableId()});
@@ -255,7 +255,7 @@ void collectSplicePattern(Pattern current, Pattern argument,  Collector c){
                   tau = c.newTypeVar(current); // <== argName;
                   c.fact(current, tau);    // <===
                   if(!isEmpty(qualifier)) c.report(error(argName, "Qualifier not allowed"));
-                  c.define("<argName.names[-1]>", formalOrPatternFormal(c), argName, 
+                  c.define(argName.names[-1], formalOrPatternFormal(c), argName, 
                             defLub([], AType(Solver s) { 
                             return inSet ? makeSetType(s.getType(tau)) : makeListType(s.getType(tau));}));
               }
@@ -320,7 +320,7 @@ void collect(current: (Pattern) `<Name name> : <Pattern pattern>`, Collector c){
     } else {
         c.push(patternNames, <uname, getLoc(name)>);
         scope = c.getScope();
-        c.define("<name>", formalOrPatternFormal(c), name, 
+        c.define(name, formalOrPatternFormal(c), name, 
                  defLub([pattern], AType(Solver s) { 
                     try{
                         return s.getType(pattern);
@@ -349,7 +349,7 @@ void collect(current: (Pattern) `<Type tp> <Name name> : <Pattern pattern>`, Col
                 }
             }
         }   
-        c.define("<name>", formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ return s.getType(tp); }));
+        c.define(name, formalOrPatternFormal(c), name, defType([tp], AType(Solver s){ return s.getType(tp); }));
     }
 }
 

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectStatement.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectStatement.rsc
@@ -87,7 +87,7 @@ void collect(current: (Statement) `<Label label> <Visit vst>`, Collector c){
         scope = c.getScope();
         c.setScopeInfo(scope, visitOrSwitchScope(), visitOrSwitchInfo(vst.subject, true));
         if(label is \default){
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(label.name, labelId(), label.name, defType(avoid()));
         }
         c.require("non-void", vst.subject, [], makeNonVoidRequirement(vst.subject, "Subject of visit"));
         c.fact(current, vst.subject);
@@ -115,7 +115,7 @@ void collect(current: (Expression) `<Label label> <Visit vst>`, Collector c){
         scope = c.getScope();
         c.setScopeInfo(scope, visitOrSwitchScope(), visitOrSwitchInfo(vst.subject, true));
         if(label is \default){
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(label.name, labelId(), label.name, defType(avoid()));
         }
         c.calculate("visit", current, [vst.subject],
             AType(Solver s){
@@ -293,7 +293,7 @@ void collect(current: (Statement) `<Label label> while( <{Expression ","}+ condi
         loopName = "";
         if(label is \default){
             loopName = prettyPrintName(label.name);
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(label.name, labelId(), label.name, defType(avoid()));
         }
         c.setScopeInfo(c.getScope(), loopScope(), loopInfo(loopName, [])); // record appends in body, initially []
         condList = [cond | Expression cond <- conditions];
@@ -339,7 +339,7 @@ void collect(current: (Statement) `<Label label> do <Statement body> while ( <Ex
         loopName = "";
         if(label is \default){
             loopName = prettyPrintName(label.name);
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(label.name, labelId(), label.name, defType(avoid()));
         }
         c.setScopeInfo(c.getScope(), loopScope(), loopInfo(loopName, [])); // appends in body
         c.require("do statement", current, [body, condition], void (Solver s){ checkConditions([condition], s); });
@@ -361,7 +361,7 @@ void collect(current: (Statement) `<Label label> for( <{Expression ","}+ conditi
         loopName = "";
         if(label is \default){
             loopName = prettyPrintName(label.name);
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(label.name, labelId(), label.name, defType(avoid()));
         }
         c.setScopeInfo(c.getScope(), loopScope(), loopInfo(loopName, [])); // appends in body
         condList = [cond | Expression cond <- conditions];
@@ -453,7 +453,7 @@ void collect(current:(Statement) `continue <Target target>;`, Collector c){
 void collect(current: (Statement) `<Label label> if( <{Expression ","}+ conditions> ) <Statement thenPart>`,  Collector c){
     c.enterCompositeScope([conditions, thenPart]); // thenPart may refer to variables defined in conditions
         if(label is \default){
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(label.name, labelId(), label.name, defType(avoid()));
         }
         condList = [cond | Expression cond <- conditions];
         c.fact(current, avalue());
@@ -472,7 +472,7 @@ void collect(current: (Statement) `<Label label> if( <{Expression ","}+ conditio
 void collect(current: (Statement) `<Label label> if( <{Expression ","}+ conditions> ) <Statement thenPart> else <Statement elsePart>`,  Collector c){
     c.enterCompositeScope([conditions, thenPart]);   // thenPart may refer to variables defined in conditions; elsePart may not
         if(label is \default){
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(label.name, labelId(), label.name, defType(avoid()));
         }
         condList = [cond | cond <- conditions];
 
@@ -495,7 +495,7 @@ void collect(current: (Statement) `<Label label> if( <{Expression ","}+ conditio
 void collect(current: (Statement) `<Label label> switch ( <Expression e> ) { <Case+ cases> }`, Collector c){
     c.enterScope(current);
         if(label is \default){
-            c.define("<label.name>", labelId(), label.name, defType(avoid()));
+            c.define(label.name, labelId(), label.name, defType(avoid()));
         }
         scope = c.getScope();
         c.setScopeInfo(scope, visitOrSwitchScope(), visitOrSwitchInfo(e, false));
@@ -605,7 +605,7 @@ void collect(current: (Catch) `catch <Pattern pattern>: <Statement body>`, Colle
 void collect(current: (Statement) `<Label label> { <Statement+ statements> }`, Collector c){
     c.enterScope(current);
         if(label is \default){
-           c.define("<label.name>", labelId(), label.name, defType(avoid()));
+           c.define(label.name, labelId(), label.name, defType(avoid()));
         }
         stats = [ s | Statement s <- statements ];
         c.calculate("non-empty block statement", current, [stats[-1]],  AType(Solver s) { return s.getType(stats[-1]); } );
@@ -723,7 +723,7 @@ private void checkAssignment(Statement current, (Assignable) `<QualifiedName nam
             if(c.isAlreadyDefined("<name>", name)){
                 c.use(name, variableRoles);
             } else {
-                c.define("<name.names[-1]>", variableId(), name, defLub([statement],
+                c.define(name.names[-1], variableId(), name, defLub([statement],
                     AType(Solver s){
                         // TODO: this seemingly redundant call is needed; suspicion: the interpreter does not
                         // handle the combination of return and possible exception thrown by s.getType properly
@@ -736,7 +736,7 @@ private void checkAssignment(Statement current, (Assignable) `<QualifiedName nam
              if(c.isAlreadyDefined("<name>", name)){
                 c.use(name, variableRoles);
             } else {
-                c.define("<name.names[-1]>", variableId(), name, defLub([statement, name],  AType(Solver s){
+                c.define(name.names[-1], variableId(), name, defLub([statement, name],  AType(Solver s){
                     return computeAssignmentRhsType(statement, s.getType(name), operator, s.getType(statement), s);
                 }));
             }
@@ -1104,7 +1104,7 @@ private void checkAssignment(Statement current, receiver: (Assignable) `\< <{Ass
    elms = [elm | elm <- elements];
    namesInRhs = getNames(rhs);
    taus = [c.newTypeVar(nm) | nm <- names];
-   for(int i <- index(names), flatNames[i] notin namesInRhs){c.define("<names[i]>", variableId(), names[i], defLub([rhs], makeDef(i)));}
+   for(int i <- index(names), flatNames[i] notin namesInRhs){c.define(names[i], variableId(), names[i], defLub([rhs], makeDef(i)));}
 
    for(name <- names) c.useLub(name, variableRoles);
 
@@ -1217,7 +1217,7 @@ void collect(current: (Statement) `<Type varType> <{Variable ","}+ variables>;`,
     scope = c.getScope();
     c.enterScope(current); // wrap in extra scope to isolate variables declared in complex (function) types
         for(var <- variables){
-            c.defineInScope(scope, "<var.name>", variableId(), var.name, defType([varType], makeGetSyntaxType(varType)));
+            c.defineInScope(scope, var.name, variableId(), var.name, defType([varType], makeGetSyntaxType(varType)));
 
             if(var is initialized){
                 initial = var.initial;

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectSyntaxDeclaration.rsc
@@ -82,7 +82,7 @@ void declareSyntax(SyntaxDefinition current, SyntaxRole syntaxRole, IdRole idRol
         syndefCounter += 1;
 
         // Define the syntax symbol itself and all labelled alternatives as constructors
-        c.define(nonterminalType.adtName, idRole, current, dt);
+        c.define(defsym2IdTree(defined), idRole, current, dt);
 
         adtParentScope = c.getScope();
         c.enterScope(current);
@@ -181,7 +181,7 @@ void collect(current: (Prod) `<ProdModifier* modifiers> <Name name> : <Sym* syms
         qualName = "<SyntaxDefinition sd := adt ? sd.defined.nonterminal : "???">_<uname>";
 
          // Define the constructor
-        c.defineInScope(adtParentScope, "<name>", constructorId(), name, defType([current],
+        c.defineInScope(adtParentScope, name, constructorId(), name, defType([current],
             AType(Solver s){
                 ptype = s.getType(current);
                 if(aprod(AProduction cprod) := ptype){

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectType.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectType.rsc
@@ -518,7 +518,7 @@ void collect(current:(Sym) `& <Nonterminal n>`, Collector c){
             c.use(n, {typeVarId() });
             //println("Use <pname> at <current@\loc>");
         } else {
-            c.define("<n>", typeVarId(), n, defType(aparameter(pname,treeType, closed=closed)));
+            c.define(n, typeVarId(), n, defType(aparameter(pname,treeType, closed=closed)));
             //println("Define <pname> at <current@\loc>");
         }
         c.fact(current, n);
@@ -575,7 +575,7 @@ void collect(current:(Sym) `<Sym symbol> <NonterminalLabel n>`, Collector c){
     //   * either it is a Nonterminal name and the rule for Nonterminal covers this requirement
     //   * or it is a more complex Sym which are non-terminals by definition
 
-    c.define("<n>", fieldId(), n, defType([symbol],
+    c.define(n, fieldId(), n, defType([symbol],
         AType(Solver s){
             res = s.getType(symbol)[alabel=un];
           return res;
@@ -815,7 +815,7 @@ void collect(current:(TypeVar) `& <Name n>`, Collector c){
             } else {
                 throw "collect TypeVar: currentAdt not found";
             }
-            c.define("<n>", typeVarId(), n, defType(aparameter(pname, bound, closed=closed)));
+            c.define(n, typeVarId(), n, defType(aparameter(pname, bound, closed=closed)));
         }
         c.calculate("type parameter without bound", current, [n], AType (Solver s) { return s.getType(n)[closed=closed]; });
         return;
@@ -853,7 +853,7 @@ void collect(current: (TypeVar) `& <Name n> \<: <Type tp>`, Collector c){
             c.use(n, {typeVarId() });
             //if(debugTP)println("Use <pname> at <current@\loc>");
         } else {
-            c.define("<n>", typeVarId(), n, defTypeCall([getLoc(tp)], AType(Solver s) {return aparameter(pname,s.getType(tp), closed=closed); }));
+            c.define(n, typeVarId(), n, defTypeCall([getLoc(tp)], AType(Solver s) {return aparameter(pname,s.getType(tp), closed=closed); }));
             //if(debugTP)println("Define <pname> at <current@\loc>");
         }
         c.calculate("type parameter, 1", current, [n, tp], AType (Solver s) { return s.getType(n)[closed=closed]; });

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/Import.rsc
@@ -508,6 +508,8 @@ ModuleStatus doSaveModule(set[MODID] component, map[MODID,set[MODID]] m_imports,
         m1.defines = toSet(defs);
 
         m1.definitions = ( def.defined : def | Define def <- m1.defines);  // TODO this is derived info, can we derive it later?
+        m1.define2id = tm.define2id;
+        
         // Remove default expressions and fragments
         m1 = visit(m1) {
                     case kwField(AType atype, str fieldName, str definingModule, Expression _defaultExp) => kwField(atype, fieldName, definingModule)

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/StaticTestingUtils.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/StaticTestingUtils.rsc
@@ -248,9 +248,7 @@ bool validateUseDefs(str moduleName, map[str, tuple[int, set[int]]] defuses, Mod
 				throw "Missing use <u> for <v>";
 			}
 			potentialDefs = foundUseDefs[occ[u]];
-			// We us containement here, give how the type chcker works at the moment.
-			// An equality test would be better.
-			if(isEmpty(potentialDefs) || !any(d <- potentialDefs, isContainedIn(occ[def], d, tm.logical2physical))){
+			if(isEmpty(potentialDefs) || !any(d <- potentialDefs, occ[def] == (tm.logical2physical[d] ? d))){
 				throw "Missing def for use <u> of <v>";
 			}
 		 }

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/UseDefTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/UseDefTests.rsc
@@ -77,6 +77,12 @@ test bool kwfield1() =
                 }",
                 ("n": <0, {1, 2}>)); 
 
+test bool \syntax() =
+    useDefOK("module Syntax
+                syntax C = \"c\";
+                syntax D = C;",
+                ("C": <0, {1}>));
+
 test bool syntaxField1() =
     useDefOK("module SyntaxField
                 syntax C = \"c\";


### PR DESCRIPTION
This PR updates `define` and `defineInScope` calls based on usethesource/typepal#48 in the Rascal typechecker to compute more precise use-def relations. Due to earlier preparatory work in #2770, essentially the only changes of this PR are rewrites of the form: `define("<tree>", ...)` -> `define(tree, ...)`. 

The integration test [succeeds](https://github.com/usethesource/rascal-core-big-tests/actions/runs/27285242398/attempts/3) (in combination with companion PR usethesource/rascal-language-servers#1113).