### PR TITLE
fixes #2885 by introducing missing definitions in the abstract grammars. This must be reviewed by @tvdstorm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/experiments</ignore>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/resource</ignore>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/tests</ignore>
-                              <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/grammar/tests</ignore>
+                                <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/grammar/tests</ignore>
                                 <ignore>${project.basedir}/src/org/rascalmpl/library/lang/rascal/syntax/tests</ignore>
                             </ignores>
                         </configuration>

--- a/src/org/rascalmpl/library/Prelude.java
+++ b/src/org/rascalmpl/library/Prelude.java
@@ -2602,7 +2602,7 @@ public class Prelude {
 					}
 				}
 				
-				throw failReason != null ? failReason : new Backtrack(RuntimeExceptionFactory.illegalArgument(tree, "Cannot find a constructor " + type));
+				throw failReason != null ? failReason : new Backtrack(RuntimeExceptionFactory.illegalArgument(tree, "Cannot find a matching constructor " + constructorName + " for lexical type " + type));
 			}
 			if (type.isInteger()) {
 				return values.integer(yield);

--- a/src/org/rascalmpl/library/lang/rascal/syntax/tests/ImplodeTests.rsc
+++ b/src/org/rascalmpl/library/lang/rascal/syntax/tests/ImplodeTests.rsc
@@ -1,58 +1,127 @@
 @license{
   Copyright (c) 2009-2015 CWI
   All rights reserved. This program and the accompanying materials
-  are made available under the terms of the Eclipse Public License v1.0
+  are made available under the terms of the Eclipse License v1.0
   which accompanies this distribution, and is available at
   http://www.eclipse.org/legal/epl-v10.html
 }
 @synopsis{Tests the potential clashes among value constructors of different adts, plus, the identified clash with: bool eq(value, value);}
 module lang::rascal::\syntax::tests::ImplodeTests
- 
+
 import lang::rascal::\syntax::tests::ImplodeTestGrammar;
 import ParseTree;
 import Exception;
 
-public data Num(loc src=|unknown:///|, map[int,list[str]] comments = ());
-public data Exp(loc src=|unknown:///|, map[int,list[str]] comments = ()) = id(str name);
-public Exp number(Num::\int("0")) = Exp::number(Num::\int("01"));
+data Num(loc src = |unknown:///|, map[int, list[str]] comments = ())
+  = \int(str x);
 
-public data Number(loc src=|unknown:///|, map[int,list[str]] comments = ());
-public data Expr(loc src=|unknown:///|, map[int,list[str]] comments = ()) = id(str name);
-public Expr number(Number::\int("0")) = Expr::number(Number::\int("02"));
+data Exp (loc src = |unknown:///|, map[int, list[str]] comments = ())
+  = id(str name)
+  | eq(Exp e1, Exp e2)
+  | number(Num n)
+  ;
+Exp number(Num::\int("0")) = Exp::number(Num::\int("01"));
 
-public Exp implodeExp(str s) = implode(#Exp, parseExp(s));
-public Exp implodeExpLit1() = implode(#Exp, expLit1());
-public Exp implodeExpLit2() = implode(#Exp, expLit2());
+data Number(loc src = |unknown:///|, map[int, list[str]] comments = ());
 
-public Expr implodeExpr(str s) = implode(#Expr, parseExp(s));
-public Expr implodeExprLit1() = implode(#Expr, exprLit1());
-public Expr implodeExprLit2() = implode(#Expr, exprLit2());
+data Expr (loc src = |unknown:///|, map[int, list[str]] comments = ())
+  = id(str name)
+  | number(Num n)
+  | eq(Expr e1, Expr e2)
+  ;
 
+Expr number(Number::\int("0")) = Expr::number(Number::\int("02"));
+
+Exp implodeExp(str s) = implode(#Exp, parseExp(s));
+Exp implodeExpLit1() = implode(#Exp, expLit1());
+Exp implodeExpLit2() = implode(#Exp, expLit2());
+
+Expr implodeExpr(str s) = implode(#Expr, parseExp(s));
+Expr implodeExprLit1() = implode(#Expr, exprLit1());
+Expr implodeExprLit2() = implode(#Expr, exprLit2());
 
 // ---- test1 ----
+test bool test11() {
+  try
+    return Exp::id(_) := implodeExp("a");
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test11() { try return Exp::id(_) := implodeExp("a"); catch ImplodeError(_): return false;}
+test bool test12() {
+  try
+    return Exp::number(Num::\int("0")) := implodeExp("0");
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test12() { try return Exp::number(Num::\int("0")) := implodeExp("0"); catch ImplodeError(_): return false;}
+test bool test13() {
+  try
+    return Exp::eq(Exp::id(_), Exp::id(_)) := implodeExp("a == b");
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test13() { try return Exp::eq(Exp::id(_),Exp::id(_)) := implodeExp("a == b"); catch ImplodeError(_): return false;}
+test bool test14() {
+  try
+    return Exp::eq(Exp::number(Num::\int("0")), Exp::number(Num::\int("1"))) := implodeExp("0 == 1");
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test14() { try return Exp::eq(Exp::number(Num::\int("0")), Exp::number(Num::\int("1"))) := implodeExp("0 == 1"); catch ImplodeError(_): return false;}
+test bool test15() {
+  try
+    return Expr::id(_) := implodeExpr("a");
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test15() { try return  Expr::id(_) := implodeExpr("a"); catch ImplodeError(_): return false;}
+test bool test16() {
+  try
+    return Expr::number(Number::\int("0")) := implodeExpr("0");
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test16() { try return Expr::number(Number::\int("0")) := implodeExpr("0"); catch ImplodeError(_): return false;}
+test bool test17() {
+  try
+    return Expr::eq(Expr::id(_), Expr::id(_)) := implodeExpr("a == b");
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test17() { try return Expr::eq(Expr::id(_),Expr::id(_)) := implodeExpr("a == b"); catch ImplodeError(_): return false;}
-
-test bool test18() { try return Expr::eq(Expr::number(Number::\int("0")), Expr::number(Number::\int("1"))) := implodeExpr("0 == 1"); catch ImplodeError(_): return false;}
+test bool test18() {
+  try
+    return Expr::eq(Expr::number(Number::\int("0")), Expr::number(Number::\int("1"))) := implodeExpr("0 == 1");
+  catch ImplodeError(_):
+    return false;
+}
 
 // ---- test2 ----
+test bool test21() {
+  try
+    return Exp::eq(Exp::id("a"), Exp::id("b")) := implodeExpLit1();
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test21() { try return Exp::eq(Exp::id("a"),Exp::id("b")) := implodeExpLit1(); catch ImplodeError(_): return false;}
+test bool test22() {
+  try
+    return Exp::eq(Exp::id("a"), Exp::number(Num::\int("11"))) := implodeExpLit2();
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test22() { try return Exp::eq(Exp::id("a"),Exp::number(Num::\int("11"))) := implodeExpLit2(); catch ImplodeError(_): return false;}
+test bool test23() {
+  try
+    return Expr::eq(Expr::id("a"), Expr::id("b")) := implodeExprLit1();
+  catch ImplodeError(_):
+    return false;
+}
 
-test bool test23() { try return Expr::eq(Expr::id("a"),Expr::id("b")) := implodeExprLit1(); catch ImplodeError(_): return false;}
-
-test bool test24() { try return  Expr::eq(Expr::id("a"),Expr::number(Number::\int("11"))) := implodeExprLit2(); catch ImplodeError(_): return false;}
+test bool test24() {
+  try
+    return Expr::eq(Expr::id("a"), Expr::number(Number::\int("11"))) := implodeExprLit2();
+  catch ImplodeError(_):
+    return false;
+}


### PR DESCRIPTION
These syntax tests are not typically executed during CI because they take too long. Not surprisingly they did not succeed anymore for a long time. They were fixed but there was a "how could this have ever worked" feeling that I'd like to shake off.

* [x] fixed error message text in ParseTree::implode method
* [x] added constructor definitions in the target data-type which were missing
* [x] tests succeed again 