### PR TITLE
Package stdlib locations as `mvn://`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,6 @@
                             <srcs>
                                 <src>${project.basedir}/src/org/rascalmpl/library</src>
                             </srcs>
-                            <sourceLookup>|std:///|</sourceLookup>
                         </configuration>
                     </execution> 
                 </executions>


### PR DESCRIPTION
This removes `std://` locations in the published Rascal JARs, in favor of `mvn://` pointing to this specific released version. Closes #2820.