### PR TITLE
XML tags and attributes should be parsed case-sensitively

### DIFF
--- a/src/org/rascalmpl/library/lang/xml/IO.java
+++ b/src/org/rascalmpl/library/lang/xml/IO.java
@@ -76,7 +76,7 @@ public class IO {
        
         try (InputStream reader = URIResolverRegistry.getInstance().getInputStream(loc)) {
             Parser xmlParser = Parser.xmlParser()
-                .settings(new ParseSettings(false, false))
+                .settings(new ParseSettings(true, true))
                 .setTrackPosition(trackOrigins.getValue())
                 ;
             

--- a/src/org/rascalmpl/library/lang/xml/IO.java
+++ b/src/org/rascalmpl/library/lang/xml/IO.java
@@ -69,14 +69,14 @@ public class IO {
         this.vf = vf;
     }
     
-    public IValue readXML(ISourceLocation loc, IBool fullyQualify, IBool trackOrigins, IBool includeEndTags,  IBool ignoreComments, IBool ignoreWhitespace, IString charset, IBool inferCharset) {
+    public IValue readXML(ISourceLocation loc, IBool fullyQualify, IBool trackOrigins, IBool includeEndTags,  IBool ignoreComments, IBool ignoreWhitespace, IString charset, IBool inferCharset, IBool preserveTagCase, IBool preserveAttributeCase) {
         if (inferCharset.getValue()) {
             charset = vf.string(URIResolverRegistry.getInstance().detectCharset(loc).toString());
         }
        
         try (InputStream reader = URIResolverRegistry.getInstance().getInputStream(loc)) {
             Parser xmlParser = Parser.xmlParser()
-                .settings(new ParseSettings(true, true))
+                .settings(new ParseSettings(preserveTagCase.getValue(), preserveAttributeCase.getValue()))
                 .setTrackPosition(trackOrigins.getValue())
                 ;
             
@@ -92,7 +92,7 @@ public class IO {
         }
     }
 
-    public IFunction streamXML(ISourceLocation loc, IString elementName, IBool fullyQualify, IBool trackOrigins, IBool includeEndTags, IBool ignoreComments, IBool ignoreWhitespace, IString charset, IBool inferCharset) {
+    public IFunction streamXML(ISourceLocation loc, IString elementName, IBool fullyQualify, IBool trackOrigins, IBool includeEndTags, IBool ignoreComments, IBool ignoreWhitespace, IString charset, IBool inferCharset, IBool preserveTagCase, IBool preserveAttributeCase) {
         if (inferCharset.getValue()) {
             charset = vf.string(URIResolverRegistry.getInstance().detectCharset(loc).toString());
         }
@@ -100,7 +100,7 @@ public class IO {
         try {
             InputStream reader = URIResolverRegistry.getInstance().getInputStream(loc);
             Parser xmlParser = Parser.xmlParser()
-                .settings(new ParseSettings(false, false))
+                .settings(new ParseSettings(preserveTagCase.getValue(), preserveAttributeCase.getValue()))
                 .setTrackPosition(trackOrigins.getValue());   
 
             StreamParser streamer = new StreamParser(xmlParser);
@@ -142,13 +142,13 @@ public class IO {
     }
 
 
-    public IValue readXML(IString string, ISourceLocation src, IBool fullyQualify, IBool trackOrigins, IBool includeEndTags, IBool ignoreComments, IBool ignoreWhitespace) {
+    public IValue readXML(IString string, ISourceLocation src, IBool fullyQualify, IBool trackOrigins, IBool includeEndTags, IBool ignoreComments, IBool ignoreWhitespace, IBool preserveTagCase, IBool preserveAttributeCase) {
         if (string.length() == 0) {
             throw RuntimeExceptionFactory.io("empty XML document");
         }
 
         Parser xmlParser = Parser.xmlParser()
-                .settings(new ParseSettings(false, false))
+                .settings(new ParseSettings(preserveTagCase.getValue(), preserveAttributeCase.getValue()))
                 .setTrackPosition(trackOrigins.getValue())
                 ;
              

--- a/src/org/rascalmpl/library/lang/xml/IO.rsc
+++ b/src/org/rascalmpl/library/lang/xml/IO.rsc
@@ -10,7 +10,7 @@ module lang::xml::IO
 import util::Maybe;
 
 @javaClass{org.rascalmpl.library.lang.xml.IO}
-java value readXML(loc file, bool fullyQualify=false, bool trackOrigins = false, bool includeEndTags=false, bool ignoreComments=true, bool ignoreWhitespace=true, str charset="UTF-8", bool inferCharset=!(charset?));
+java value readXML(loc file, bool fullyQualify=false, bool trackOrigins = false, bool includeEndTags=false, bool ignoreComments=true, bool ignoreWhitespace=true, str charset="UTF-8", bool inferCharset=!(charset?), bool preserveTagCase=true, bool preserveAttributeCase=true);
 
 @javaClass{org.rascalmpl.library.lang.xml.IO}
 @synopsis{Stream all the tags in a file, one-by-one, without ever having the entire XML file in memory.}
@@ -51,10 +51,10 @@ to store both  the internal DOM _and_ the Rascal `node` structure, ((streamXML))
 of the function call overhead for each next element. If you do run out of memory with ((readXML)) though, then ((streamXML)) reaches exponentially
 higher throughput than ((readXML)). 
 }
-java Maybe[value]() streamXML(loc file, str elementName, bool fullyQualify=false, bool trackOrigins = false, bool includeEndTags=false, bool ignoreComments=true, bool ignoreWhitespace=true, str charset="UTF-8", bool inferCharset=!(charset?));
+java Maybe[value]() streamXML(loc file, str elementName, bool fullyQualify=false, bool trackOrigins = false, bool includeEndTags=false, bool ignoreComments=true, bool ignoreWhitespace=true, str charset="UTF-8", bool inferCharset=!(charset?), bool preserveTagCase=true, bool preserveAttributeCase=true);
 
 @javaClass{org.rascalmpl.library.lang.xml.IO}
-java value readXML(str contents, loc src = |unknown:///|, bool fullyQualify=false, bool trackOrigins = false, bool includeEndTags=false, bool ignoreComments=true, bool ignoreWhitespace=true);
+java value readXML(str contents, loc src = |unknown:///|, bool fullyQualify=false, bool trackOrigins = false, bool includeEndTags=false, bool ignoreComments=true, bool ignoreWhitespace=true, bool preserveTagCase=true, bool preserveAttributeCase=true);
 
 @javaClass{org.rascalmpl.library.lang.xml.IO}
 @synopsis{Pretty-print any value as an XML string}


### PR DESCRIPTION
Right now, the XML parser is configure to convert all tags and attributes to lower case