### PR TITLE
Show error on missing Rascal dependency

### DIFF
--- a/src/org/rascalmpl/library/util/PathConfig.java
+++ b/src/org/rascalmpl/library/util/PathConfig.java
@@ -760,6 +760,9 @@ public class PathConfig {
                 buildRascalLSPConfig(manifestRoot, mode, mavenClasspath, srcsWriter, libsWriter, messages);
             }
             else {
+                if (mavenClasspath.stream().filter(PathConfig::isRascal).findFirst().isEmpty()) {
+                    messages.append(Messages.error("Dependency on 'org.rascalmpl:rascal' is required", getPomXmlLocation(manifestRoot)));
+                }
                 buildNormalProjectConfig(manifestRoot, mode, mavenClasspath, isRoot, srcsWriter, libsWriter, messages);
             }
         }
@@ -977,6 +980,19 @@ public class PathConfig {
             return false;
         }
         return ((IString) msg).getValue().startsWith(prefix);
+    }
+
+    private static boolean isRascalMplGroup(ArtifactCoordinate coord) {
+        return "org.rascalmpl".equals(coord.getGroupId());
+    }
+
+    private static boolean isRascal(Artifact art) {
+        var coord = art.getCoordinate();
+        return isRascalMplGroup(coord) && isRascal(coord.getArtifactId());
+    }
+
+    private static boolean isRascal(String projectName) {
+        return "rascal".equalsIgnoreCase(projectName);
     }
 
     private static boolean isTypePalArtifact(ArtifactCoordinate artifact) {


### PR DESCRIPTION
Show errors while requesting a path config for projects Rascal projects without a dependency on Rascal.

Prerequisite for proper functioning of
- https://github.com/usethesource/rascal-language-servers/pull/1159
- https://github.com/usethesource/rascal-language-servers/pull/1156