### PR TITLE
fix: preserve subject type for variable-becomes patterns

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/CollectPattern.rsc
@@ -319,13 +319,9 @@ void collect(current: (Pattern) `<Name name> : <Pattern pattern>`, Collector c){
         c.useLub(name, variableRoles);
     } else {
         c.push(patternNames, <uname, getLoc(name)>);
-        scope = c.getScope();
         c.define(name, formalOrPatternFormal(c), name, 
-                 defLub([pattern], AType(Solver s) { 
-                    try{
-                        return s.getType(pattern);
-                    } catch _:
-                        return getPatternType(pattern, avalue(), scope, s); 
+                 defLub([current], AType(Solver s) {
+                    return s.getType(current);
                  }));
     }
     collect(pattern, c);

--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/PatternTCTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/PatternTCTests.rsc
@@ -202,6 +202,13 @@ test bool typedVariableBecomesWrongType() = cannotMatch("str N : 3 := 3;");
 test bool redeclaredTypedVariableBecomesShadowsAnother() = redeclaredVariable("int N = 5; int N : 3 := 3 && N == 3;");  
   	
 test bool doubleTypedVariableBecomes() = redeclaredVariable("[int N : 3, int N : 4] := [3,4] && N == 3;");  
+
+test bool variableBecomesUsesSyntaxSubjectType() = checkModuleOK("
+   module VariableBecomesUsesSyntaxSubjectType
+      syntax B = \"b\";
+      B a(int _) = (B)`b`;
+      map[int, B] b = (n : f | n \<- [0], f:_ := a(n));
+   ");
   	
 test bool matchListExternalVar1() = checkOK("list[int] S; [1, *S, 2] !:= [1,2,3] && S != [3];");
 


### PR DESCRIPTION
## Summary

- I now derive an untyped variable-becomes binding from the complete pattern fact, so it keeps the matched subject type instead of the nested pattern's early `value` fact.
- I added regression coverage for a variable-becomes wildcard matched against a syntactic type inside a comprehension.

## Testing

- `mvn -q -Pcompiler-tests -Drascal.compile.skip -Drascal.tutor.skip -Drascal.test.memory=4 -Dtest=org.rascalmpl.compiler.lang.rascalcore.check.tests.RunTests test` (focused local run of `PatternTCTests`; passed)
- `git diff --check`

I also started the full compiler-test suite with a clean build, but stopped it after 10 minutes while it was still compiling Rascal source modules; I left the complete clean build to CI.

Fixes #2818
