### PR TITLE
Make sure unknown URIs quickly throw an error instead of first going towards the remote registry

### DIFF
--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -78,7 +78,6 @@ public class URIResolverRegistry {
 		loadServices();
 	}
 
-
 	/**
 	 * Use with care! This (expensive) reinitialization method clears all caches of all resolvers by
 	 * reloading them from scratch.
@@ -463,6 +462,9 @@ public class URIResolverRegistry {
 	private static final Pattern splitScheme = Pattern.compile("^([^\\+]*)\\+");
 
 	private ISourceLocationInput getInputResolver(String scheme) {
+		if (scheme.equals(URIUtil.unknownLocation().getScheme())) {
+			return null;
+		}
 		ISourceLocationInput result = inputResolvers.get(scheme);
 		if (result == null) {
 			Matcher m = splitScheme.matcher(scheme);
@@ -481,6 +483,9 @@ public class URIResolverRegistry {
 	}
 
 	private IClassloaderLocationResolver getClassloaderResolver(String scheme) {
+		if (scheme.equals(URIUtil.unknownLocation().getScheme())) {
+			return null;
+		}
 		IClassloaderLocationResolver result = classloaderResolvers.get(scheme);
 		if (result == null) {
 			Matcher m = splitScheme.matcher(scheme);
@@ -496,6 +501,9 @@ public class URIResolverRegistry {
 	}
 
 	private ISourceLocationOutput getOutputResolver(String scheme) {
+		if (scheme.equals(URIUtil.unknownLocation().getScheme())) {
+			return null;
+		}
 		ISourceLocationOutput result = outputResolvers.get(scheme);
 		if (result == null) {
 			Matcher m = splitScheme.matcher(scheme);

--- a/src/org/rascalmpl/uri/URIResolverRegistry.java
+++ b/src/org/rascalmpl/uri/URIResolverRegistry.java
@@ -462,9 +462,6 @@ public class URIResolverRegistry {
 	private static final Pattern splitScheme = Pattern.compile("^([^\\+]*)\\+");
 
 	private ISourceLocationInput getInputResolver(String scheme) {
-		if (scheme.equals(URIUtil.unknownLocation().getScheme())) {
-			return null;
-		}
 		ISourceLocationInput result = inputResolvers.get(scheme);
 		if (result == null) {
 			Matcher m = splitScheme.matcher(scheme);
@@ -483,9 +480,6 @@ public class URIResolverRegistry {
 	}
 
 	private IClassloaderLocationResolver getClassloaderResolver(String scheme) {
-		if (scheme.equals(URIUtil.unknownLocation().getScheme())) {
-			return null;
-		}
 		IClassloaderLocationResolver result = classloaderResolvers.get(scheme);
 		if (result == null) {
 			Matcher m = splitScheme.matcher(scheme);
@@ -501,9 +495,6 @@ public class URIResolverRegistry {
 	}
 
 	private ISourceLocationOutput getOutputResolver(String scheme) {
-		if (scheme.equals(URIUtil.unknownLocation().getScheme())) {
-			return null;
-		}
 		ISourceLocationOutput result = outputResolvers.get(scheme);
 		if (result == null) {
 			Matcher m = splitScheme.matcher(scheme);

--- a/src/org/rascalmpl/uri/URIUtil.java
+++ b/src/org/rascalmpl/uri/URIUtil.java
@@ -508,8 +508,4 @@ public class URIUtil {
 
 		return URIUtil.changePath(location, path);
     }
-	
-    public static URI invalidURI() {
-        return rootScheme("invalid");
-    }
 }

--- a/src/org/rascalmpl/uri/resolvers.config
+++ b/src/org/rascalmpl/uri/resolvers.config
@@ -14,4 +14,6 @@ org.rascalmpl.uri.file.CurrentWorkingDriveResolver
 org.rascalmpl.uri.file.UNCResolver
 org.rascalmpl.uri.file.SystemPathURIResolver
 org.rascalmpl.uri.libraries.MemoryResolver
+org.rascalmpl.uri.unsupported.UnknownURIResolver
+org.rascalmpl.uri.unsupported.LibraryURIResolver
 

--- a/src/org/rascalmpl/uri/unsupported/LibraryURIResolver.java
+++ b/src/org/rascalmpl/uri/unsupported/LibraryURIResolver.java
@@ -1,0 +1,7 @@
+package org.rascalmpl.uri.unsupported;
+
+public class LibraryURIResolver extends UnsupportedURIResolver {
+    public LibraryURIResolver() {
+        super("lib", "The lib scheme has been removed, please rewrite to mvn scheme or use getResource");
+    }
+}

--- a/src/org/rascalmpl/uri/unsupported/UnknownURIResolver.java
+++ b/src/org/rascalmpl/uri/unsupported/UnknownURIResolver.java
@@ -1,0 +1,9 @@
+package org.rascalmpl.uri.unsupported;
+
+import org.rascalmpl.uri.URIUtil;
+
+public class UnknownURIResolver extends UnsupportedURIResolver {
+    public UnknownURIResolver() {
+        super(URIUtil.unknownLocation().getScheme(), "The unknown scheme cannot be read/written to, it indicates someone didn't know the location");
+    }
+}

--- a/src/org/rascalmpl/uri/unsupported/UnsupportedURIResolver.java
+++ b/src/org/rascalmpl/uri/unsupported/UnsupportedURIResolver.java
@@ -1,0 +1,125 @@
+package org.rascalmpl.uri.unsupported;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.function.Consumer;
+
+import org.rascalmpl.uri.FileAttributes;
+import org.rascalmpl.uri.ISourceLocationInputOutput;
+import org.rascalmpl.uri.ISourceLocationWatcher;
+
+import io.usethesource.vallang.ISourceLocation;
+
+abstract class UnsupportedURIResolver implements ISourceLocationInputOutput, ISourceLocationWatcher {
+
+    private final String scheme;
+    private final String message;
+
+    protected UnsupportedURIResolver(String scheme, String message) {
+        this.scheme = scheme;
+        this.message = message;
+    }
+
+    private IOException buildException() {
+        return new IOException(message);
+    }
+
+    @Override
+    public InputStream getInputStream(ISourceLocation uri) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public boolean exists(ISourceLocation uri) {
+        return false;
+    }
+
+    @Override
+    public long lastModified(ISourceLocation uri) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public long size(ISourceLocation uri) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public boolean isDirectory(ISourceLocation uri) {
+        return false;
+    }
+
+    @Override
+    public boolean isFile(ISourceLocation uri) {
+        return false;
+    }
+
+    @Override
+    public boolean isReadable(ISourceLocation uri) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public String[] list(ISourceLocation uri) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public String scheme() {
+        return this.scheme;
+    }
+
+    @Override
+    public boolean supportsHost() {
+        return false;
+    }
+
+    @Override
+    public FileAttributes stat(ISourceLocation uri) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public OutputStream getOutputStream(ISourceLocation uri, boolean append) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public void mkDirectory(ISourceLocation uri) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public void remove(ISourceLocation uri) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public void setLastModified(ISourceLocation uri, long timestamp) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public boolean isWritable(ISourceLocation uri) throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public void watch(ISourceLocation root, Consumer<ISourceLocationChanged> watcher, boolean recursive)
+        throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public void unwatch(ISourceLocation root, Consumer<ISourceLocationChanged> watcher, boolean recursive)
+        throws IOException {
+        throw buildException();
+    }
+
+    @Override
+    public boolean supportsRecursiveWatch() {
+        return false;
+    }
+    
+}

--- a/test/org/rascalmpl/test/repl/JlineParserTest.java
+++ b/test/org/rascalmpl/test/repl/JlineParserTest.java
@@ -16,7 +16,7 @@ public class JlineParserTest {
     }
 
     private ParsedLine completeParser(String input, int cursor) {
-        var parser = new RascalLineParser(l -> { throw new ParseError("rascal parser not supported in the test yet", URIUtil.invalidURI(), 0, 0, 0, 0, 0, 0); });
+        var parser = new RascalLineParser(l -> { throw new ParseError("rascal parser not supported in the test yet", URIUtil.unknownLocation().getURI(), 0, 0, 0, 0, 0, 0); });
 
         return parser.parse(input, cursor, ParseContext.COMPLETE);
     }


### PR DESCRIPTION
As they would right now fall-back to the external resolver, but in reality we've marked them as invalid, so they should never have successful IO results

I've also removed an old overload in the URI resolver that shouldn't be used anymore (and was only used by a single test).