### PR TITLE
Fill the cache on the first run of mvn, such that later jobs won't have cache misses

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,17 +20,18 @@ jobs:
     steps: 
       - uses: actions/checkout@v5
 
-      # - uses: s4u/maven-settings-action@v3.1.0
-      #   if: ${{ env.IS_OWN_PR != '' }}
-      #   with:
-      #     servers: '[{"id": "usethesource-gh", "username":"github", "password": "${{ secrets.MAVEN_MIRROR_PASSWORD }}"}]'
-      #     mirrors: '[{"id": "usethesource-gh", "name": "uts mirror", "mirrorOf": "usethesource", "url": "${{ secrets.MAVEN_MIRROR_URL }}"}]'
       - uses: actions/setup-java@v5
+        id: java
         with:
           java-version: 11
           distribution: 'temurin'
           cache: 'maven'
           overwrite-settings: false
+      
+      - name: fill caches for maven for downstream jobs
+        if: steps.java.outputs.cache-hit != 'true'
+        run: mvn -B dependency:go-offline dependency:resolve-plugins -DexcludeArtifactIds=lifecycle-mapping
+      
       - name: Run Tests
         run: mvn -B -Drascal.compile.skip -Drascal.tutor.skip -Drascal.test.memory=14 test
 
@@ -65,12 +66,6 @@ jobs:
           chromedriver-version: '107.0.5304.62'
       - run: which chromedriver
 
-      # - uses: s4u/maven-settings-action@v3.1.0
-      #   if: ${{ env.IS_OWN_PR != '' }}
-      #   with:
-      #     servers: '[{"id": "usethesource-gh", "username":"github", "password": "${{ secrets.MAVEN_MIRROR_PASSWORD }}"}]'
-      #     mirrors: '[{"id": "usethesource-gh", "name": "uts mirror", "mirrorOf": "usethesource", "url": "${{ secrets.MAVEN_MIRROR_URL }}"}]'
-      
       - uses: actions/checkout@v5
 
       - uses: actions/setup-java@v5
@@ -160,11 +155,6 @@ jobs:
     steps: 
       - uses: actions/checkout@v5
 
-      # - uses: s4u/maven-settings-action@v3.1.0
-      #   if: ${{ env.IS_OWN_PR != '' }}
-      #   with:
-      #     servers: '[{"id": "usethesource-gh", "username":"github", "password": "${{ secrets.MAVEN_MIRROR_PASSWORD }}"}]'
-      #     mirrors: '[{"id": "usethesource-gh", "name": "uts mirror", "mirrorOf": "usethesource", "url": "${{ secrets.MAVEN_MIRROR_URL }}"}]'
       - uses: actions/setup-java@v5
         with:
           java-version: 11
@@ -197,11 +187,6 @@ jobs:
     steps: 
       - uses: actions/checkout@v5
 
-      # - uses: s4u/maven-settings-action@v3.1.0
-      #   if: ${{ env.IS_OWN_PR != '' }}
-      #   with:
-      #     servers: '[{"id": "usethesource-gh", "username":"github", "password": "${{ secrets.MAVEN_MIRROR_PASSWORD }}"}]'
-      #     mirrors: '[{"id": "usethesource-gh", "name": "uts mirror", "mirrorOf": "usethesource", "url": "${{ secrets.MAVEN_MIRROR_URL }}"}]'
       - uses: actions/setup-java@v5
         with:
           java-version: 11


### PR DESCRIPTION
Since GH actions commit the cache after the first job is completed, any follow up jobs that run more plugins/extension will have a cache miss.