### PR TITLE
Add loading tests to JUnit suite.

### DIFF
--- a/src/org/rascalmpl/library/lang/rascal/tests/loading/LoadingErrorModules.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/loading/LoadingErrorModules.rsc
@@ -91,22 +91,49 @@ test bool moduleWithStaticError() {
 
 test bool importNonExistingModule() {
     exec = createRascalRuntime(pcfg=init());
+    
+    // clean slate
+    remove(moduleFile("ZZ"));
 
-    writeFile(moduleFile("A"), "module A import Z; str func() = aap;");
-
+    writeFile(moduleFile("A"), 
+        "module A 
+        'import ZZ; 
+        'str func() = foo();
+        '");
+ 
     try {
         exec.eval(#void, "import A;");
         return false;
     }
-    catch ModuleLoadMessages([error(_,_)]): {
+    catch ModuleLoadMessages([error(_m, _l)]): {
         // that's ok
         ;
     }
 
-    writeFile(moduleFile("Z"), "module Z public str aap = \"aap\";");
+    writeFile(moduleFile("ZZ"), 
+        "module ZZ 
+        'str foo() = \"bar\";
+        '");
 
-    return exec.eval(#void, "import A;") == ok()
-        && result("aap") == exec.eval(#str, "func()");
+    try {
+        res = exec.eval(#void, "import A;");
+        println("res: <res>");
+        res = exec.eval(#str, "func()");
+        println("res2: <res>");
+        return res == ok() && result("bar") == res;
+    }
+    catch ModuleLoadMessages(msgs): {
+        iprintln("unexpected messages: <msgs>");
+        return false;
+    }
+    catch StaticError(str message, loc location): {
+        println("unexpected static error: <message> @ <location>");
+        return false;
+    }
+    catch value v: {
+        println("some exception <v>");
+        return false;
+    }
 }
 
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/loading/LoadingErrorModules.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/loading/LoadingErrorModules.rsc
@@ -92,8 +92,10 @@ test bool moduleWithStaticError() {
 test bool importNonExistingModule() {
     exec = createRascalRuntime(pcfg=init());
 
+    writeFile(moduleFile("A"), "module A import Z; str func() = aap;");
+
     try {
-        exec.eval(#void, "import Z;");
+        exec.eval(#void, "import A;");
         return false;
     }
     catch ModuleLoadMessages([error(_,_)]): {
@@ -103,8 +105,8 @@ test bool importNonExistingModule() {
 
     writeFile(moduleFile("Z"), "module Z public str aap = \"aap\";");
 
-    return exec.eval(#void, "import Z;") == ok()
-        && result("aap") == exec.eval(#str, "aap");
+    return exec.eval(#void, "import A;") == ok()
+        && result("aap") == exec.eval(#str, "func()");
 }
 
 

--- a/src/org/rascalmpl/library/lang/rascal/tests/loading/LoadingErrorModules.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/tests/loading/LoadingErrorModules.rsc
@@ -105,9 +105,9 @@ test bool importNonExistingModule() {
         exec.eval(#void, "import A;");
         return false;
     }
-    catch ModuleLoadMessages([error(_m, _l)]): {
+    catch ModuleLoadMessages([error(m, l)]): {
         // that's ok
-        ;
+        println("expected message: <m> @<l>");
     }
 
     writeFile(moduleFile("ZZ"), 
@@ -116,22 +116,18 @@ test bool importNonExistingModule() {
         '");
 
     try {
-        res = exec.eval(#void, "import A;");
-        println("res: <res>");
-        res = exec.eval(#str, "func()");
-        println("res2: <res>");
-        return res == ok() && result("bar") == res;
+        res0 = exec.eval(#void, "import ZZ;");
+        res1 = exec.eval(#void, "import A;");
+        res2 = exec.eval(#str, "func()");
+        return res0 == ok() && res1 == ok() && result("bar") == res2;
     }
     catch ModuleLoadMessages(msgs): {
-        iprintln("unexpected messages: <msgs>");
+        println("unexpected messages:");
+        iprintln(msgs);
         return false;
     }
     catch StaticError(str message, loc location): {
         println("unexpected static error: <message> @ <location>");
-        return false;
-    }
-    catch value v: {
-        println("some exception <v>");
         return false;
     }
 }

--- a/src/org/rascalmpl/library/util/Eval.java
+++ b/src/org/rascalmpl/library/util/Eval.java
@@ -58,7 +58,7 @@ public class Eval {
 	public final Type TypeTyp = RascalTypeFactory.getInstance().reifiedType(param);
 	public final Type Result_void = tf.constructor(store, Result, "ok");
 	public final Type Result_value = tf.constructor(store, Result, "result", param, "val");
-	public final Type Exception = tf.abstractDataType(store, "Exception");
+	public final Type Exception = tf.abstractDataType(store, "RuntimeException");
 	public final Type Exception_StaticError = tf.constructor(store, Exception, "StaticError", tf.stringType(), "message", tf.sourceLocationType(), "location");
 	public final Type Exception_LoadMessages = tf.constructor(store, Exception, "ModuleLoadMessages", tf.listType(Messages.Message), "messages");
 	private final Type resetType = tf.functionType(tf.voidType(), tf.tupleEmpty(), tf.tupleEmpty());

--- a/src/org/rascalmpl/library/util/Eval.java
+++ b/src/org/rascalmpl/library/util/Eval.java
@@ -203,6 +203,8 @@ public class Eval {
 			finally {
 				// very necessary to clean up the timer thread
 				timer.cancel();
+				// necessary to make sure only new messages are reported.
+				exec.clearLoadMessages();
 			}
 		});
 	}
@@ -217,6 +219,10 @@ public class Eval {
 		
 		public RascalRuntime(PathConfig pcfg, Reader input, PrintWriter stderr, PrintWriter stdout, IDEServices services) throws IOException, URISyntaxException{
 			eval = ShellEvaluatorFactory.getDefaultEvaluatorForPathConfig(URIUtil.rootLocation("cwd"), pcfg, input, stdout, stderr, services);
+		}
+
+		public void clearLoadMessages() {
+			eval.__getHeap().clearModuleLoadMessage();
 		}
 
 		public IValue staticTypeOf(String line) {

--- a/src/org/rascalmpl/library/util/Eval.rsc
+++ b/src/org/rascalmpl/library/util/Eval.rsc
@@ -31,6 +31,10 @@ data Result[&T]
 @description{
 `eval` will throw the first static error that is blocking the execution of a command.
 }
+@pitfalls{
+* ModuleLoadMessages are only reported the first time they are discovered. This is unlike the real REPL which
+keeps reporting them until they are solved.
+}
 data RuntimeException 
   = StaticError(str message, loc location)
   | ModuleLoadMessages(list[Message] messages)

--- a/src/org/rascalmpl/semantics/dynamic/Import.java
+++ b/src/org/rascalmpl/semantics/dynamic/Import.java
@@ -346,6 +346,7 @@ public abstract class Import {
 
       if (uri == null) {
           heap.setModuleURI(jobName, URIUtil.correctLocation("not-found", name, "").getURI());
+          heap.popModuleLoading();
           throw new ModuleImport(name, "can not find in search path", x);
       }
       else {

--- a/test/org/rascalmpl/test/parallel/AllSuiteParallel.java
+++ b/test/org/rascalmpl/test/parallel/AllSuiteParallel.java
@@ -12,7 +12,8 @@ import org.rascalmpl.test.infrastructure.RecursiveRascalParallelTest;
     "lang::rascal::tests::demo",
     "lang::rascal::tests::functionality", 
     "lang::rascal::tests::imports",
-    "lang::rascal::tests::library"
+    "lang::rascal::tests::library",
+    "lang::rascal::tests::loading"
     })
 public class AllSuiteParallel {
 }


### PR DESCRIPTION
Add tests from 508a458f75c4b1aacb8e753bd6916cd079f62943 / #2747 to JUnit/CI suite.

* [x] fixes bug where util::Eval would not get rid of older static messages even though the module was fixed
* [x] fixes nasty bug in util::Eval where an StaticError would be of the wrong ADT type so you could not catch it
* [x] fixes a stack issue (one pop too few) in the module loader in the context of a missing module error  

With these three fixes the test in question works again.