### PR TITLE
Only return external output resolver if the input resolver also goes to the external

### DIFF
--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -506,7 +506,11 @@ public class URIResolverRegistry {
 					return result;
 				}
 			}
-			if (externalRegistry != null && externalRegistry.supportsOutput(scheme)) {
+			// only return an external registry if the input is also going to an external resolver
+			// as input resolvers are quite common, but output less, and we don't want all of them
+			// to always go via the external registries (just to receive an exception)
+			var inputResolver = getInputResolver(scheme);
+			if (externalRegistry != null && externalRegistry.supportsOutput(scheme) && inputResolver == externalRegistry) {
 				return externalRegistry;
 			}
 		}


### PR DESCRIPTION
This would lead to subtle bugs with write functions failing in ways that aren't expected. 