### PR TITLE
Fix normalized hash test in case of collisions.

### DIFF
--- a/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ChangeAndHashTests.rsc
+++ b/src/org/rascalmpl/compiler/lang/rascalcore/check/tests/ChangeAndHashTests.rsc
@@ -572,6 +572,7 @@ test bool normalizedHashIdentity1(str S1)
 
 test bool normalizedHashIdentity2(str S1, str S2)
     = normalizedMD5Hash(S1) == normalizedMD5Hash(S2)
-    ? removeWhitespace(S1) == removeWhitespace(S2)
+    /* If the normalized hashes are equal, expect the normalized strings to be equal, unless there is an actual MD5 collision for the input strings. */
+    ? removeWhitespace(S1) == removeWhitespace(S2) || md5Hash(S1) == md5Hash(S2)
     : S1 != S2
     ;


### PR DESCRIPTION
Allow normalized hash collisions in tests in case there would be a hash collision for the input strings anyway.

Example failure:
https://github.com/usethesource/rascal/actions/runs/32944398075/job/98103370299

```
rascal>import IO;
ok
rascal>str1 = "𠙹𠟒𒇇𠢆𒑡𡓅𒌓";
str: "��������������"
───
𠙹𠟒𒇇𠢆𒑡𡓅𒌓
───

rascal>str2 = "𠌰𒄇𒑃𒎔𒉱𠤿𠙨";
str: "��������������"
───
𠌰𒄇𒑃𒎔𒉱𠤿𠙨
───

rascal>md5Hash(str1) == md5Hash(str2);
bool: true
```

Fixes test added in:
- https://github.com/usethesource/rascal/pull/2644